### PR TITLE
add regex + small query support to symbol search

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -135,9 +135,6 @@ func (o *Options) SetDefaults() {
 		}
 	}
 
-	// Sourcegraph modification: We never want to run ctags
-	o.CTags = ""
-
 	if o.Parallelism == 0 {
 		o.Parallelism = 1
 	}

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -17,7 +17,6 @@ package zoekt
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"log"
 	"sort"
 	"unicode/utf8"
@@ -180,6 +179,7 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch) []LineMatch {
 	default:
 		if ms[0].scope == query.ScopeSymbol {
 			ms = p.mapSymbols(ms)
+			p.idx = ms[0].file
 		}
 
 		ms = breakMatchesOnNewlines(ms, p.data(query.ScopeFileContent))
@@ -193,8 +193,6 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch) []LineMatch {
 
 	return result
 }
-
-type _ = fmt.Formatter
 
 func (p *contentProvider) mapSymbols(ms []*candidateMatch) []*candidateMatch {
 	cms := make([]*candidateMatch, 0, len(ms))
@@ -218,7 +216,7 @@ func (p *contentProvider) mapSymbols(ms []*candidateMatch) []*candidateMatch {
 		if err == nil {
 			cms = append(cms, &candidateMatch{
 				caseSensitive: cm.caseSensitive,
-				scope:         query.ScopeFileContent,
+				scope:         query.ScopeSymbol,
 				substrBytes:   cm.substrBytes,
 				substrLowered: cm.substrLowered,
 				file:          file,
@@ -228,7 +226,6 @@ func (p *contentProvider) mapSymbols(ms []*candidateMatch) []*candidateMatch {
 			})
 		}
 	}
-
 	return cms
 }
 

--- a/eval.go
+++ b/eval.go
@@ -147,15 +147,15 @@ nextFileMatch:
 		}
 
 		nextDoc := mt.nextDoc()
+		/*
+			if int(nextDoc) <= lastDoc {
+				nextDoc = uint32(lastDoc + 1)
+			}
+		*/
 		if nextDoc >= docCount {
 			break
 		}
 		lastDoc = int(nextDoc)
-
-		/*
-			fmt.Println()
-			fmt.Println(string(d.fileName(nextDoc)))
-		*/
 
 		if canceled || (res.Stats.MatchCount >= opts.ShardMaxMatchCount && opts.ShardMaxMatchCount > 0) ||
 			(opts.ShardMaxImportantMatch > 0 && importantMatchCount >= opts.ShardMaxImportantMatch) {
@@ -315,17 +315,21 @@ func gatherMatches(mt matchTree, known map[matchTree]bool) []*candidateMatch {
 		}
 	})
 
-	foundContentMatch := false
+	scope := query.ScopeFileName
 	for _, c := range cands {
-		if c.scope == query.ScopeFileContent {
-			foundContentMatch = true
+		switch c.scope {
+		case query.ScopeFileContent, query.ScopeSymbol:
+			scope = c.scope
+		}
+
+		if scope == query.ScopeFileContent {
 			break
 		}
 	}
 
 	res := cands[:0]
 	for _, c := range cands {
-		if !foundContentMatch || c.scope == query.ScopeFileContent {
+		if c.scope == scope {
 			res = append(res, c)
 		}
 	}

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -355,7 +355,7 @@ func (b *IndexBuilder) addSymbols(symbols []*Symbol, doc uint32) error {
 		symStrs = append(symStrs, symStr)
 
 		buf := &bytes.Buffer{}
-		for _, n := range []uint32{doc, sym.Start, sym.End} {
+		for _, n := range []uint32{doc, sym.Start} {
 			err = binary.Write(buf, binary.BigEndian, n)
 			if err != nil {
 				return nil

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -163,6 +163,8 @@ type IndexBuilder struct {
 	namePostings    *postingsBuilder
 	symbolPostings  *postingsBuilder
 
+	symbolFileOffsets []uint32
+
 	// root repository
 	repo Repository
 
@@ -196,10 +198,11 @@ func (b *IndexBuilder) ContentSize() uint32 {
 // Repository contains repo metadata, and may be set to nil.
 func NewIndexBuilder(r *Repository) (*IndexBuilder, error) {
 	b := &IndexBuilder{
-		contentPostings: newPostingsBuilder(),
-		namePostings:    newPostingsBuilder(),
-		symbolPostings:  newPostingsBuilder(),
-		languageMap:     map[string]byte{},
+		contentPostings:   newPostingsBuilder(),
+		namePostings:      newPostingsBuilder(),
+		symbolPostings:    newPostingsBuilder(),
+		symbolFileOffsets: []uint32{0},
+		languageMap:       map[string]byte{},
 	}
 
 	if r == nil {
@@ -412,6 +415,7 @@ func (b *IndexBuilder) Add(doc Document) error {
 		fmt.Println(err)
 		return err
 	}
+	b.symbolFileOffsets = append(b.symbolFileOffsets, uint32(len(b.symbolStrings)))
 
 	if doc.SubRepositoryPath != "" {
 		rel, err := filepath.Rel(doc.SubRepositoryPath, doc.Name)

--- a/indexdata.go
+++ b/indexdata.go
@@ -45,6 +45,16 @@ type indexData struct {
 	boundariesStart uint32
 	boundaries      []uint32
 
+	symbolNames []byte
+	symbolIndex []uint32
+
+	symbolMetaData      []byte
+	symbolMetaDataIndex []uint32
+
+	symbolNgrams      map[ngram][]uint32
+	symbolRuneOffsets []uint32
+	symbolEndRunes    []uint32
+
 	// rune offsets for the file content boundaries
 	fileEndRunes []uint32
 

--- a/indexdata.go
+++ b/indexdata.go
@@ -54,6 +54,7 @@ type indexData struct {
 	symbolNgrams      map[ngram][]uint32
 	symbolRuneOffsets []uint32
 	symbolEndRunes    []uint32
+	symbolFileOffsets []uint32
 
 	// rune offsets for the file content boundaries
 	fileEndRunes []uint32

--- a/indexdata.go
+++ b/indexdata.go
@@ -244,6 +244,7 @@ func (d *indexData) iterateNgrams(substr *query.Substring) (*ngramIterationResul
 
 	firstNG := ngramOffs[firstI].ngram
 	lastNG := ngramOffs[lastI].ngram
+
 	iter := &ngramDocIterator{
 		leftPad:  firstI,
 		rightPad: uint32(utf8.RuneCountInString(str)) - firstI,

--- a/matchiter.go
+++ b/matchiter.go
@@ -26,7 +26,7 @@ import (
 // candidateMatch is a candidate match for a substring.
 type candidateMatch struct {
 	caseSensitive bool
-	fileName      bool
+	scope         query.SearchScope
 
 	substrBytes   []byte
 	substrLowered []byte
@@ -37,6 +37,9 @@ type candidateMatch struct {
 	runeOffset  uint32
 	byteOffset  uint32
 	byteMatchSz uint32
+
+	// Symbol
+	symKind string
 }
 
 // Matches content against the substring, and populates byteMatchSz on success

--- a/matchiter.go
+++ b/matchiter.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"unicode/utf8"
 
 	"github.com/google/zoekt/query"
 )
@@ -210,74 +209,4 @@ func (i *ngramDocIterator) candidates() []*candidateMatch {
 	}
 	i.matchCount += len(candidates)
 	return candidates
-}
-
-type trimBySectionMatchIter struct {
-	matchIterator
-
-	patternSize  uint32
-	fileEndRunes []uint32
-
-	// mutable
-	doc      uint32
-	sections []DocumentSection
-}
-
-func (i *trimBySectionMatchIter) String() string {
-	return fmt.Sprintf("trimSection(sz=%d, %v)", i.patternSize, i.matchIterator)
-}
-
-func (d *indexData) newTrimByDocSectionIter(q *query.Substring, iter matchIterator) *trimBySectionMatchIter {
-	return &trimBySectionMatchIter{
-		matchIterator: iter,
-		patternSize:   uint32(utf8.RuneCountInString(q.Pattern)),
-		fileEndRunes:  d.fileEndRunes,
-		sections:      d.runeDocSections,
-	}
-}
-
-func (i *trimBySectionMatchIter) prepare(doc uint32) {
-	i.matchIterator.prepare(doc)
-	i.doc = doc
-
-	var fileStart uint32
-	if doc > 0 {
-		fileStart = i.fileEndRunes[doc-1]
-	}
-
-	for len(i.sections) > 0 && i.sections[0].Start < fileStart {
-		i.sections = i.sections[1:]
-	}
-}
-
-func (i *trimBySectionMatchIter) candidates() []*candidateMatch {
-	var fileStart uint32
-	if i.doc > 0 {
-		fileStart = i.fileEndRunes[i.doc-1]
-	}
-
-	ms := i.matchIterator.candidates()
-	trimmed := ms[:0]
-	for len(i.sections) > 0 && len(ms) > 0 {
-		start := fileStart + ms[0].runeOffset
-		end := start + i.patternSize
-		if start >= i.sections[0].End {
-			i.sections = i.sections[1:]
-			continue
-		}
-
-		if start < i.sections[0].Start {
-			ms = ms[1:]
-			continue
-		}
-
-		// here we have: sec.Start <= start < sec.End
-		if end <= i.sections[0].End {
-			// complete match falls inside section.
-			trimmed = append(trimmed, ms[0])
-		}
-
-		ms = ms[1:]
-	}
-	return trimmed
 }

--- a/matchtree.go
+++ b/matchtree.go
@@ -194,7 +194,7 @@ func (t *symbolMatchTree) matches(cp *contentProvider, cost int, known map[match
 		// SECOND
 
 		next := t.child.nextDoc()
-		if next == maxUInt32 {
+		if next == maxUInt32 || next+2 >= uint32(len(t.metaDataIndex)) {
 			t.child.prepare(t.sym)
 			break
 		}
@@ -495,8 +495,6 @@ func (t *regexpMatchTree) matches(cp *contentProvider, cost int, known map[match
 	if cost < costRegexp {
 		return false, false
 	}
-
-	fmt.Println(string(cp.data(t.scope)))
 
 	idxs := t.regexp.FindAllIndex(cp.data(t.scope), -1)
 	found := t.found[:0]

--- a/matchtree.go
+++ b/matchtree.go
@@ -153,7 +153,7 @@ type symbolMatchTree struct {
 
 func (t *symbolMatchTree) nextDoc() uint32 {
 	idx := t.child.nextDoc()
-	if idx == maxUInt32 {
+	if idx + 2 >= uint32(len(t.metaDataIndex)) {
 		return maxUInt32
 	}
 	t.sym = idx
@@ -190,8 +190,6 @@ func (t *symbolMatchTree) matches(cp *contentProvider, cost int, known map[match
 				cands = append(cands, t.found...)
 			}
 		})
-
-		// SECOND
 
 		next := t.child.nextDoc()
 		if next == maxUInt32 || next+2 >= uint32(len(t.metaDataIndex)) {

--- a/matchtree.go
+++ b/matchtree.go
@@ -153,7 +153,7 @@ type symbolMatchTree struct {
 
 func (t *symbolMatchTree) nextDoc() uint32 {
 	idx := t.child.nextDoc()
-	if idx + 2 >= uint32(len(t.metaDataIndex)) {
+	if idx == maxUInt32 || idx + 2 >= uint32(len(t.metaDataIndex)) {
 		return maxUInt32
 	}
 	t.sym = idx

--- a/read.go
+++ b/read.go
@@ -238,6 +238,11 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
+	d.symbolFileOffsets, err = readSectionU32(d.file, toc.symbolFileOffsets)
+	if err != nil {
+		return nil, err
+	}
+
 	d.fileNameContent, err = d.readSectionBlob(toc.fileNames.data)
 	if err != nil {
 		return nil, err

--- a/read.go
+++ b/read.go
@@ -233,13 +233,6 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		d.symbolNgrams[ng] = fromDeltas(symbolPostingsData[off:end], nil)
 	}
 
-	for i := 0; i < 5; i++ {
-		fmt.Println(d.symbolIndex[i])
-		fmt.Println(d.symbolIndex[i+1])
-		fmt.Println(string(d.symbolNames[d.symbolIndex[i]:d.symbolIndex[i+1]]))
-		fmt.Println(string(d.symbolMetaData[d.symbolMetaDataIndex[i]:d.symbolMetaDataIndex[i+1]]))
-	}
-
 	d.fileBranchMasks, err = readSectionU64(d.file, toc.branchMasks)
 	if err != nil {
 		return nil, err

--- a/toc.go
+++ b/toc.go
@@ -27,6 +27,7 @@ package zoekt
 // 13: content checksums
 // 14: languages
 // 15: rune based symbol sections
+// 16: posting list for symbols
 const IndexFormatVersion = 15
 
 // FeatureVersion is increased if a feature is added that requires reindexing data
@@ -41,18 +42,25 @@ const IndexFormatVersion = 15
 const FeatureVersion = 8
 
 type indexTOC struct {
-	fileContents compoundSection
-	fileNames    compoundSection
-	fileSections compoundSection
-	postings     compoundSection
-	newlines     compoundSection
-	ngramText    simpleSection
-	runeOffsets  simpleSection
-	fileEndRunes simpleSection
-	languages    simpleSection
+	fileContents   compoundSection
+	fileNames      compoundSection
+	symbolNames    compoundSection
+	symbolMetaData compoundSection
+	fileSections   compoundSection
+	postings       compoundSection
+	newlines       compoundSection
+	ngramText      simpleSection
+	runeOffsets    simpleSection
+	fileEndRunes   simpleSection
+	languages      simpleSection
 
 	branchMasks simpleSection
 	subRepos    simpleSection
+
+	symbolNgramText   simpleSection
+	symbolPostings    compoundSection
+	symbolRuneOffsets simpleSection
+	symbolEndRunes    simpleSection
 
 	nameNgramText    simpleSection
 	namePostings     compoundSection
@@ -72,12 +80,18 @@ func (t *indexTOC) sections() []section {
 		&t.repoMetaData,
 		&t.fileContents,
 		&t.fileNames,
+		&t.symbolNames,
+		&t.symbolMetaData,
 		&t.fileSections,
 		&t.newlines,
 		&t.ngramText,
 		&t.postings,
 		&t.nameNgramText,
 		&t.namePostings,
+		&t.symbolNgramText,
+		&t.symbolPostings,
+		&t.symbolRuneOffsets,
+		&t.symbolEndRunes,
 		&t.branchMasks,
 		&t.subRepos,
 		&t.runeOffsets,

--- a/toc.go
+++ b/toc.go
@@ -28,7 +28,7 @@ package zoekt
 // 14: languages
 // 15: rune based symbol sections
 // 16: posting list for symbols
-const IndexFormatVersion = 15
+const IndexFormatVersion = 16
 
 // FeatureVersion is increased if a feature is added that requires reindexing data
 // without changing the format version
@@ -61,6 +61,7 @@ type indexTOC struct {
 	symbolPostings    compoundSection
 	symbolRuneOffsets simpleSection
 	symbolEndRunes    simpleSection
+	symbolFileOffsets simpleSection
 
 	nameNgramText    simpleSection
 	namePostings     compoundSection
@@ -92,6 +93,7 @@ func (t *indexTOC) sections() []section {
 		&t.symbolPostings,
 		&t.symbolRuneOffsets,
 		&t.symbolEndRunes,
+		&t.symbolFileOffsets,
 		&t.branchMasks,
 		&t.subRepos,
 		&t.runeOffsets,

--- a/write.go
+++ b/write.go
@@ -98,6 +98,10 @@ func (b *IndexBuilder) Write(out io.Writer) error {
 
 	writePostings(w, b.contentPostings, &toc.ngramText, &toc.runeOffsets, &toc.postings, &toc.fileEndRunes)
 
+	writePostings(w, b.symbolPostings, &toc.symbolNgramText, &toc.symbolRuneOffsets, &toc.symbolPostings, &toc.symbolEndRunes)
+	toc.symbolNames.writeStrings(w, b.symbolStrings)
+	toc.symbolMetaData.writeStrings(w, b.symbolMetadata)
+
 	// names.
 	toc.fileNames.writeStrings(w, b.nameStrings)
 

--- a/write.go
+++ b/write.go
@@ -102,6 +102,12 @@ func (b *IndexBuilder) Write(out io.Writer) error {
 	toc.symbolNames.writeStrings(w, b.symbolStrings)
 	toc.symbolMetaData.writeStrings(w, b.symbolMetadata)
 
+	toc.symbolFileOffsets.start(w)
+	for _, o := range b.symbolFileOffsets {
+		w.U32(o)
+	}
+	toc.symbolFileOffsets.end(w)
+
 	// names.
 	toc.fileNames.writeStrings(w, b.nameStrings)
 


### PR DESCRIPTION
This is a working prototype of symbol search using Zoekt for regex queries.

installing:
`$ go install ./cmd/zoekt/`
`$ go install ./cmd/zoekt-index/`

`universal-ctags` (w/ interactive mode) is required prior to indexing.

indexing:
`$ zoekt-index ./`

example queries:
`$ zoekt 'sym:^IndexBuilder$'`
`$ zoekt 'sym:^test_.*'`
`$ zoekt 'sym:.* file:indexbuilder.go'`

Todo:  
- Add unit tests
- Parallelize ctags metadata generation to speed up indexing time
- Add ranking for symbols
- Update zoekt API with symbols endpoint

cc: https://github.com/sourcegraph/sourcegraph/issues/3534