### PR TITLE
Handle offset error in symbol search for older indexes

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -199,6 +199,8 @@ type symbolSubstrMatchTree struct {
 
 	doc      uint32
 	sections []DocumentSection
+
+	secID uint32
 }
 
 func (t *symbolSubstrMatchTree) prepare(doc uint32) {
@@ -212,10 +214,24 @@ func (t *symbolSubstrMatchTree) prepare(doc uint32) {
 
 	var sections []DocumentSection
 	if len(t.sections) > 0 {
-		sections = t.sections[t.fileEndSymbol[doc]:t.fileEndSymbol[doc+1]]
-	}
-	secIdx := 0
+		most := t.fileEndSymbol[len(t.fileEndSymbol)-1]
+		if most == uint32(len(t.sections)) {
+			sections = t.sections[t.fileEndSymbol[doc]:t.fileEndSymbol[doc+1]]
+		} else {
+			for t.secID < uint32(len(t.sections)) && t.sections[t.secID].Start < fileStart {
+				t.secID++
+			}
 
+			fileEnd, symbolEnd := t.fileEndRunes[doc], t.secID
+			for symbolEnd < uint32(len(t.sections)) && t.sections[symbolEnd].Start < fileEnd {
+				symbolEnd++
+			}
+
+			sections = t.sections[t.secID:symbolEnd]
+		}
+	}
+
+	secIdx := 0
 	trimmed := t.current[:0]
 	for len(sections) > secIdx && len(t.current) > 0 {
 		start := fileStart + t.current[0].runeOffset


### PR DESCRIPTION
In 3.7.2 indexes, there is a bug where extra symbols from skipped files are accounted for in fileEndSymbols. This was fixed in #27.

```
2019/10/18 05:19:45 crashed shard: shard(/data/index/gitolite.sgdev.org%2F13k%2Fhackmdio%2Fcodimd_v16.00000.zoekt): runtime error: slice bounds out of range [:4110] with capacity 4098, goroutine 920142 [running]:
runtime/debug.Stack(0xc837c0e7e0, 0xceb568a0a0, 0x4f)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
github.com/google/zoekt/shards.searchOneShard.func1(0xa69240, 0xc837c0e7e0, 0xc837c0df80)
        /go/src/github.com/google/zoekt/shards/shards.go:265 +0x9c
panic(0x9623c0, 0xcb7fde8500)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/google/zoekt.(*symbolSubstrMatchTree).prepare(0xc7783fe1e0, 0xc500000019)
        /go/src/github.com/google/zoekt/matchtree.go:215 +0x36a
github.com/google/zoekt.(*indexData).Search(0xcd684a0d80, 0xa68d40, 0xc837dbc000, 0xa5de40, 0xc837c102c0, 0xcdbb3959c0, 0x0, 0x0, 0x0)
        /go/src/github.com/google/zoekt/eval.go:165 +0x72c
github.com/google/zoekt/shards.searchOneShard(0xa68d40, 0xc837dbc000, 0xa69240, 0xc837c0e7e0, 0xa5de40, 0xc837c102c0, 0xcdbb3959c0, 0xc837c0df80)
        /go/src/github.com/google/zoekt/shards/shards.go:273 +0xe1
github.com/google/zoekt/shards.(*shardedSearcher).Search.func2(0xc837dbc060, 0xc837c10330, 0xc837c10310, 0xcdbb3959c0, 0xc837c0df80)
        /go/src/github.com/google/zoekt/shards/shards.go:207 +0x8e
created by github.com/google/zoekt/shards.(*shardedSearcher).Search
        /go/src/github.com/google/zoekt/shards/shards.go:205 +0x6a5
```

However, the current symbol search approach does not take this into consideration. This causes the above crash message. In order to support v3.7.2 indexes, we now resort to this method of manually iterating through to find file symbol start and end indices instead of relying on fileEndSymbols (since it can be faulty).