### PR TITLE
Index large files

### DIFF
--- a/cmd/zoekt-archive-index/main.go
+++ b/cmd/zoekt-archive-index/main.go
@@ -163,11 +163,6 @@ func do(opts Options, bopts build.Options) error {
 	add := func(f *File) error {
 		defer f.Close()
 
-		// We do not index large files
-		if f.Size > int64(bopts.SizeMax) && !bopts.IgnoreSizeMax(f.Name) {
-			return nil
-		}
-
 		contents, err := ioutil.ReadAll(f)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR fixes https://github.com/sourcegraph/sourcegraph/issues/10382 by removing a condition that prevents the indexation of large files.