### PR TITLE
do initial index dir scan in a goroutine for faster startup

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -209,6 +209,7 @@ func main() {
 	}
 	go watchdog(30*time.Second, watchdogAddr)
 
+	log.Printf("listening on %s", *listen)
 	if *sslCert != "" || *sslKey != "" {
 		err = http.ListenAndServeTLS(*listen, *sslCert, *sslKey, handler)
 	} else {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -79,6 +79,7 @@ type throttledLoader struct {
 }
 
 func (tl *throttledLoader) load(key string) {
+	log.Printf("loading %s", key)
 	tl.throttle <- struct{}{}
 	shard, err := loadShard(key)
 	<-tl.throttle

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -79,7 +79,6 @@ type throttledLoader struct {
 }
 
 func (tl *throttledLoader) load(key string) {
-	log.Printf("loading %s", key)
 	tl.throttle <- struct{}{}
 	shard, err := loadShard(key)
 	<-tl.throttle

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -55,12 +55,6 @@ func NewDirectoryWatcher(dir string, loader shardLoader) (io.Closer, error) {
 		loader:     loader,
 		quit:       quitter,
 	}
-	go func() {
-		if err := sw.scan(); err != nil {
-			log.Fatalf("failed to scan index directory: %v", err)
-		}
-	}()
-
 	if err := sw.watch(quitter); err != nil {
 		return nil, err
 	}
@@ -133,6 +127,7 @@ func (s *shardWatcher) watch(quitter <-chan struct{}) error {
 	}
 
 	go func() {
+		s.scan()
 		for {
 			select {
 			case <-watcher.Events:

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -105,10 +105,19 @@ func (s *shardWatcher) scan() error {
 	}
 
 	var wg sync.WaitGroup
+	nLoaded := 0
+	log.Printf("loading %d shards", len(toLoad))
+	percent := func(n int) int {
+		return (100*n)/len(toLoad)
+	}
 	for _, t := range toLoad {
 		wg.Add(1)
 		go func(k string) {
 			s.loader.load(k)
+			nLoaded++
+			if percent(nLoaded)/10 != percent(nLoaded-1)/10 {
+				log.Printf("loaded %d%% of shards", percent(nLoaded))
+			}
 			wg.Done()
 		}(t)
 	}

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -55,9 +55,11 @@ func NewDirectoryWatcher(dir string, loader shardLoader) (io.Closer, error) {
 		loader:     loader,
 		quit:       quitter,
 	}
-	if err := sw.scan(); err != nil {
-		return nil, err
-	}
+	go func() {
+		if err := sw.scan(); err != nil {
+			log.Fatalf("failed to scan index directory: %v", err)
+		}
+	}()
 
 	if err := sw.watch(quitter); err != nil {
 		return nil, err


### PR DESCRIPTION
With the index files being loaded in the background, the server can start listening right away.

Also this PR adds a bit of logging to show the progress loading index files, and when the web server starts listening.

Addresses https://github.com/sourcegraph/sourcegraph/issues/4832.