### PR TITLE
zoekt-archive-index: Enforce flowrate on the socket

### DIFF
--- a/cmd/zoekt-archive-index/flowrate.go
+++ b/cmd/zoekt-archive-index/flowrate.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/mxk/go-flowrate/flowrate"
+)
+
+type connReadWriter struct {
+	net.Conn
+
+	Reader io.Reader
+	Writer io.Writer
+}
+
+func (c *connReadWriter) Read(b []byte) (int, error) {
+	return c.Reader.Read(b)
+}
+
+func (c *connReadWriter) Write(b []byte) (int, error) {
+	return c.Writer.Write(b)
+}
+
+type dial func(ctx context.Context, network, addr string) (net.Conn, error)
+
+func limitDial(d dial, limit int64) dial {
+	if limit <= 0 {
+		return d
+	}
+
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := d(ctx, network, addr)
+		if err != nil {
+			return nil, err
+		}
+		return &connReadWriter{
+			Conn:   conn,
+			Reader: flowrate.NewReader(conn, limit),
+			Writer: flowrate.NewWriter(conn, limit),
+		}, nil
+	}
+}
+
+func limitHTTPDefaultClient(limitMbps int64) {
+	if limitMbps <= 0 {
+		return
+	}
+
+	const megabit = 1000 * 1000
+	limit := (limitMbps * megabit) / 8
+
+	t := http.DefaultTransport.(*http.Transport)
+	t.DialContext = limitDial(t.DialContext, limit)
+}

--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -58,13 +58,12 @@ func isGitOID(s string) bool {
 type Options struct {
 	Incremental bool
 
-	Archive           string
-	DownloadLimitMbps int64
-	Name              string
-	RepoURL           string
-	Branch            string
-	Commit            string
-	Strip             int
+	Archive string
+	Name    string
+	RepoURL string
+	Branch  string
+	Commit  string
+	Strip   int
 }
 
 func (o *Options) SetDefaults() {
@@ -151,7 +150,7 @@ func do(opts Options, bopts build.Options) error {
 		}
 	}
 
-	a, err := openArchive(opts.Archive, opts.DownloadLimitMbps)
+	a, err := openArchive(opts.Archive)
 	if err != nil {
 		return err
 	}
@@ -203,11 +202,12 @@ func main() {
 	var (
 		incremental = flag.Bool("incremental", true, "only index changed repositories")
 
-		name              = flag.String("name", "", "The repository name for the archive")
-		urlRaw            = flag.String("url", "", "The repository URL for the archive")
-		branch            = flag.String("branch", "", "The branch name for the archive")
-		commit            = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
-		strip             = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+		name   = flag.String("name", "", "The repository name for the archive")
+		urlRaw = flag.String("url", "", "The repository URL for the archive")
+		branch = flag.String("branch", "", "The branch name for the archive")
+		commit = flag.String("commit", "", "The commit sha for the archive. If incremental this will avoid updating shards already at commit")
+		strip  = flag.Int("strip_components", 0, "Remove the specified number of leading path elements. Pathnames with fewer elements will be silently skipped.")
+
 		downloadLimitMbps = flag.Int64("download-limit-mbps", 0, "If non-zero, limit archive downloads to specified amount in megabits per second")
 	)
 	flag.Parse()
@@ -225,14 +225,16 @@ func main() {
 	opts := Options{
 		Incremental: *incremental,
 
-		Archive:           archive,
-		DownloadLimitMbps: *downloadLimitMbps,
-		Name:              *name,
-		RepoURL:           *urlRaw,
-		Branch:            *branch,
-		Commit:            *commit,
-		Strip:             *strip,
+		Archive: archive,
+		Name:    *name,
+		RepoURL: *urlRaw,
+		Branch:  *branch,
+		Commit:  *commit,
+		Strip:   *strip,
 	}
+
+	// Sourcegraph specific: Limit HTTP traffic
+	limitHTTPDefaultClient(*downloadLimitMbps)
 
 	if err := do(opts, *bopts); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
flowrate is a Sourcegraph specific feature to limit the amount of traffic we
generate on the networks. The way it is implemented is it keeps conflicting
with upstream zoekt merges. This rewrites it so we instead enforce it in the
DefaultTransport. This should more reliably enforce flowrate as well as
prevent difficult merge conflicts.