### PR TITLE
Special case symbol search regex .*

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -148,6 +148,7 @@ type branchQueryMatchTree struct {
 type symbolRegexpMatchTree struct {
 	matchTree
 	regexp *regexp.Regexp
+	all    bool // skips regex match if .*
 
 	reEvaluated bool
 	found       []*candidateMatch
@@ -171,9 +172,14 @@ func (t *symbolRegexpMatchTree) matches(cp *contentProvider, cost int, known map
 
 	found := t.found[:0]
 	for i, sec := range sections {
-		idx := t.regexp.FindIndex(content[sec.Start:sec.End])
-		if idx == nil {
-			continue
+		var idx []int
+		if t.all {
+			idx = []int{0, int(sec.End - sec.Start)}
+		} else {
+			idx = t.regexp.FindIndex(content[sec.Start:sec.End])
+			if idx == nil {
+				continue
+			}
 		}
 
 		cm := &candidateMatch{
@@ -779,6 +785,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 
 		return &symbolRegexpMatchTree{
 			regexp:    regexp,
+			all:       regexp.String() == "(?i)(?-s:.)*", // .*
 			matchTree: subMT,
 		}, nil
 	}

--- a/matchtree.go
+++ b/matchtree.go
@@ -785,7 +785,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 
 		return &symbolRegexpMatchTree{
 			regexp:    regexp,
-			all:       regexp.String() == "(?i)(?-s:.)*", // .*
+			all:       regexp.String() == "(?i)(?-s:.)*",
 			matchTree: subMT,
 		}, nil
 	}

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -17,6 +17,8 @@ package zoekt
 import (
 	"reflect"
 	"testing"
+
+	"github.com/google/zoekt/query"
 )
 
 func Test_breakOnNewlines(t *testing.T) {
@@ -150,5 +152,41 @@ func Test_breakOnNewlines(t *testing.T) {
 				t.Errorf("breakMatchOnNewlines() = %+v, want %+v", got2, want2)
 			}
 		})
+	}
+}
+
+func TestSymbolMatchRegexAll(t *testing.T) {
+	tests := []struct {
+		query string
+		all   bool
+	}{
+		{query: ".*", all: true},
+		{query: "(a|b)", all: false},
+		{query: "b.r", all: false},
+	}
+
+	for _, tt := range tests {
+		q, err := query.Parse("sym:" + tt.query)
+		if err != nil {
+			t.Errorf("Error parsing query: %s", "sym:"+tt.query)
+			continue
+		}
+
+		d := &indexData{}
+		mt, err := d.newMatchTree(q)
+		if err != nil {
+			t.Errorf("Error creating match tree from query: %s", q)
+			continue
+		}
+
+		regexMT, ok := mt.(*symbolRegexpMatchTree)
+		if !ok {
+			t.Errorf("Expected symbol regex match tree from query: %s, got %v", q, mt)
+			continue
+		}
+
+		if regexMT.all != tt.all {
+			t.Errorf("Expected property all: %t from query: %s", tt.all, q)
+		}
 	}
 }


### PR DESCRIPTION
This PR handles a special case for the symbol search regex pattern `.*`. It avoids running the expensive operation of regex matches when all symbols are desired. This is a small optimization that will slightly improve symbol sidebar performance.

Testing on the linux kernel and golang repositories yielded a ~400ms (2.2s -> 1.8s) performance improvement. This is from running the query `sym:.*` that enumerates all symbols.

The existing test `TestSymbolRegexpAll` in `index_test.go` covers this. 