### PR TITLE
Fix symbol metadata offset error

### DIFF
--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -388,6 +388,7 @@ func (b *IndexBuilder) Add(doc Document) error {
 	if doc.SkipReason != "" {
 		doc.Content = []byte(notIndexedMarker + doc.SkipReason)
 		doc.Symbols = nil
+		doc.SymbolsMetaData = nil
 		if doc.Language == "" {
 			doc.Language = "skipped"
 		}
@@ -406,7 +407,6 @@ func (b *IndexBuilder) Add(doc Document) error {
 	if last.End > uint32(len(doc.Content)) {
 		return fmt.Errorf("section goes past end of content")
 	}
-	b.addSymbols(doc.SymbolsMetaData)
 
 	if doc.SubRepositoryPath != "" {
 		rel, err := filepath.Rel(doc.SubRepositoryPath, doc.Name)
@@ -422,6 +422,7 @@ func (b *IndexBuilder) Add(doc Document) error {
 	if err != nil {
 		return err
 	}
+	b.addSymbols(doc.SymbolsMetaData)
 
 	subRepoIdx, ok := b.subRepoIndices[doc.SubRepositoryPath]
 	if !ok {


### PR DESCRIPTION
In the case of an error during index building for a file (ex. file document size greater than maximum allowed), we avoid storing ctags information generated from that file. This avoids a rare bug where the ctags information is incorrectly shown for a different symbol because of this offset where an invalid file has ctags information that shouldn't be there. When clicking on the results, it takes us to the correct location in the codebase.

<img width="608" alt="Screen Shot 2019-09-10 at 5 06 34 PM" src="https://user-images.githubusercontent.com/3507526/64834879-b03c5500-d598-11e9-9267-cb8baddb5e44.png">
vs
<img width="559" alt="Screen Shot 2019-09-10 at 5 07 59 PM" src="https://user-images.githubusercontent.com/3507526/64834898-c21df800-d598-11e9-91c0-259f41c37221.png">