### PR TITLE
ctags: discard ultra long ctags line instead of failing to index entirely

### DIFF
--- a/ctags/json.go
+++ b/ctags/json.go
@@ -66,6 +66,9 @@ func newProcess(bin string) (*ctagsProcess, error) {
 		out:     bufio.NewScanner(out),
 		outPipe: out,
 	}
+	initialBuffer := make([]byte, bufio.MaxScanTokenSize)
+	maxBufferSize := 1 * 1024 * 1024 // 1 MiB
+	proc.out.Buffer(initialBuffer, maxBufferSize)
 
 	if err := cmd.Start(); err != nil {
 		return nil, err
@@ -96,6 +99,12 @@ func (p *ctagsProcess) read(rep *reply) error {
 	}
 	if debug {
 		log.Printf("read %s", p.out.Text())
+	}
+
+	if l := len(p.out.Bytes()); l > bufio.MaxScanTokenSize {
+		log.Printf("warning: discarding ctags line which exceed bufio.MaxScanTokenSize with length=%d", l)
+		log.Printf("line: %q", p.out.Text())
+		return nil
 	}
 
 	// See https://github.com/universal-ctags/ctags/issues/1493


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#5587

In particular, this fixes indexing repositories with ultra long symbols like this: https://sourcegraph.com/github.com/corretto/corretto-8@f83f2350525ae18bc34487c1c6eddf6cd343b02d/-/blob/src/langtools/test/tools/javac/limits/LongName.java#L38

There is follow-up work needed to upstream this change into Zoekt which I will leave up to @keegancsmith and @kzh - this change just definitively and quickly resolves the issue since it is semi-critical.

### How I confirmed this fixes the issue:

I cross compiled the binary for Alpine Linux, copied it into an existing `zoekt-indexserver` container, and ran the problematic command mentioned in https://github.com/sourcegraph/sourcegraph/issues/5587#issuecomment-531600379 by running the following script:

```sh
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o zoekt-archive-index ./cmd/zoekt-archive-index/
docker create --name=zoekt-indexserver-test -it sourcegraph/zoekt-indexserver:0.0.20190913055037-b3e888a zoekt-archive-index -parallelism=4 -index /tmp/zoekt-index -file_limit 1048576 -incremental -branch HEAD -commit 3edc870d4f7e46056d20af8d99e388494df74178 -name github.com/corretto/corretto-8 -require_ctags https://github.com/corretto/corretto-8/tarball/3edc870d4f7e46056d20af8d99e388494df74178
docker cp ./zoekt-archive-index zoekt-indexserver-test:/usr/local/bin/zoekt-archive-index
docker start zoekt-indexserver-test
docker logs -f zoekt-indexserver-test && docker rm -f zoekt-indexserver-test
```

Output before:

```
2019/09/15 21:35:39 builder.go:542: finished /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00000.zoekt: 294914658 index bytes (overhead 2.8)
2019/09/15 21:35:43 builder.go:542: finished /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00001.zoekt: 286913355 index bytes (overhead 2.8)
2019/09/15 21:35:50 builder.go:542: finished /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00002.zoekt: 279052872 index bytes (overhead 2.7)
2019/09/15 21:35:50 builder.go:305: Builder.Finish /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00000.zoekt226585431
2019/09/15 21:35:50 builder.go:305: Builder.Finish /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00001.zoekt704809162
2019/09/15 21:35:50 builder.go:305: Builder.Finish /tmp/zoekt-index/github.com%2Fcorretto%2Fcorretto-8_v16.00002.zoekt706913185
2019/09/15 21:35:50 main.go:235: bufio.Scanner: token too long
zoekt-indexserver-test
```

Output after: https://gist.github.com/slimsag/d2678c13b8cbc35bfcf7808915fc560e