### PR TITLE
indexdata: optionally store file content in memory + disable mmap

### DIFF
--- a/read.go
+++ b/read.go
@@ -18,7 +18,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // IndexFile is a file suitable for concurrent read access. For performance
@@ -365,6 +369,19 @@ func (d *indexData) readDocSections(i uint32, buf []DocumentSection) ([]Document
 	return unmarshalDocSections(blob, buf), sec.sz, nil
 }
 
+// Sourcegraph Experiment: Read content into memory and do not rely on
+// MMAP. We have seen unexpected behaviour of the OS file cache which we
+// haven't been able to narrow down. As such we want a toggle to just keep
+// everything in memory. This will use a lot more memory.
+var sourcegraphInMemoryContent bool
+
+func init() {
+	sourcegraphInMemoryContent, _ = strconv.ParseBool(os.Getenv("IN_MEMORY_CONTENT"))
+	if sourcegraphInMemoryContent {
+		log.Println("INFO: IN_MEMORY_CONTENT=true, this will load all file contents into memory to avoid paging out to disk in case of cache misses (at increased memory cost).")
+	}
+}
+
 // NewSearcher creates a Searcher for a single index file.  Search
 // results coming from this searcher are valid only for the lifetime
 // of the Searcher itself, ie. []byte members should be copied into
@@ -380,6 +397,15 @@ func NewSearcher(r IndexFile) (Searcher, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if sourcegraphInMemoryContent {
+		cached := &cachedIndexFile{file: r}
+		if err := cached.cache(toc.fileContents.data); err != nil {
+			return nil, err
+		}
+		r = cached
+	}
+
 	indexData.file = r
 	return indexData, nil
 }
@@ -404,4 +430,68 @@ func ReadMetadata(inf IndexFile) (*Repository, *IndexMetadata, error) {
 	}
 
 	return &repo, &md, nil
+}
+
+// Sourcegraph experiment follows which caches blocks
+type cachedBlock struct {
+	off  uint32
+	data []byte
+}
+
+type cachedIndexFile struct {
+	file   IndexFile
+	blocks []cachedBlock
+}
+
+func (c *cachedIndexFile) cache(ss simpleSection) error {
+	b, err := c.file.Read(ss.off, ss.sz)
+	if err != nil {
+		return err
+	}
+
+	// copy to ensure in memory (likely pointing into mmap region)
+	data := make([]byte, ss.sz)
+	copy(data, b)
+
+	c.blocks = append(c.blocks, cachedBlock{
+		off:  ss.off,
+		data: data,
+	})
+	return nil
+}
+
+func (c *cachedIndexFile) Read(off uint32, sz uint32) ([]byte, error) {
+	for _, block := range c.blocks {
+		if off < block.off {
+			continue
+		}
+		relOff := off - block.off
+		relEnd := relOff + sz
+		if relEnd <= uint32(len(block.data)) {
+			return block.data[relOff:relEnd], nil
+		}
+	}
+	return c.file.Read(off, sz)
+}
+func (c *cachedIndexFile) Size() (uint32, error) {
+	return c.file.Size()
+}
+func (c *cachedIndexFile) Close() {
+	c.blocks = nil
+	c.file.Close()
+}
+
+func (c *cachedIndexFile) Name() string {
+	var b strings.Builder
+	b.WriteString("Cached{")
+	b.WriteString(c.file.Name())
+	b.WriteString(", Blocks: ")
+	for i, block := range c.blocks {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		_, _ = fmt.Fprintf(&b, "{%d %d}", block.off, len(block.data))
+	}
+	b.WriteString("}")
+	return b.String()
 }


### PR DESCRIPTION
@keegancsmith I made this as an experiment for what the reported overhead in memory with the underlying mmap usage. I also did the testing more empirically, eliminating other variables (like system restart) and making sure to execute the same exact search queries prior to measuring.

| Branch | rss | max_usage_bytes | working_set_bytes |
|--------|-----------------------|-----------------------------------|---------|
| sg/keep-content-in-memory | 79 GiB | 79 GiB  | 74 GiB |
| core/keep-content-in-memory | 79 GiB | 79 GiB | 78 GiB |
| 3.13.2 | 50 GiB | 50 GiB | 30 GiB |

Conclusions:

- Indeed, the mmap usage makes no substantial difference.
- The memory usage increase is 36.7%, working set increase (which is what Kubernetes monitors) is ~61.5%. Not as bad as previously thought, but perhaps not great still either.