### PR TITLE
indexserver: Wait for frontend to start

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
+	"io"
 	"io/ioutil"
 	"log"
 	"math"
@@ -95,6 +96,8 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) error {
 
 // Run the sync loop. This blocks forever.
 func (s *Server) Run() {
+	waitForFrontend(s.Root)
+
 	queue := &Queue{}
 
 	// Start a goroutine which updates the queue with commits to index.
@@ -406,6 +409,54 @@ func resolveRevision(root *url.URL, repo, spec string) (string, error) {
 		return "", err
 	}
 	return b.String(), nil
+}
+
+func ping(root *url.URL) error {
+	u := root.ResolveReference(&url.URL{Path: "/.internal/ping"})
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ping: bad HTTP response status %d", resp.StatusCode)
+	}
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+	if err != nil {
+		return err
+	}
+	if want := []byte("pong"); !bytes.Equal(body, want) {
+		const max = 15
+		if len(body) > max {
+			body = body[:max]
+		}
+		return fmt.Errorf("ping: bad HTTP response body %q (want %q)", string(body), string(want))
+	}
+	return nil
+}
+
+func waitForFrontend(root *url.URL) {
+	warned := false
+	lastWarn := time.Now()
+	for {
+		err := ping(root)
+		if err == nil {
+			break
+		}
+
+		if time.Since(lastWarn) > 15*time.Second {
+			warned = true
+			lastWarn = time.Now()
+			log.Printf("frontend API not reachable, will try again: %s", err)
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if warned {
+		log.Println("frontend API is now reachable. Starting indexing...")
+	}
 }
 
 func tarballURL(root *url.URL, repo, commit string) string {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -422,15 +422,11 @@ func ping(root *url.URL) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("ping: bad HTTP response status %d", resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 16))
 	if err != nil {
 		return err
 	}
 	if want := []byte("pong"); !bytes.Equal(body, want) {
-		const max = 15
-		if len(body) > max {
-			body = body[:max]
-		}
 		return fmt.Errorf("ping: bad HTTP response body %q (want %q)", string(body), string(want))
 	}
 	return nil

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetIndexOptions(t *testing.T) {
@@ -82,5 +85,48 @@ func TestListRepos(t *testing.T) {
 	}
 	if want := "/.internal/repos/list"; gotURL.Path != want {
 		t.Fatalf("unexpected request path. got %q, want %q", gotURL.Path, want)
+	}
+}
+
+func TestPing(t *testing.T) {
+	var response []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.internal/ping" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write(response)
+	}))
+	defer server.Close()
+
+	root, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ping fails
+	response = []byte("hello")
+	err = ping(root)
+	if got, want := fmt.Sprintf("%v", err), "bad HTTP response body"; !strings.Contains(got, want) {
+		t.Errorf("wanted ping to fail,\ngot:  %q\nwant: %q", got, want)
+	}
+
+	response = []byte("pong")
+	err = ping(root)
+	if err != nil {
+		t.Errorf("wanted ping to succeed, got: %v", err)
+	}
+
+	// We expect waitForFrontend to just work now
+	done := make(chan struct{})
+	go func() {
+		waitForFrontend(root)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("waitForFrontend blocking")
 	}
 }


### PR DESCRIPTION
This should stop the logspam we see when indexserver starts up faster than the
frontend pod.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3371