### PR TITLE
zoekt-sourcegraph-indexserver: Use tarball redirect

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -335,7 +335,10 @@ func resolveRevision(root *url.URL, repo, spec string) (string, error) {
 }
 
 func tarballURL(root *url.URL, repo, commit string) string {
-	return root.ResolveReference(&url.URL{Path: fmt.Sprintf("/.internal/git/%s/tar/%s", repo, commit)}).String()
+	return root.ResolveReference(&url.URL{
+		Path:     fmt.Sprintf("/.internal/git/%s/tar/%s", repo, commit),
+		RawQuery: "redirect=1",
+	}).String()
 }
 
 func main() {


### PR DESCRIPTION
This commit makes zoekt-sourcegraph-indexserver ask for a redirect to
from the internal frontend git tar endpoint to the new gitserver archive
endpoint.

Part of https://github.com/sourcegraph/sourcegraph/issues/4949