### PR TITLE
add build option for large file whitelist

### DIFF
--- a/api.go
+++ b/api.go
@@ -215,6 +215,7 @@ type IndexMetadata struct {
 	PlainASCII          bool
 	LanguageMap         map[string]byte
 	ZoektVersion        string
+	IndexOptions        *IndexOptions
 }
 
 // Statistics of a (collection of) repositories.

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -1,0 +1,32 @@
+package build
+
+import "testing"
+
+func TestOptions(t *testing.T) {
+	t.Run("LargeFiles", func(t *testing.T) {
+		opts := Options{
+			LargeFiles: []string{"/foo", "*.foo", "/foo/bar/*.foo"},
+		}
+
+		tests := []struct {
+			name   string
+			ignore bool
+		}{
+			{name: "/foo", ignore: true},
+			{name: "/foo/foo", ignore: false},
+			{name: ".foo", ignore: true},
+			{name: "foo.foo", ignore: true},
+			{name: "/foo/foo", ignore: false},
+			{name: "/foo/bar/bar.foo", ignore: true},
+			{name: "/foo/bar/.foo", ignore: true},
+			{name: "/foo/bar/foo", ignore: false},
+		}
+
+		for _, test := range tests {
+			ignore := opts.IgnoreSizeMax(test.name)
+			if ignore != test.ignore {
+				t.Errorf("unexpected result for name %s: got %v, want %v", test.name, ignore, test.ignore)
+			}
+		}
+	})
+}

--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -224,7 +224,7 @@ func main() {
 		strip      = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
 		largeFiles = largeFilesFlag{}
 	)
-	flag.Var(&largeFiles, "large_file", "A glob pattern where matching files are to be index regardless of their size.")
+	flag.Var(&largeFiles, "large_file", "A glob pattern where matching files are to be indexed regardless of their size.")
 	flag.Parse()
 
 	log.SetFlags(log.LstdFlags | log.Lshortfile)

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -29,6 +29,18 @@ import (
 
 var _ = log.Println
 
+type largeFilesFlag []string
+
+func (f *largeFilesFlag) String() string {
+	s := append([]string{""}, *f...)
+	return strings.Join(s, "-large_file ")
+}
+
+func (f *largeFilesFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 func main() {
 	var sizeMax = flag.Int("file_limit", 128*1024, "maximum file size")
 	var shardLimit = flag.Int("shard_limit", 100<<20, "maximum corpus size for a shard")
@@ -45,6 +57,8 @@ func main() {
 		"It also affects name if the indexed repository is under this directory.")
 	ctags := flag.Bool("require_ctags", false, "If set, ctags calls must succeed.")
 	version := flag.Bool("version", false, "Print version number")
+	largeFiles := largeFilesFlag{}
+	flag.Var(&largeFiles, "large_file", "A glob pattern where matching files are to be index regardless of their size.")
 	flag.Parse()
 
 	if *version {
@@ -65,6 +79,7 @@ func main() {
 		ShardMax:         *shardLimit,
 		IndexDir:         *indexDir,
 		CTagsMustSucceed: *ctags,
+		LargeFiles:       largeFiles,
 	}
 	opts.SetDefaults()
 

--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -57,11 +57,26 @@ func (a *fileAggregator) add(path string, info os.FileInfo, err error) error {
 	return nil
 }
 
+type largeFilesFlag []string
+
+func (f *largeFilesFlag) String() string {
+	s := append([]string{""}, *f...)
+	return strings.Join(s, "-large_file ")
+}
+
+func (f *largeFilesFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
 func main() {
 	var cpuProfile = flag.String("cpu_profile", "", "write cpu profile to file")
 	var sizeMax = flag.Int("file_limit", 128*1024, "maximum file size")
 	var shardLimit = flag.Int("shard_limit", 100<<20, "maximum corpus size for a shard")
 	var parallelism = flag.Int("parallelism", 4, "maximum number of parallel indexing processes.")
+
+	largeFiles := largeFilesFlag{}
+	flag.Var(&largeFiles, "large_file", "A glob pattern where matching files are to be index regardless of their size.")
 
 	ignoreDirs := flag.String("ignore_dirs", ".git,.hg,.svn", "comma separated list of directories to ignore.")
 	indexDir := flag.String("index", build.DefaultDir, "directory for search indices")
@@ -72,6 +87,7 @@ func main() {
 		SizeMax:     *sizeMax,
 		ShardMax:    *shardLimit,
 		IndexDir:    *indexDir,
+		LargeFiles:  largeFiles,
 	}
 	opts.SetDefaults()
 	if *cpuProfile != "" {
@@ -129,7 +145,7 @@ func indexArg(arg string, opts build.Options, ignore map[string]struct{}) error 
 
 	for f := range comm {
 		displayName := strings.TrimPrefix(f.name, dir+"/")
-		if f.size > int64(opts.SizeMax) {
+		if f.size > int64(opts.SizeMax) && !opts.IgnoreSizeMax(displayName) {
 			builder.Add(zoekt.Document{
 				Name:       displayName,
 				SkipReason: fmt.Sprintf("document size %d larger than limit %d", f.size, opts.SizeMax),

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -479,7 +479,7 @@ func IndexGitRepo(opts Options) error {
 				return err
 			}
 
-			if blob.Size > int64(opts.BuildOptions.SizeMax) {
+			if blob.Size > int64(opts.BuildOptions.SizeMax) && !opts.BuildOptions.IgnoreSizeMax(key.FullPath()) {
 				if err := builder.Add(zoekt.Document{
 					SkipReason:        fmt.Sprintf("file size %d exceeds maximum size %d", blob.Size, opts.BuildOptions.SizeMax),
 					Name:              key.FullPath(),

--- a/index_test.go
+++ b/index_test.go
@@ -40,7 +40,11 @@ func clearScores(r *SearchResult) {
 }
 
 func testIndexBuilder(t *testing.T, repo *Repository, docs ...Document) *IndexBuilder {
-	b, err := NewIndexBuilder(repo)
+	return createTestIndexBuilder(t, repo, docs, nil)
+}
+
+func createTestIndexBuilder(t *testing.T, repo *Repository, docs []Document, opts *IndexOptions) *IndexBuilder {
+	b, err := NewIndexBuilder(repo, opts)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -64,7 +68,7 @@ func TestBoundary(t *testing.T) {
 }
 
 func TestDocSectionInvalid(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -257,7 +261,7 @@ func TestCaseFold(t *testing.T) {
 }
 
 func TestAndSearch(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -298,7 +302,7 @@ func TestAndSearch(t *testing.T) {
 }
 
 func TestAndNegateSearch(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -328,7 +332,7 @@ func TestAndNegateSearch(t *testing.T) {
 }
 
 func TestNegativeMatchesOnlyShortcut(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -352,7 +356,7 @@ func TestNegativeMatchesOnlyShortcut(t *testing.T) {
 }
 
 func TestFileSearch(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -388,7 +392,7 @@ func TestFileSearch(t *testing.T) {
 }
 
 func TestFileCase(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -406,7 +410,7 @@ func TestFileCase(t *testing.T) {
 }
 
 func TestFileRegexpSearchBruteForce(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -426,7 +430,7 @@ func TestFileRegexpSearchBruteForce(t *testing.T) {
 }
 
 func TestFileRegexpSearchShortString(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -444,7 +448,7 @@ func TestFileRegexpSearchShortString(t *testing.T) {
 }
 
 func TestFileSubstringSearchBruteForce(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -464,7 +468,7 @@ func TestFileSubstringSearchBruteForce(t *testing.T) {
 }
 
 func TestFileSubstringSearchBruteForceEnd(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -484,7 +488,7 @@ func TestFileSubstringSearchBruteForceEnd(t *testing.T) {
 }
 
 func TestSearchMatchAll(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -501,7 +505,7 @@ func TestSearchMatchAll(t *testing.T) {
 }
 
 func TestSearchNewline(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -518,7 +522,7 @@ func TestSearchNewline(t *testing.T) {
 }
 
 func TestSearchMatchAllRegexp(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -538,7 +542,7 @@ func TestSearchMatchAllRegexp(t *testing.T) {
 }
 
 func TestFileRestriction(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -674,7 +678,7 @@ func TestBranchLimit(t *testing.T) {
 			r.Branches = append(r.Branches, RepositoryBranch{
 				s, "v-" + s})
 		}
-		_, err := NewIndexBuilder(r)
+		_, err := NewIndexBuilder(r, nil)
 		if limit == 64 && err != nil {
 			t.Fatalf("NewIndexBuilder: %v", err)
 		} else if limit == 65 && err == nil {
@@ -1109,24 +1113,37 @@ func TestListReposByContent(t *testing.T) {
 }
 
 func TestMetadata(t *testing.T) {
+	lf := []string{"test"}
 	content := []byte("bla the needle")
 	// ----------------01234567890123
-	b := testIndexBuilder(t, &Repository{
+	b := createTestIndexBuilder(t, &Repository{
 		Name: "reponame",
-	}, Document{Name: "f1", Content: content},
-		Document{Name: "f2", Content: content})
+	}, []Document{
+		Document{Name: "f1", Content: content},
+		Document{Name: "f2", Content: content},
+	}, &IndexOptions{
+		LargeFiles: lf,
+	})
 
 	var buf bytes.Buffer
 	b.Write(&buf)
 	f := &memSeeker{buf.Bytes()}
 
-	rd, _, err := ReadMetadata(f)
+	rd, id, err := ReadMetadata(f)
 	if err != nil {
 		t.Fatalf("ReadMetadata: %v", err)
 	}
 
 	if got, want := rd.Name, "reponame"; got != want {
-		t.Fatalf("got %q want %q", got, want)
+		t.Fatalf("repo metadata: got %q want %q", got, want)
+	}
+
+	got := id.IndexOptions
+	want := IndexOptions{
+		LargeFiles: lf,
+	}
+	if reflect.DeepEqual(got, want) {
+		t.Fatalf("index metadata: got %q want %q", got, want)
 	}
 }
 
@@ -1777,7 +1794,7 @@ func TestDistanceHitIterBailLast(t *testing.T) {
 
 func TestDocumentSectionRuneBoundary(t *testing.T) {
 	content := string([]rune{kelvinCodePoint, kelvinCodePoint, kelvinCodePoint})
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -1832,7 +1849,7 @@ func TestSkipInvalidContent(t *testing.T) {
 		"abc def \x00 abc",
 	} {
 
-		b, err := NewIndexBuilder(nil)
+		b, err := NewIndexBuilder(nil, nil)
 		if err != nil {
 			t.Fatalf("NewIndexBuilder: %v", err)
 		}

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -145,6 +145,12 @@ func (s *postingsBuilder) newSearchableString(data []byte, byteSections []Docume
 	return &dest, runeSecs, nil
 }
 
+// IndexOptions contains options that were used while building an index but are
+// not specific to a repository.
+type IndexOptions struct {
+	LargeFiles []string
+}
+
 // IndexBuilder builds a single index shard.
 type IndexBuilder struct {
 	contentStrings  []*searchableString
@@ -171,6 +177,8 @@ type IndexBuilder struct {
 
 	// languages codes
 	languages []byte
+
+	opts *IndexOptions
 }
 
 func (d *Repository) verify() error {
@@ -191,11 +199,12 @@ func (b *IndexBuilder) ContentSize() uint32 {
 
 // NewIndexBuilder creates a fresh IndexBuilder. The passed in
 // Repository contains repo metadata, and may be set to nil.
-func NewIndexBuilder(r *Repository) (*IndexBuilder, error) {
+func NewIndexBuilder(r *Repository, iopts *IndexOptions) (*IndexBuilder, error) {
 	b := &IndexBuilder{
 		contentPostings: newPostingsBuilder(),
 		namePostings:    newPostingsBuilder(),
 		languageMap:     map[string]byte{},
+		opts:            iopts,
 	}
 
 	if r == nil {

--- a/read_test.go
+++ b/read_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestReadWrite(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestReadWrite(t *testing.T) {
 }
 
 func TestReadWriteNames(t *testing.T) {
-	b, err := NewIndexBuilder(nil)
+	b, err := NewIndexBuilder(nil, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -219,7 +219,7 @@ func TestUnloadIndex(t *testing.T) {
 }
 
 func testIndexBuilder(t *testing.T, repo *zoekt.Repository, docs ...zoekt.Document) *zoekt.IndexBuilder {
-	b, err := zoekt.NewIndexBuilder(repo)
+	b, err := zoekt.NewIndexBuilder(repo, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -69,7 +69,7 @@ func TestBasic(t *testing.T) {
 		FileURLTemplate:      "file-url",
 		LineFragmentTemplate: "#line",
 		Branches:             []zoekt.RepositoryBranch{{Name: "master", Version: "1234"}},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestPrint(t *testing.T) {
 		FileURLTemplate:      "file-url",
 		LineFragmentTemplate: "line",
 		Branches:             []zoekt.RepositoryBranch{{Name: "master", Version: "1234"}},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestPrintDefault(t *testing.T) {
 		Name:     "name",
 		URL:      "repo-url",
 		Branches: []zoekt.RepositoryBranch{{Name: "master", Version: "1234"}},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestCrash(t *testing.T) {
 func TestHostCustomization(t *testing.T) {
 	b, err := zoekt.NewIndexBuilder(&zoekt.Repository{
 		Name: "name",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -334,7 +334,7 @@ func TestHostCustomization(t *testing.T) {
 func TestDupResult(t *testing.T) {
 	b, err := zoekt.NewIndexBuilder(&zoekt.Repository{
 		Name: "name",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestDupResult(t *testing.T) {
 func TestTruncateLine(t *testing.T) {
 	b, err := zoekt.NewIndexBuilder(&zoekt.Repository{
 		Name: "name",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("NewIndexBuilder: %v", err)
 	}

--- a/write.go
+++ b/write.go
@@ -126,6 +126,7 @@ func (b *IndexBuilder) Write(out io.Writer) error {
 		PlainASCII:          b.contentPostings.isPlainASCII && b.namePostings.isPlainASCII,
 		LanguageMap:         b.languageMap,
 		ZoektVersion:        Version,
+		IndexOptions:        b.opts,
 	}, &toc.metaData, w); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is part of the solution for #1624. We are adding a configuration option called "search.largeFiles" which is a list of glob patterns. Any files matching the patterns in the list will be indexed and searched regardless of the size. 

This PR adds functionality so that zoekt's indexer supports the desired functionality.

Ultimately, this will be upstreamed but I am opening this PR so that we can release this without waiting for it to be [approved and merged upstream.](https://gerrit-review.googlesource.com/c/zoekt/+/220077)