### PR TITLE
Support reading v15 shards

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -176,11 +176,13 @@ func (t *symbolRegexpMatchTree) matches(cp *contentProvider, cost int, known map
 			continue
 		}
 
-		secID := cp.id.fileEndSymbol[cp.idx] + uint32(i)
 		cm := &candidateMatch{
 			byteOffset:  sec.Start + uint32(idx[0]),
 			byteMatchSz: uint32(idx[1] - idx[0]),
-			symbolInfo:  cp.id.symbolData.data(secID),
+		}
+		if cp.idx < uint32(len(cp.id.fileEndSymbol)) { // If v15 fileEndSymbol is empty
+			secID := cp.id.fileEndSymbol[cp.idx] + uint32(i)
+			cm.symbolInfo = cp.id.symbolData.data(secID)
 		}
 		found = append(found, cm)
 	}

--- a/read.go
+++ b/read.go
@@ -154,11 +154,7 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	if IndexFormatVersion != 16 {
-		panic(`Sourcegraph: While we are on version 16 we have added code into
-	read.go which supports reading IndexFormatVersion 15. If you change the
-	IndexFormatVersion please reach out to Kevin and Keegan.`)
-	}
+	ensureSourcegraphSymbolsHack()
 
 	// Once we are not on version 16 use this code again
 	// if d.metaData.IndexFormatVersion != IndexFormatVersion {

--- a/read.go
+++ b/read.go
@@ -77,13 +77,13 @@ func (r *reader) readTOC(toc *indexTOC) error {
 		return err
 	}
 
-	secs := toc.sections()
+	secs := toc.sectionsHACK(sectionCount)
 
 	if len(secs) != int(sectionCount) {
 		return fmt.Errorf("section count mismatch: got %d want %d", sectionCount, len(secs))
 	}
 
-	for _, s := range toc.sections() {
+	for _, s := range secs {
 		if err := s.read(r); err != nil {
 			return err
 		}

--- a/toc.go
+++ b/toc.go
@@ -78,6 +78,43 @@ type indexTOC struct {
 	runeDocSections  simpleSection
 }
 
+func (t *indexTOC) sectionsHACK(expectedSectionCount uint32) []section {
+	if IndexFormatVersion != 16 {
+		panic(`Sourcegraph: While we are on version 16 we have added code into
+	read.go which supports reading IndexFormatVersion 15. If you change the
+	IndexFormatVersion please reach out to Kevin and Keegan.`)
+	}
+
+	// Sourcegraph hack for v15.
+	if expectedSectionCount == 19 {
+		return []section{
+			// This must be first, so it can be reliably read across
+			// file format versions.
+			&t.metaData,
+			&t.repoMetaData,
+			&t.fileContents,
+			&t.fileNames,
+			&t.fileSections,
+			&t.newlines,
+			&t.ngramText,
+			&t.postings,
+			&t.nameNgramText,
+			&t.namePostings,
+			&t.branchMasks,
+			&t.subRepos,
+			&t.runeOffsets,
+			&t.nameRuneOffsets,
+			&t.fileEndRunes,
+			&t.nameEndRunes,
+			&t.contentChecksums,
+			&t.languages,
+			&t.runeDocSections,
+		}
+	}
+
+	return t.sections()
+}
+
 func (t *indexTOC) sections() []section {
 	return []section{
 		// This must be first, so it can be reliably read across

--- a/toc.go
+++ b/toc.go
@@ -39,7 +39,8 @@ const IndexFormatVersion = 16
 // 6: Include '#' into the LineFragment template
 // 7: Record skip reasons in the index.
 // 8: Record source path in the index.
-const FeatureVersion = 8
+// 9: Store ctags metadata
+const FeatureVersion = 9
 
 func init() {
 	ensureSourcegraphSymbolsHack()
@@ -50,6 +51,11 @@ func ensureSourcegraphSymbolsHack() {
 		panic(`Sourcegraph: While we are on version 16 we have added code into
 	read.go which supports reading IndexFormatVersion 15. If you change the
 	IndexFormatVersion please reach out to Kevin and Keegan.`)
+	}
+	if FeatureVersion != 9 {
+		panic(`Sourcegraph: While we are on FeatureVersion 9 we have added code into
+	read.go which supports reading FeatureVersion 8. If you change the
+	FeatureVersion please reach out to Kevin and Keegan.`)
 	}
 }
 

--- a/toc.go
+++ b/toc.go
@@ -14,7 +14,7 @@
 
 package zoekt
 
-// FormatVersion is a version number. It is increased every time the
+// IndexFormatVersion is a version number. It is increased every time the
 // on-disk index format is changed.
 // 5: subrepositories.
 // 6: remove size prefix for posting varint list.
@@ -30,6 +30,14 @@ package zoekt
 // 16: ctags metadata
 const IndexFormatVersion = 16
 
+func init() {
+	if IndexFormatVersion != 16 {
+		panic(`Sourcegraph: While we are on version 16 we have added code into
+	read.go which supports reading IndexFormatVersion 15. If you change the
+	IndexFormatVersion please reach out to Kevin and Keegan.`)
+	}
+}
+
 // FeatureVersion is increased if a feature is added that requires reindexing data
 // without changing the format version
 // 2: Rank field for shards.
@@ -39,8 +47,7 @@ const IndexFormatVersion = 16
 // 6: Include '#' into the LineFragment template
 // 7: Record skip reasons in the index.
 // 8: Record source path in the index.
-// 9: Store ctags metadata
-const FeatureVersion = 9
+const FeatureVersion = 8
 
 type indexTOC struct {
 	fileContents compoundSection

--- a/toc.go
+++ b/toc.go
@@ -30,14 +30,6 @@ package zoekt
 // 16: ctags metadata
 const IndexFormatVersion = 16
 
-func init() {
-	if IndexFormatVersion != 16 {
-		panic(`Sourcegraph: While we are on version 16 we have added code into
-	read.go which supports reading IndexFormatVersion 15. If you change the
-	IndexFormatVersion please reach out to Kevin and Keegan.`)
-	}
-}
-
 // FeatureVersion is increased if a feature is added that requires reindexing data
 // without changing the format version
 // 2: Rank field for shards.
@@ -48,6 +40,18 @@ func init() {
 // 7: Record skip reasons in the index.
 // 8: Record source path in the index.
 const FeatureVersion = 8
+
+func init() {
+	ensureSourcegraphSymbolsHack()
+}
+
+func ensureSourcegraphSymbolsHack() {
+	if IndexFormatVersion != 16 {
+		panic(`Sourcegraph: While we are on version 16 we have added code into
+	read.go which supports reading IndexFormatVersion 15. If you change the
+	IndexFormatVersion please reach out to Kevin and Keegan.`)
+	}
+}
 
 type indexTOC struct {
 	fileContents compoundSection
@@ -79,11 +83,7 @@ type indexTOC struct {
 }
 
 func (t *indexTOC) sectionsHACK(expectedSectionCount uint32) []section {
-	if IndexFormatVersion != 16 {
-		panic(`Sourcegraph: While we are on version 16 we have added code into
-	read.go which supports reading IndexFormatVersion 15. If you change the
-	IndexFormatVersion please reach out to Kevin and Keegan.`)
-	}
+	ensureSourcegraphSymbolsHack()
 
 	// Sourcegraph hack for v15.
 	if expectedSectionCount == 19 {


### PR DESCRIPTION
We can update our read code to support reading older shards. This will allow us
to continue serving indexed search when we are busy re-indexing everything from
v15 to v16.

I added the panics to ensure when someone updates the version they do not accidently shoot themselves in the foot.

Open Question: Have we shipped `FeatureVersion: 9` to any customers? If so we need to work around that as well.