### PR TITLE
Improve performance for concatened queries

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -652,7 +652,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 	}
 	switch s := q.(type) {
 	case *query.Regexp:
-		subQ := query.RegexpToQuery(s.Regexp, ngramSize)
+		subQ, isSym := query.RegexpToQuery(s.Regexp, ngramSize)
 		subQ = query.Map(subQ, func(q query.Q) query.Q {
 			if sub, ok := q.(*query.Substring); ok {
 				sub.FileName = s.FileName
@@ -664,6 +664,12 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 		subMT, err := d.newMatchTree(subQ)
 		if err != nil {
 			return nil, err
+		}
+
+		// if the query can be used in place of the regexp
+		// return the subtree
+		if isSym {
+			return subMT, nil
 		}
 
 		prefix := ""

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -198,9 +198,10 @@ func TestSymetricQuerySkipRegexpTree(t *testing.T) {
 	}{
 		{query: "^foo", skip: false},
 		{query: "foo", skip: true},
-		{query: "thread|needle|hack", skip: true},
-		{query: "thread(needle|hack)", skip: true},
-		{query: "thread(needle|)", skip: false},
+		{query: "thread|needle|haystack", skip: true},
+		{query: "contain(er|ing)", skip: false},
+		{query: "thread (needle|haystack)", skip: true},
+		{query: "thread (needle|)", skip: false},
 	}
 
 	for _, tt := range tests {

--- a/query/regexp.go
+++ b/query/regexp.go
@@ -45,13 +45,16 @@ func LowerRegexp(r *syntax.Regexp) *syntax.Regexp {
 
 // RegexpToQuery tries to distill a substring search query that
 // matches a superset of the regexp.
-func RegexpToQuery(r *syntax.Regexp, minTextSize int) Q {
-	q := regexpToQueryRecursive(r, minTextSize)
+// If the returned query is symetric with the original regexp,
+// it returns true. A symetric query has the same behaviour as the original
+// regexp and can be used instead.
+func RegexpToQuery(r *syntax.Regexp, minTextSize int) (query Q, isSymetric bool) {
+	q, isSym := regexpToQueryRecursive(r, minTextSize)
 	q = Simplify(q)
-	return q
+	return q, isSym
 }
 
-func regexpToQueryRecursive(r *syntax.Regexp, minTextSize int) Q {
+func regexpToQueryRecursive(r *syntax.Regexp, minTextSize int) (query Q, symetric bool) {
 	// TODO - we could perhaps transform Begin/EndText in '\n'?
 	// TODO - we could perhaps transform CharClass in (OrQuery )
 	// if there are just a few runes, and part of a OpConcat?
@@ -59,7 +62,7 @@ func regexpToQueryRecursive(r *syntax.Regexp, minTextSize int) Q {
 	case syntax.OpLiteral:
 		s := string(r.Rune)
 		if len(s) >= minTextSize {
-			return &Substring{Pattern: s}
+			return &Substring{Pattern: s}, true
 		}
 	case syntax.OpCapture:
 		return regexpToQueryRecursive(r.Sub[0], minTextSize)
@@ -74,15 +77,19 @@ func regexpToQueryRecursive(r *syntax.Regexp, minTextSize int) Q {
 
 	case syntax.OpConcat, syntax.OpAlternate:
 		var qs []Q
+		isSym := true
 		for _, sr := range r.Sub {
-			if sq := regexpToQueryRecursive(sr, minTextSize); sq != nil {
+			if sq, sm := regexpToQueryRecursive(sr, minTextSize); sq != nil {
+				if !sm {
+					isSym = false
+				}
 				qs = append(qs, sq)
 			}
 		}
 		if r.Op == syntax.OpConcat {
-			return &And{qs}
+			return &And{qs}, isSym
 		}
-		return &Or{qs}
+		return &Or{qs}, isSym
 	}
-	return &Const{true}
+	return &Const{true}, false
 }

--- a/query/regexp.go
+++ b/query/regexp.go
@@ -87,6 +87,9 @@ func regexpToQueryRecursive(r *syntax.Regexp, minTextSize int) (query Q, symetri
 			}
 		}
 		if r.Op == syntax.OpConcat {
+			if len(qs) > 1 {
+				isSym = false
+			}
 			return &And{qs}, isSym
 		}
 		return &Or{qs}, isSym

--- a/query/regexp_test.go
+++ b/query/regexp_test.go
@@ -75,18 +75,12 @@ func TestRegexpParse(t *testing.T) {
 			}}, false},
 		{"foo", &Substring{Pattern: "foo"}, true},
 		{"^foo", &Substring{Pattern: "foo"}, false},
-		{"(thread|needle|hack)", &Or{[]Q{
+		{"(foo) (bar)", &And{[]Q{&Substring{Pattern: "foo"}, &Substring{Pattern: "bar"}}}, false},
+		{"(thread|needle|haystack)", &Or{[]Q{
 			&Substring{Pattern: "thread"},
 			&Substring{Pattern: "needle"},
-			&Substring{Pattern: "hack"},
+			&Substring{Pattern: "haystack"},
 		}}, true},
-		{"thread(needle|hack)", &And{[]Q{
-			&Substring{Pattern: "thread"},
-			&Or{[]Q{
-				&Substring{Pattern: "needle"},
-				&Substring{Pattern: "hack"},
-			}}}},
-			true},
 	}
 
 	for _, c := range cases {

--- a/query/regexp_test.go
+++ b/query/regexp_test.go
@@ -52,13 +52,14 @@ func printRegexp(t *testing.T, r *syntax.Regexp, lvl int) {
 
 func TestRegexpParse(t *testing.T) {
 	type testcase struct {
-		in   string
-		want Q
+		in         string
+		query      Q
+		isSymetric bool
 	}
 
 	cases := []testcase{
-		{"(foo|)bar", &Substring{Pattern: "bar"}},
-		{"(foo|)", &Const{true}},
+		{"(foo|)bar", &Substring{Pattern: "bar"}, false},
+		{"(foo|)", &Const{true}, false},
 		{"(foo|bar)baz.*bla", &And{[]Q{
 			&Or{[]Q{
 				&Substring{Pattern: "foo"},
@@ -66,12 +67,26 @@ func TestRegexpParse(t *testing.T) {
 			}},
 			&Substring{Pattern: "baz"},
 			&Substring{Pattern: "bla"},
-		}}},
+		}}, false},
 		{"^[a-z](People)+barrabas$",
 			&And{[]Q{
 				&Substring{Pattern: "People"},
 				&Substring{Pattern: "barrabas"},
-			}}},
+			}}, false},
+		{"foo", &Substring{Pattern: "foo"}, true},
+		{"^foo", &Substring{Pattern: "foo"}, false},
+		{"(thread|needle|hack)", &Or{[]Q{
+			&Substring{Pattern: "thread"},
+			&Substring{Pattern: "needle"},
+			&Substring{Pattern: "hack"},
+		}}, true},
+		{"thread(needle|hack)", &And{[]Q{
+			&Substring{Pattern: "thread"},
+			&Or{[]Q{
+				&Substring{Pattern: "needle"},
+				&Substring{Pattern: "hack"},
+			}}}},
+			true},
 	}
 
 	for _, c := range cases {
@@ -81,10 +96,14 @@ func TestRegexpParse(t *testing.T) {
 			continue
 		}
 
-		got := RegexpToQuery(r, 3)
-		if !reflect.DeepEqual(c.want, got) {
+		query, isSym := RegexpToQuery(r, 3)
+		if !reflect.DeepEqual(c.query, query) {
 			printRegexp(t, r, 0)
-			t.Errorf("regexpToQuery(%q): got %v, want %v", c.in, got, c.want)
+			t.Errorf("regexpToQuery(%q): got %v, want %v", c.in, query, c.query)
+		}
+		if isSym != c.isSymetric {
+			printRegexp(t, r, 0)
+			t.Errorf("regexpToQuery(%q): got %v, want %v", c.in, isSym, c.isSymetric)
 		}
 	}
 }


### PR DESCRIPTION
This PR modifies the behaviour of the `regexpToQuery` method to make it return whether the generated query is *symetric*, meaning that it has the exact same behaviour as the original regexp.
When that happens, the `matchTree` method skips creating a `regexpMatchTree` node, which prevents running the regex engine.

This is not the most elegant solution, but it seems to be working.

I also added a feature flag: By default the improvement is disabled. To enable it, we must prefix any query will `exp:enable-fast-regexp`.

This fixes https://github.com/sourcegraph/sourcegraph/issues/8800