### PR TITLE
indexdata: optionally store any section in memory

### DIFF
--- a/inmemory.go
+++ b/inmemory.go
@@ -1,0 +1,171 @@
+package zoekt
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+)
+
+// This file contains a Sourcegraph specific extension which allows loading
+// parts of a shard into memory. This is to experiment with avoiding the OS
+// page cache misses and drops.
+
+func sourcegraphInMemoryContent(toc *indexTOC, file IndexFile) (IndexFile, error) {
+	if len(inMemoryContentFields) == 0 {
+		return file, nil
+	}
+
+	return newCachedIndexFile(toc, inMemoryContentFields, file)
+}
+
+var inMemoryContentFields []string
+
+func init() {
+	var logs []string
+	inMemoryContentFields, logs = parseInMemoryContentVar(os.Getenv("IN_MEMORY_CONTENT"))
+	for _, l := range logs {
+		log.Println(l)
+	}
+}
+
+func parseInMemoryContentVar(s string) (fields, logs []string) {
+	if s == "" {
+		return nil, nil
+	}
+
+	valid := allSimpleSections(&indexTOC{})
+	var invalid []string
+	for _, field := range strings.Split(s, ",") {
+		if _, ok := valid[field]; ok {
+			fields = append(fields, field)
+		} else {
+			invalid = append(invalid, field)
+		}
+	}
+
+	var validSlice []string
+	for field := range valid {
+		validSlice = append(validSlice, field)
+	}
+	sort.Strings(validSlice)
+
+	logs = []string{
+		fmt.Sprintf("INFO: IN_MEMORY_CONTENT environment variable enabled for %s.", strings.Join(fields, ",")),
+		`INFO: IN_MEMORY_CONTENT will pin parts of the search database into memory to avoid paging out to disk in case of an OS page cache miss (at increased memory cost).`,
+		`INFO: IN_MEMORY_CONTENT some fields are always pinned in, notably "filecontents" and "postings" are not.`,
+		`INFO: IN_MEMORY_CONTENT is a "," joined list of fields.`,
+		fmt.Sprintf("INFO: IN_MEMORY_CONTENT valid fields are %s.", strings.Join(validSlice, ",")),
+	}
+
+	if len(invalid) > 0 {
+		logs = append(logs, fmt.Sprintf("WARN: IN_MEMORY_CONTENT ignoring invalid fields: %s.", strings.Join(invalid, ",")))
+	}
+
+	return fields, logs
+}
+
+func allSimpleSections(t *indexTOC) map[string]simpleSection {
+	return map[string]simpleSection{
+		"filecontents":     t.fileContents.data,
+		"filenames":        t.fileNames.data,
+		"filesections":     t.fileSections.data,
+		"postings":         t.postings.data,
+		"newlines":         t.newlines.data,
+		"ngramtext":        t.ngramText,
+		"runeoffsets":      t.runeOffsets,
+		"fileendrunes":     t.fileEndRunes,
+		"languages":        t.languages,
+		"fileendsymbol":    t.fileEndSymbol,
+		"symbolmap":        t.symbolMap.data,
+		"symbolkindmap":    t.symbolKindMap.data,
+		"symbolmetadata":   t.symbolMetaData,
+		"branchmasks":      t.branchMasks,
+		"subrepos":         t.subRepos,
+		"namengramtext":    t.nameNgramText,
+		"namepostings":     t.namePostings.data,
+		"nameruneoffsets":  t.nameRuneOffsets,
+		"metadata":         t.metaData,
+		"repometadata":     t.repoMetaData,
+		"nameendrunes":     t.nameEndRunes,
+		"contentchecksums": t.contentChecksums,
+		"runedocsections":  t.runeDocSections,
+	}
+}
+
+func newCachedIndexFile(toc *indexTOC, fields []string, file IndexFile) (IndexFile, error) {
+	sections := allSimpleSections(toc)
+	c := &cachedIndexFile{file: file}
+	for _, field := range fields {
+		section := sections[field]
+		if err := c.cache(section); err != nil {
+			return nil, fmt.Errorf("failed to load section %s=%v for %s: %w", field, section, file.Name(), err)
+		}
+		log.Printf("DBUG: %s: pinned into memory section %s (%2.fMB)", file.Name(), field, float64(section.sz)/1024/1024)
+	}
+	return c, nil
+}
+
+type cachedBlock struct {
+	off  uint32
+	data []byte
+}
+
+type cachedIndexFile struct {
+	file   IndexFile
+	blocks []cachedBlock
+}
+
+func (c *cachedIndexFile) cache(ss simpleSection) error {
+	b, err := c.file.Read(ss.off, ss.sz)
+	if err != nil {
+		return err
+	}
+
+	// copy to ensure in memory (likely pointing into mmap region)
+	data := make([]byte, ss.sz)
+	copy(data, b)
+
+	c.blocks = append(c.blocks, cachedBlock{
+		off:  ss.off,
+		data: data,
+	})
+	return nil
+}
+
+func (c *cachedIndexFile) Read(off uint32, sz uint32) ([]byte, error) {
+	for _, block := range c.blocks {
+		if off < block.off {
+			continue
+		}
+		relOff := off - block.off
+		relEnd := relOff + sz
+		if relEnd <= uint32(len(block.data)) {
+			return block.data[relOff:relEnd], nil
+		}
+	}
+	return c.file.Read(off, sz)
+}
+func (c *cachedIndexFile) Size() (uint32, error) {
+	return c.file.Size()
+}
+func (c *cachedIndexFile) Close() {
+	c.blocks = nil
+	c.file.Close()
+}
+
+func (c *cachedIndexFile) Name() string {
+	var b strings.Builder
+	b.WriteString("Cached{")
+	b.WriteString(c.file.Name())
+	b.WriteString(", Blocks: ")
+	for i, block := range c.blocks {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		_, _ = fmt.Fprintf(&b, "{%d %d}", block.off, len(block.data))
+	}
+	b.WriteString("}")
+	return b.String()
+}

--- a/read.go
+++ b/read.go
@@ -18,7 +18,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // IndexFile is a file suitable for concurrent read access. For performance
@@ -365,6 +369,19 @@ func (d *indexData) readDocSections(i uint32, buf []DocumentSection) ([]Document
 	return unmarshalDocSections(blob, buf), sec.sz, nil
 }
 
+// Sourcegraph Experiment: Read content into memory and do not rely on
+// MMAP. We have seen unexpected behaviour of the OS file cache which we
+// haven't been able to narrow down. As such we want a toggle to just keep
+// everything in memory. This will use a lot more memory.
+var sourcegraphInMemoryContent bool
+
+func init() {
+	sourcegraphInMemoryContent, _ = strconv.ParseBool(os.Getenv("IN_MEMORY_CONTENT"))
+	if sourcegraphInMemoryContent {
+		log.Println("INFO: IN_MEMORY_CONTENT=true, this will load all file contents into memory to avoid paging out to disk in case of cache misses (at increased memory cost).")
+	}
+}
+
 // NewSearcher creates a Searcher for a single index file.  Search
 // results coming from this searcher are valid only for the lifetime
 // of the Searcher itself, ie. []byte members should be copied into
@@ -380,6 +397,15 @@ func NewSearcher(r IndexFile) (Searcher, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if sourcegraphInMemoryContent {
+		cached := &cachedIndexFile{file: r}
+		if err := cached.cache(toc.fileContents.data); err != nil {
+			return nil, err
+		}
+		r = cached
+	}
+
 	indexData.file = r
 	return indexData, nil
 }
@@ -404,4 +430,68 @@ func ReadMetadata(inf IndexFile) (*Repository, *IndexMetadata, error) {
 	}
 
 	return &repo, &md, nil
+}
+
+// Sourcegraph experiment follows which caches blocks
+type cachedBlock struct {
+	off  uint32
+	data []byte
+}
+
+type cachedIndexFile struct {
+	file   IndexFile
+	blocks []cachedBlock
+}
+
+func (c *cachedIndexFile) cache(ss simpleSection) error {
+	b, err := c.file.Read(ss.off, ss.sz)
+	if err != nil {
+		return err
+	}
+
+	// copy to ensure in memory (likely pointing into mmap region)
+	data := make([]byte, ss.sz)
+	copy(data, b)
+
+	c.blocks = append(c.blocks, cachedBlock{
+		off:  ss.off,
+		data: data,
+	})
+	return nil
+}
+
+func (c *cachedIndexFile) Read(off uint32, sz uint32) ([]byte, error) {
+	for _, block := range c.blocks {
+		if off < block.off {
+			continue
+		}
+		relOff := off - block.off
+		relEnd := relOff + sz
+		if relEnd <= uint32(len(block.data)) {
+			return block.data[relOff:relEnd], nil
+		}
+	}
+	return c.file.Read(off, sz)
+}
+func (c *cachedIndexFile) Size() (uint32, error) {
+	return c.file.Size()
+}
+func (c *cachedIndexFile) Close() {
+	c.blocks = nil
+	c.file.Close()
+}
+
+func (c *cachedIndexFile) Name() string {
+	var b strings.Builder
+	b.WriteString("Cached{")
+	b.WriteString(c.file.Name())
+	b.WriteString(", Blocks: ")
+	for i, block := range c.blocks {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		_, _ = fmt.Fprintf(&b, "{%d %d}", block.off, len(block.data))
+	}
+	b.WriteString("}")
+	return b.String()
 }


### PR DESCRIPTION
We have recently been seeing poor behaviour around the page cache and MMAP in
production. We haven't tracked down why yet, but this adds a workaround for
installations which have enough RAM. Instead of relying on page cache, we copy
in content. We do this by wrapping IndexFile with cachedIndexFile.

cachedIndexFile has a list of cached blocks. If a read call falls within a
cached block, the overlapping part of the block is returned.

This is opt-in behaviour. You opt-in by setting the environment variable
`IN_MEMORY_CONTENT`. Tested by adding some debug logs and running tests with and
without the envvar set.

```shellsession
$ IN_MEMORY_CONTENT=filecontents,postings go run ./cmd/zoekt-webserver
2020/03/18 11:57:33 INFO: IN_MEMORY_CONTENT environment variable enabled for filecontents,postings.
2020/03/18 11:57:33 INFO: IN_MEMORY_CONTENT will pin parts of the search database into memory to avoid paging out to disk in case of an OS page cache miss (at increased memory cost).
2020/03/18 11:57:33 INFO: IN_MEMORY_CONTENT some fields are always pinned in, notably "filecontents" and "postings" are not.
2020/03/18 11:57:33 INFO: IN_MEMORY_CONTENT is a "," joined list of fields.
2020/03/18 11:57:33 INFO: IN_MEMORY_CONTENT valid fields are branchmasks,contentchecksums,filecontents,fileendrunes,fileendsymbol,filenames,filesections,languages,metadata,nameendrunes,namengramtext,namepostings,nameruneoffsets,newlines,ngramtext,postings,repometadata,runedocsections,runeoffsets,subrepos,symbolkindmap,symbolmap,symbolmetadata.
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/github.com%2Fgoogle%2Fzoekt_v15.00000.zoekt: pinned into memory section filecontents: 0.3MB
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/github.com%2Fgoogle%2Fzoekt_v15.00000.zoekt: pinned into memory section postings: 0.5MB
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/build_v16.00000.zoekt: pinned into memory section filecontents: 2.8MB
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/tools_v16.00000.zoekt: pinned into memory section filecontents: 5.6MB
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/build_v16.00000.zoekt: pinned into memory section postings: 5.0MB
2020/03/18 12:02:54 DBUG: /Users/keegan/.zoekt/tools_v16.00000.zoekt: pinned into memory section postings: 9.8MB
2020/03/18 12:02:55 DBUG: /Users/keegan/.zoekt/go_v16.00000.zoekt: pinned into memory section filecontents: 70.3MB
2020/03/18 12:02:55 DBUG: /Users/keegan/.zoekt/go_v16.00000.zoekt: pinned into memory section postings: 113.2MB
2020/03/18 11:57:33 listening on :6070
```

Part of https://github.com/sourcegraph/sourcegraph/issues/9001