### PR TITLE
Throttle archive downloads to 1 Gbps max to avoid DoS'ing networks

### DIFF
--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -58,12 +58,13 @@ func isGitOID(s string) bool {
 type Options struct {
 	Incremental bool
 
-	Archive string
-	Name    string
-	RepoURL string
-	Branch  string
-	Commit  string
-	Strip   int
+	Archive           string
+	DownloadLimitMbps int64
+	Name              string
+	RepoURL           string
+	Branch            string
+	Commit            string
+	Strip             int
 }
 
 func (o *Options) SetDefaults() {
@@ -150,7 +151,7 @@ func do(opts Options, bopts build.Options) error {
 		}
 	}
 
-	a, err := openArchive(opts.Archive)
+	a, err := openArchive(opts.Archive, opts.DownloadLimitMbps)
 	if err != nil {
 		return err
 	}
@@ -202,11 +203,12 @@ func main() {
 	var (
 		incremental = flag.Bool("incremental", true, "only index changed repositories")
 
-		name   = flag.String("name", "", "The repository name for the archive")
-		urlRaw = flag.String("url", "", "The repository URL for the archive")
-		branch = flag.String("branch", "", "The branch name for the archive")
-		commit = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
-		strip  = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+		name              = flag.String("name", "", "The repository name for the archive")
+		urlRaw            = flag.String("url", "", "The repository URL for the archive")
+		branch            = flag.String("branch", "", "The branch name for the archive")
+		commit            = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
+		strip             = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+		downloadLimitMbps = flag.Int64("download-limit-mbps", 0, "If non-zero, limit archive downloads to specified amount in megabits per second")
 	)
 	flag.Parse()
 
@@ -223,12 +225,13 @@ func main() {
 	opts := Options{
 		Incremental: *incremental,
 
-		Archive: archive,
-		Name:    *name,
-		RepoURL: *urlRaw,
-		Branch:  *branch,
-		Commit:  *commit,
-		Strip:   *strip,
+		Archive:           archive,
+		DownloadLimitMbps: *downloadLimitMbps,
+		Name:              *name,
+		RepoURL:           *urlRaw,
+		Branch:            *branch,
+		Commit:            *commit,
+		Strip:             *strip,
 	}
 
 	if err := do(opts, *bopts); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/keegancsmith/rpc v1.1.0
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/prometheus/client_golang v1.1.0
 	github.com/xanzy/go-gitlab v0.13.0
 	go.uber.org/automaxprocs v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/pelletier/go-buffruneio v0.2.0 h1:U4t4R6YkofJ5xHm3dJzuRpPZ0mr5MMCoAWooScCR7aA=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
Fixes sourcegraph/sourcegraph#5686

Please see [the inline code comment](https://github.com/sourcegraph/zoekt/compare/master...sourcegraph:sg/throttling?expand=1#diff-93aae9eb97f3bf8173e933ea0200072eR245-R257) for explanation of why we must do this.