### PR TITLE
WIP: Add ability to disregard max file size for specific files

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -73,6 +73,9 @@ type Options struct {
 
 	// Write memory profiles to this file.
 	MemProfile string
+
+	// LargeFiles are files that should be indexed regardless of their size.
+	LargeFiles map[string]struct{}
 }
 
 // Builder manages (parallel) creation of uniformly sized shards.
@@ -224,7 +227,7 @@ func (b *Builder) Add(doc zoekt.Document) error {
 	// we pass through a part of the source tree with binary/large
 	// files, the corresponding shard would be mostly empty, so
 	// insert a reason here too.
-	if len(doc.Content) > b.opts.SizeMax {
+	if _, ok := b.opts.LargeFiles[doc.Name]; !ok && len(doc.Content) > b.opts.SizeMax {
 		doc.SkipReason = fmt.Sprintf("document size %d larger than limit %d", len(doc.Content), b.opts.SizeMax)
 	} else if err := zoekt.CheckText(doc.Content); err != nil {
 		doc.SkipReason = err.Error()

--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -169,7 +169,7 @@ func do(opts Options, bopts build.Options) error {
 		}
 
 		// We do not index large files
-		if f.Size > int64(bopts.SizeMax) {
+		if _, ok := bopts.LargeFiles[f.Name]; !ok && f.Size > int64(bopts.SizeMax) {
 			continue
 		}
 
@@ -205,11 +205,12 @@ func main() {
 		incremental = flag.Bool("incremental", true, "only index changed repositories")
 		ctags       = flag.Bool("require_ctags", false, "If set, ctags calls must succeed.")
 
-		name   = flag.String("name", "", "The repository name for the archive")
-		urlRaw = flag.String("url", "", "The repository URL for the archive")
-		branch = flag.String("branch", "", "The branch name for the archive")
-		commit = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
-		strip  = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+		name       = flag.String("name", "", "The repository name for the archive")
+		urlRaw     = flag.String("url", "", "The repository URL for the archive")
+		branch     = flag.String("branch", "", "The branch name for the archive")
+		commit     = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
+		strip      = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+		largeFiles = flag.String("large_files", "", "comma separated list of large files to index regardless of their size.")
 	)
 	flag.Parse()
 
@@ -220,12 +221,24 @@ func main() {
 	}
 	archive := flag.Args()[0]
 
+	largeFilesMap := map[string]struct{}{}
+	if *largeFiles != "" {
+		dirs := strings.Split(*largeFiles, ",")
+		for _, d := range dirs {
+			d = strings.TrimSpace(d)
+			if d != "" {
+				largeFilesMap[d] = struct{}{}
+			}
+		}
+	}
+
 	bopts := build.Options{
 		Parallelism:      *parallelism,
 		SizeMax:          *sizeMax,
 		ShardMax:         *shardLimit,
 		IndexDir:         *indexDir,
 		CTagsMustSucceed: *ctags,
+		LargeFiles:       largeFilesMap,
 	}
 	opts := Options{
 		Incremental: *incremental,

--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -210,7 +210,7 @@ func main() {
 		branch     = flag.String("branch", "", "The branch name for the archive")
 		commit     = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
 		strip      = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
-		largeFiles = flag.String("large_files", "", "comma separated list of large files to index regardless of their size.")
+		largeFiles = flag.String("large_files", "", "Comma separated list of large files to index regardless of their size.")
 	)
 	flag.Parse()
 

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestUpdateOptions(t *testing.T) {
+	tests := []string{
+		"test,test",
+		"",
+	}
+
+	for _, test := range tests {
+		t.Run(test, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/options", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			form := url.Values{}
+			form.Add("large_files", test)
+
+			req.PostForm = form
+
+			rr := httptest.NewRecorder()
+
+			rootURL, _ := url.Parse("http://localhost:3080")
+
+			s := &Server{
+				Root:       rootURL,
+				IndexDir:   "",
+				Interval:   1000,
+				CPUCount:   1,
+				LargeFiles: "random,value",
+			}
+
+			s.ServeHTTP(rr, req)
+
+			if s.LargeFiles != test {
+				t.Errorf("did not properly set large files option; got %s wanted %s", s.LargeFiles, test)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Add ability to disregard max file size for specific files

This PR adds a `large_files` flag that is a comma separated list of files that we want to index regardless of the file size.

This is part of the solution for https://github.com/sourcegraph/sourcegraph/issues/1624.

## Testing plan

1. Make a large file. I ran this program:

```go
package main

import (
	"fmt"
	"log"
	"os"
)

func main() {
	file, err := os.Create("/tmp/large-file.txt")
	if err != nil {
		log.Fatal(err)
	}
	defer file.Close()

	maxSize := 20 * 1024 * 1024
	size := 0

	for size < maxSize+1 {
		n, _ := file.WriteString("test\n")
		size += n
	}

	info, _ := file.Stat()
	fmt.Printf("File size: %v\n", info.Size())
}
```

2. Create a temporary git directory and add the large file you just created

```
mkdir /tmp/big-index
cd /tmp/big-index
git init
mv /tmp/large-file.txt ./
git add .
git commit -m "add a large file"
```

3. Create an archive of the repo

```
git archive master --format=tar --output=/tmp/big-index.tar
```

4. Run the archive command

```
go run ./cmd/zoekt-archive-index -large_files large-file.txt -branch master -index /tmp/test-indexes -name big-index /tmp/big-index.tar
```

5. Make sure the contents of the big file are indexed

```
cat /tmp/test-indexes/big-index_v15.00000.zoekt
```