### PR TITLE
indexserver: Keep shards in trash for 24 hours before removing

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -135,6 +135,12 @@ func shardRepoName(path string) (string, bool) {
 func removeAll(shards []shard) {
 	for _, shard := range shards {
 		if err := os.Remove(shard.Path); err != nil {
+			// We only expect this to fail due to IsNotExist, which is
+			// fine. Additionally this shouldn't fail partially. But if it
+			// does, and the file still exists, then we have the potential for
+			// a partial index for a repo. However, this should be exceedingly
+			// rare due to it being a mix of partial failure on something in
+			// trash + an admin re-adding a repository.
 			debug.Printf("failed to remove shard %s: %v", shard.Path, err)
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -10,6 +10,10 @@ import (
 	"github.com/google/zoekt"
 )
 
+// cleanup trashes shards in indexDir that do not exist in repos. For repos
+// that do not exist in indexDir, but do in indexDir/.trash it will move them
+// back into indexDir. Additionally it uses now to remove shards that have
+// been in the trash for 24 hours.
 func cleanup(indexDir string, repos []string, now time.Time) {
 	trashDir := filepath.Join(indexDir, ".trash")
 	if err := os.MkdirAll(trashDir, 0755); err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -96,8 +96,8 @@ func getShards(dir string) map[string][]shard {
 			continue
 		}
 
-		name, ok := shardRepoName(path)
-		if !ok {
+		name, err := shardRepoName(path)
+		if err != nil {
 			debug.Printf("failed to read shard: %v", err)
 			continue
 		}
@@ -111,25 +111,25 @@ func getShards(dir string) map[string][]shard {
 	return shards
 }
 
-func shardRepoName(path string) (string, bool) {
+func shardRepoName(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return "", false
+		return "", err
 	}
 	defer f.Close()
 
 	ifile, err := zoekt.NewIndexFile(f)
 	if err != nil {
-		return "", false
+		return "", err
 	}
 	defer ifile.Close()
 
 	repo, _, err := zoekt.ReadMetadata(ifile)
 	if err != nil {
-		return "", false
+		return "", err
 	}
 
-	return repo.Name, true
+	return repo.Name, nil
 }
 
 func removeAll(shards []shard) {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -84,7 +84,7 @@ func getShards(dir string) map[string][]shard {
 	names, _ := d.Readdirnames(-1)
 	sort.Strings(names)
 
-	shards := map[string][]shard{}
+	shards := make(map[string][]shard, len(names))
 	for _, n := range names {
 		path := filepath.Join(dir, n)
 		fi, err := os.Stat(path)

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/google/zoekt"
+)
+
+func cleanup(indexDir string, repos []string, now time.Time) {
+	trashDir := filepath.Join(indexDir, ".trash")
+	if err := os.MkdirAll(trashDir, 0755); err != nil {
+		log.Printf("failed to create trash dir: %v", err)
+	}
+
+	trash := getShards(trashDir)
+	index := getShards(indexDir)
+
+	// trash: Remove old shards and conflicts with index
+	minAge := now.Add(-24 * time.Hour)
+	for repo, shards := range trash {
+		old := false
+		for _, shard := range shards {
+			if shard.ModTime.Before(minAge) {
+				old = true
+			} else if shard.ModTime.After(now) {
+				debug.Printf("trashed shard %s has timestamp in the future, reseting to now", shard.Path)
+				_ = os.Chtimes(shard.Path, now, now)
+			}
+		}
+
+		if _, conflicts := index[repo]; !conflicts && !old {
+			continue
+		}
+
+		log.Printf("removing old shards from trash for %s", repo)
+		removeAll(shards)
+		delete(trash, repo)
+	}
+
+	// index: Move missing repos from trash into index
+	for _, repo := range repos {
+		// Delete from index so that index will only contain shards to be
+		// trashed.
+		delete(index, repo)
+
+		shards, ok := trash[repo]
+		if !ok {
+			continue
+		}
+
+		log.Printf("restoring shards from trash for %s", repo)
+		moveAll(indexDir, shards)
+	}
+
+	// index: Move non-existant repos into trash
+	for _, shards := range index {
+		// Best-effort touch. If touch fails, we will just remove from the
+		// trash sooner.
+		for _, shard := range shards {
+			_ = os.Chtimes(shard.Path, now, now)
+		}
+
+		moveAll(trashDir, shards)
+	}
+}
+
+type shard struct {
+	Repo    string
+	Path    string
+	ModTime time.Time
+}
+
+func getShards(dir string) map[string][]shard {
+	d, err := os.Open(dir)
+	if err != nil {
+		debug.Printf("failed to getShards: %s", dir)
+		return nil
+	}
+	defer d.Close()
+	names, _ := d.Readdirnames(-1)
+	sort.Strings(names)
+
+	shards := map[string][]shard{}
+	for _, n := range names {
+		path := filepath.Join(dir, n)
+		fi, err := os.Stat(path)
+		if err != nil {
+			debug.Printf("stat failed: %v", err)
+			continue
+		}
+		if fi.IsDir() {
+			continue
+		}
+
+		name, ok := shardRepoName(path)
+		if !ok {
+			debug.Printf("failed to read shard: %v", err)
+			continue
+		}
+
+		shards[name] = append(shards[name], shard{
+			Repo:    name,
+			Path:    path,
+			ModTime: fi.ModTime(),
+		})
+	}
+	return shards
+}
+
+func shardRepoName(path string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	ifile, err := zoekt.NewIndexFile(f)
+	if err != nil {
+		return "", false
+	}
+	defer ifile.Close()
+
+	repo, _, err := zoekt.ReadMetadata(ifile)
+	if err != nil {
+		return "", false
+	}
+
+	return repo.Name, true
+}
+
+func removeAll(shards []shard) {
+	for _, shard := range shards {
+		if err := os.Remove(shard.Path); err != nil {
+			debug.Printf("failed to remove shard %s: %v", shard.Path, err)
+		}
+	}
+}
+
+func moveAll(dstDir string, shards []shard) {
+	for i, shard := range shards {
+		dst := filepath.Join(dstDir, filepath.Base(shard.Path))
+		if err := os.Rename(shard.Path, dst); err != nil {
+			log.Printf("failed to move shard, deleting all shards for %s: %v", shard.Repo, err)
+			removeAll(shards)
+			return
+		}
+		// update path so that partial failure removes the dst path
+		shards[i].Path = dst
+	}
+}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -103,32 +103,30 @@ func TestCleanup(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 
-			{
-				// Create index files
-				var fs []shard
-				for _, f := range tt.index {
-					f.Path = filepath.Join(dir, f.Path)
-					fs = append(fs, f)
+			// Create index files
+			var fs []shard
+			for _, f := range tt.index {
+				f.Path = filepath.Join(dir, f.Path)
+				fs = append(fs, f)
+			}
+			for _, f := range tt.trash {
+				f.Path = filepath.Join(dir, ".trash", f.Path)
+				fs = append(fs, f)
+			}
+			for _, f := range fs {
+				createEmptyShard(t, f.Repo, f.Path)
+				if err := os.Chtimes(f.Path, f.ModTime, f.ModTime); err != nil {
+					t.Fatal(err)
 				}
-				for _, f := range tt.trash {
-					f.Path = filepath.Join(dir, ".trash", f.Path)
-					fs = append(fs, f)
-				}
-				for _, f := range fs {
-					createEmptyShard(t, f.Repo, f.Path)
-					if err := os.Chtimes(f.Path, f.ModTime, f.ModTime); err != nil {
-						t.Fatal(err)
-					}
-				}
+			}
 
-				cleanup(dir, tt.repos, now)
+			cleanup(dir, tt.repos, now)
 
-				if got, want := readdir(dir), tt.wantIndex; !reflect.DeepEqual(got, want) {
-					t.Errorf("unexpected index\ngot:  %+v\nwant: %+v", got, want)
-				}
-				if got, want := readdir(filepath.Join(dir, ".trash")), tt.wantTrash; !reflect.DeepEqual(got, want) {
-					t.Errorf("unexpected trash\ngot:  %+v\nwant: %+v", got, want)
-				}
+			if got, want := readdir(dir), tt.wantIndex; !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected index\ngot:  %+v\nwant: %+v", got, want)
+			}
+			if got, want := readdir(filepath.Join(dir, ".trash")), tt.wantTrash; !reflect.DeepEqual(got, want) {
+				t.Errorf("unexpected trash\ngot:  %+v\nwant: %+v", got, want)
 			}
 		})
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/zoekt"
+)
+
+func TestCleanup(t *testing.T) {
+	mk := func(name string, n int, mtime time.Time) shard {
+		return shard{
+			Repo:    name,
+			Path:    fmt.Sprintf("%s_v%d.%05d.zoekt", url.QueryEscape(name), 15, n),
+			ModTime: mtime,
+		}
+	}
+	// We don't use getShards so that we have two implementations of the same
+	// thing (ie pick up bugs in one)
+	readdir := func(dir string) []shard {
+		paths, _ := filepath.Glob(filepath.Join(dir, "*"))
+		sort.Strings(paths)
+		var shards []shard
+		for _, path := range paths {
+			if filepath.Base(path) == ".trash" {
+				continue
+			}
+			name, _ := shardRepoName(path)
+			fi, _ := os.Stat(path)
+			shards = append(shards, shard{
+				Repo:    name,
+				Path:    filepath.Base(path),
+				ModTime: fi.ModTime(),
+			})
+		}
+		return shards
+	}
+
+	now := time.Now().Truncate(time.Second)
+	recent := now.Add(-time.Hour)
+	old := now.Add(-25 * time.Hour)
+	cases := []struct {
+		name  string
+		repos []string
+		index []shard
+		trash []shard
+
+		wantIndex []shard
+		wantTrash []shard
+	}{{
+		name: "noop",
+	}, {
+		name:  "not indexed yet",
+		repos: []string{"foo", "bar"},
+	}, {
+		name:      "just trash",
+		trash:     []shard{mk("foo", 0, recent), mk("bar", 0, recent), mk("bar", 5, old)},
+		wantTrash: []shard{mk("foo", 0, recent)},
+	}, {
+		name:      "single trash",
+		repos:     []string{"foo"},
+		index:     []shard{mk("foo", 0, old), mk("bar", 0, old), mk("bar", 1, old)},
+		wantIndex: []shard{mk("foo", 0, old)},
+		wantTrash: []shard{mk("bar", 0, now), mk("bar", 1, now)},
+	}, {
+		name:      "just index",
+		repos:     []string{"foo"},
+		index:     []shard{mk("foo", 0, old), mk("foo", 1, recent), mk("bar", 0, recent), mk("bar", 1, old)},
+		wantIndex: []shard{mk("foo", 0, old), mk("foo", 1, recent)},
+		wantTrash: []shard{mk("bar", 0, now), mk("bar", 1, now)},
+	}, {
+		name:      "future timestamp",
+		trash:     []shard{mk("foo", 0, now.Add(time.Hour))},
+		wantTrash: []shard{mk("foo", 0, now)},
+	}, {
+		name:      "conflict",
+		repos:     []string{"foo"},
+		trash:     []shard{mk("foo", 0, recent), mk("foo", 1, recent), mk("bar", 0, recent), mk("bar", 1, old)},
+		index:     []shard{mk("foo", 0, recent), mk("bar", 0, recent)},
+		wantIndex: []shard{mk("foo", 0, recent)},
+		wantTrash: []shard{mk("bar", 0, now)},
+	}, {
+		name:      "all",
+		repos:     []string{"exists", "trashed"},
+		trash:     []shard{mk("trashed", 0, recent), mk("delete", 0, old)},
+		index:     []shard{mk("exists", 0, recent), mk("trash", 0, recent)},
+		wantIndex: []shard{mk("exists", 0, recent), mk("trashed", 0, recent)},
+		wantTrash: []shard{mk("trash", 0, now)},
+	}}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "TestCleanup")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			{
+				// Create index files
+				var fs []shard
+				for _, f := range tt.index {
+					f.Path = filepath.Join(dir, f.Path)
+					fs = append(fs, f)
+				}
+				for _, f := range tt.trash {
+					f.Path = filepath.Join(dir, ".trash", f.Path)
+					fs = append(fs, f)
+				}
+				for _, f := range fs {
+					createEmptyShard(t, f.Repo, f.Path)
+					if err := os.Chtimes(f.Path, f.ModTime, f.ModTime); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				cleanup(dir, tt.repos, now)
+
+				if got, want := readdir(dir), tt.wantIndex; !reflect.DeepEqual(got, want) {
+					t.Errorf("unexpected index\ngot:  %+v\nwant: %+v", got, want)
+				}
+				if got, want := readdir(filepath.Join(dir, ".trash")), tt.wantTrash; !reflect.DeepEqual(got, want) {
+					t.Errorf("unexpected trash\ngot:  %+v\nwant: %+v", got, want)
+				}
+			}
+		})
+	}
+}
+
+func createEmptyShard(t *testing.T, repo, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	b, err := zoekt.NewIndexBuilder(&zoekt.Repository{Name: repo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := b.Write(f); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR implements functionality allowing us to restore deleted shards. This
is useful when an admin accidently disables a large number of repositories
temporarily. Instead of having to recompute all the indexes, we can restore
them.

We rely on mtime to track the age of a trashed shard. Additionally we take
care to treat all shards for a repo together, to prevent restoring partial
indexes of a repository.

Part of https://github.com/sourcegraph/sourcegraph/issues/2572