### PR TITLE
add DISABLE_MMAP flag which allows for disabling usage of mmap on Linux

### DIFF
--- a/indexfile_nolinux.go
+++ b/indexfile_nolinux.go
@@ -12,42 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !linux
+
 package zoekt
 
 import (
-	"fmt"
 	"os"
 )
 
-type indexFileFromOS struct {
-	f *os.File
-}
-
-func (f *indexFileFromOS) Read(off, sz uint32) ([]byte, error) {
-	r := make([]byte, sz)
-	_, err := f.f.ReadAt(r, int64(off))
-	return r, err
-}
-
-func (f indexFileFromOS) Size() (uint32, error) {
-	fi, err := f.f.Stat()
-	if err != nil {
-		return 0, err
-	}
-
-	sz := fi.Size()
-
-	if sz >= maxUInt32 {
-		return 0, fmt.Errorf("overflow")
-	}
-
-	return uint32(sz), nil
-}
-
-func (f indexFileFromOS) Close() {
-	f.f.Close()
-}
-
-func (f indexFileFromOS) Name() string {
-	return f.f.Name()
+// NewIndexFile returns a new index file. The index file takes
+// ownership of the passed in file, and may close it.
+func NewIndexFile(f *os.File) (IndexFile, error) {
+	return &indexFileFromOS{f}, nil
 }


### PR DESCRIPTION
This allows disabling the usage of mmap on Linux. In some deployments of Zoekt
we have seen this mmap usage lead to large variance in the response time of
Zoekt after specific indexes are not used for a few minutes and get paged out
of the OS page cache. e.g. the page cache gets invalidated, someone runs a
search query that relies on the mmap'd index, and the OS then must load a
substantial amount of data from disk resulting in a response time of e.g. 10s
instead of the regular 0.15s.

Using `DISABLE_MMAP=true` works around this problem by ensuring the index
files are always loaded into memory. Another option considered would've
been to use `madvise`, but this seemed more complex to figure out the exact
semantics of (after all, it is just advise for the kernel and not guaranteed)
especially in the context of zoekt running in e.g. Alpine linux with an arbitrary
host linux kernel.

The default is `DISABLE_MMAP=false`.

Helps https://github.com/sourcegraph/customer/issues/37