### PR TITLE
Follow up on post-merge review of performance work on sharded searcher

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -133,7 +133,6 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 				}
 			}
 		}
-
 		and.Children[i] = &query.Const{Value: len(filtered) > 0}
 
 		// Stop after first RepoSet, otherwise we might append duplicate

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/zoekt/query"
 )
 
-type Repositorer interface {
+type repositorer interface {
 	Repository() *zoekt.Repository
 }
 
@@ -126,7 +126,7 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 		filtered := shards[:0]
 
 		for _, s := range shards {
-			if repositorer, ok := s.Searcher.(Repositorer); ok {
+			if repositorer, ok := s.Searcher.(repositorer); ok {
 				repo := repositorer.Repository()
 				if setQuery.Set[repo.Name] {
 					filtered = append(filtered, s)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -137,9 +137,7 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 
 		// Stop after first RepoSet, otherwise we might append duplicate
 		// shards to `filtered`
-		if len(filtered) != 0 {
-			return filtered, and
-		}
+		return filtered, and
 	}
 
 	return shards, and

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -137,7 +137,7 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 
 		// Stop after first RepoSet, otherwise we might append duplicate
 		// shards to `filtered`
-		return filtered, and
+		return filtered, query.Simplify(and)
 	}
 
 	return shards, and

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -166,7 +166,7 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 		shardName := fmt.Sprintf("shard%d", i)
 		repoName := fmt.Sprintf("repository%d", i)
 
-		if i%2 == 0 {
+		if i%3 == 0 {
 			repoSetNames = append(repoSetNames, repoName)
 		}
 
@@ -194,6 +194,15 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 	// result and using repoSet will half the number of results
 	if len(res.Files) != len(repoSetNames) {
 		t.Fatalf("with reposet: got %d results, want %d", len(res.Files), len(repoSetNames))
+	}
+
+	// With the same reposet multiple times
+	res, err = ss.Search(context.Background(), query.NewAnd(set, set, sub), &zoekt.SearchOptions{})
+	if err != nil {
+		t.Errorf("Search: %v", err)
+	}
+	if len(res.Files) != len(repoSetNames) {
+		t.Fatalf("with reposet multiple times: got %d results, want %d", len(res.Files), len(repoSetNames))
 	}
 }
 


### PR DESCRIPTION
This adresses the comments by @keegancsmith in https://github.com/sourcegraph/zoekt/pull/14 after the merge.

I'm quoting the commit message of the first commit here:

> 
> This commit does a couple of things to make the added behavior correct:
> 
> 1. It reuses the simplified query produced by `selectRepoSet` which
>    in turn reduces the work the shards have to do when evaluating the
>    query
> 2. It only evaluates the `query.RepoSet` if it's part of a top-level
>    `query.And`. The previous code was too naive when considering that a
>    `query.RepoSet` can appear anywhere in a `query.Q`. See this comment
>    for more details:
>    #14 (comment)
> 3. It changes the const value that's returned in the simplified version
>    so that `typeRepoSearcher`, which evaluates `query.TypeRepo` queries to
>    a `query.RepoSet` works (the tests in `shards/eval_test.go` break
>    without this.

I think the behavior is now correct.

I don't think it's worth it, but if the usecase of multiple RepoSet queries ever arises we can easily remove the `break` and use a set to not append duplicates to the `filtered` slice.