### PR TITLE
make LineMatches only contain single lines

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -150,6 +150,7 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch) []LineMatch {
 			result = []LineMatch{res}
 		}
 	} else {
+		ms = breakMatchesOnNewlines(ms, p.data(false))
 		result = p.fillContentMatches(ms)
 	}
 

--- a/matchtree.go
+++ b/matchtree.go
@@ -411,16 +411,53 @@ func (t *regexpMatchTree) matches(cp *contentProvider, cost int, known map[match
 	idxs := t.regexp.FindAllIndex(cp.data(t.fileName), -1)
 	found := t.found[:0]
 	for _, idx := range idxs {
-		found = append(found, &candidateMatch{
+		cm := &candidateMatch{
 			byteOffset:  uint32(idx[0]),
 			byteMatchSz: uint32(idx[1] - idx[0]),
 			fileName:    t.fileName,
-		})
+		}
+
+		found = append(found, cm)
 	}
 	t.found = found
 	t.reEvaluated = true
 
 	return len(t.found) > 0, true
+}
+
+// breakMatchesOnNewlines returns matches resulting from breaking each element
+// of cms on newlines within text.
+func breakMatchesOnNewlines(cms []*candidateMatch, text []byte) []*candidateMatch {
+	var cms2 []*candidateMatch
+	for _, cm := range cms {
+		cms2 = append(cms2, breakOnNewlines(cm, text)...)
+	}
+	return cms2
+}
+
+// breakOnNewlines returns matches resulting from breaking cm on newlines
+// within text.
+func breakOnNewlines(cm *candidateMatch, text []byte) []*candidateMatch {
+	var cms []*candidateMatch
+	var addMe = &candidateMatch{}
+	*addMe = *cm
+	for i := uint32(cm.byteOffset); i < cm.byteOffset+cm.byteMatchSz; i++ {
+		if text[i] == '\n' {
+			addMe.byteMatchSz = i - addMe.byteOffset
+			if addMe.byteMatchSz != 0 {
+				cms = append(cms, addMe)
+			}
+
+			addMe = &candidateMatch{}
+			*addMe = *cm
+			addMe.byteOffset = i + 1
+		}
+	}
+	addMe.byteMatchSz = cm.byteOffset + cm.byteMatchSz - addMe.byteOffset
+	if addMe.byteMatchSz != 0 {
+		cms = append(cms, addMe)
+	}
+	return cms
 }
 
 func evalMatchTree(cp *contentProvider, cost int, known map[matchTree]bool, mt matchTree) (bool, bool) {

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -1,0 +1,174 @@
+// Copyright 2018 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zoekt
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_breakOnNewlines(t *testing.T) {
+	type args struct {
+		cm   *candidateMatch
+		text []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*candidateMatch
+	}{
+		{
+			name: "trivial case",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 0,
+				},
+				text: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "no newlines",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 1,
+				},
+				text: []byte("a"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  0,
+					byteMatchSz: 1,
+				},
+			},
+		},
+		{
+			name: "newline at start",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 2,
+				},
+				text: []byte("\na"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  1,
+					byteMatchSz: 1,
+				},
+			},
+		},
+		{
+			name: "newline at end",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 2,
+				},
+				text: []byte("a\n"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  0,
+					byteMatchSz: 1,
+				},
+			},
+		},
+		{
+			name: "newline in middle",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 3,
+				},
+				text: []byte("a\nb"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  0,
+					byteMatchSz: 1,
+				},
+				{
+					byteOffset:  2,
+					byteMatchSz: 1,
+				},
+			},
+		},
+		{
+			name: "two newlines",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  0,
+					byteMatchSz: 5,
+				},
+				text: []byte("a\nb\nc"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  0,
+					byteMatchSz: 1,
+				},
+				{
+					byteOffset:  2,
+					byteMatchSz: 1,
+				},
+				{
+					byteOffset:  4,
+					byteMatchSz: 1,
+				},
+			},
+		},
+		{
+			name: "two newlines, nonzero offset",
+			args: args{
+				cm: &candidateMatch{
+					byteOffset:  2,
+					byteMatchSz: 3,
+				},
+				text: []byte("a\nb\nc"),
+			},
+			want: []*candidateMatch{
+				{
+					byteOffset:  2,
+					byteMatchSz: 1,
+				},
+				{
+					byteOffset:  4,
+					byteMatchSz: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := breakOnNewlines(tt.args.cm, tt.args.text); !reflect.DeepEqual(got, tt.want) {
+				type PrintableCm struct {
+					byteOffset  uint32
+					byteMatchSz uint32
+				}
+				var got2, want2 []PrintableCm
+				for _, g := range got {
+					got2 = append(got2, PrintableCm{byteOffset: g.byteOffset, byteMatchSz: g.byteMatchSz})
+				}
+				for _, w := range tt.want {
+					want2 = append(want2, PrintableCm{byteOffset: w.byteOffset, byteMatchSz: w.byteMatchSz})
+				}
+				t.Errorf("breakMatchOnNewlines() = %+v, want %+v", got2, want2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/4138, also known as https://github.com/google/zoekt/issues/88.

Before:
![Screen Shot 2019-06-12 at 19 39 39](https://user-images.githubusercontent.com/15530/59399721-eaa01700-8d49-11e9-8cc4-2af0744a8990.png)

After:
![Screen Shot 2019-06-12 at 19 36 41](https://user-images.githubusercontent.com/15530/59399613-7d8c8180-8d49-11e9-88f3-4ce65288dc96.png)
