### PR TITLE
fetch options from server and pass them through to index command

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -139,19 +139,13 @@ func (s *Server) Run() {
 type IndexOptions struct {
 	// LargeFiles is a slice of glob patterns where matching files are
 	// indexed regardless of their size.
-	LargeFiles *[]string
+	LargeFiles []string
 }
 
 func (o *IndexOptions) toArgs() string {
 	f := ""
-	var globs []string
-	if o.LargeFiles != nil {
-		globs = *o.LargeFiles
-	} else {
-		globs = []string{}
-	}
-	for i := range globs {
-		f += "-large_file " + globs[i]
+	for i := range o.LargeFiles {
+		f += "-large_file " + o.LargeFiles[i]
 	}
 	return f
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestGetIndexOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"LargeFiles": ["test"]}`))
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	opts, err := getIndexOptions(u, server.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(opts.LargeFiles) == 0 {
+		t.Error("expected non-empty result from large files list")
+	}
+	if opts.LargeFiles[0] != "test" {
+		t.Error("decoded wrong results")
+	}
+}

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 )
 
 func TestGetIndexOptions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"LargeFiles": ["test"]}`))
+		w.Write([]byte(`{"LargeFiles": ["foo","bar"]}`))
 	}))
 	defer server.Close()
 
@@ -22,7 +23,9 @@ func TestGetIndexOptions(t *testing.T) {
 	if len(opts.LargeFiles) == 0 {
 		t.Error("expected non-empty result from large files list")
 	}
-	if opts.LargeFiles[0] != "test" {
-		t.Error("decoded wrong results")
+
+	want := []string{"-large_file", "foo", "-large_file", "bar"}
+	if got := opts.toArgs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("got unexpected arguments from options\ngot: %v\nwant: %v\n", got, want)
 	}
 }


### PR DESCRIPTION
> IMPORTANT: Do not merge until https://gerrit-review.googlesource.com/c/zoekt/+/220077 as accepted and merged.

This PR is part of the solution for https://github.com/sourcegraph/sourcegraph/issues/1624. We are adding a configuration option called "search.largeFiles" which is a list of glob patterns. Any files matching the patterns in the list will be indexed and searched regardless of the size.

This PR fetches this option from Sourcegraph and passes it through as a new option to the zoekt index command.