### PR TITLE
Get branches configuration and index them using gitIndex

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
@@ -197,12 +198,17 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 		args = append(args, "-incremental")
 	}
 
+	var branches []string
 	if o.Branch != "" {
-		args = append(args, "-branches", o.Branch)
+		branches = append(branches, o.Branch)
 	}
 
 	for _, branch := range o.Branches {
-		args = append(args, "-branches", branch.Name)
+		branches = append(branches, branch.Name)
+	}
+
+	if len(branches) > 0 {
+		args = append(args, "-branches", strings.Join(branches, ","))
 	}
 
 	args = append(args, o.BuildOptions().Args()...)

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -178,7 +178,7 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 			if branch.Name == "HEAD" {
 				continue
 			}
-			gitArgs = append(gitArgs, fmt.Sprintf("+${%s}:refs/heads/%s", branch.Version, branch.Name))
+			gitArgs = append(gitArgs, fmt.Sprintf("+%s:refs/heads/%s", branch.Version, branch.Name))
 		}
 		cmd = exec.Command("git", gitArgs...)
 		cmd.Stdin = &bytes.Buffer{}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -171,15 +171,16 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 		return err
 	}
 
-	// we assume the first branch is always HEAD
-	if len(o.Branches) > 1 {
-		gitArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--no-tags", cloneURL}
-		for _, branch := range o.Branches {
-			if branch.Name == "HEAD" {
-				continue
-			}
-			gitArgs = append(gitArgs, fmt.Sprintf("+%s:refs/heads/%s", branch.Version, branch.Name))
+	gitArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--no-tags", cloneURL}
+	headOnly := true
+	for _, branch := range o.Branches {
+		if branch.Name == "HEAD" {
+			continue
 		}
+		headOnly = false
+		gitArgs = append(gitArgs, fmt.Sprintf("+%s:refs/heads/%s", branch.Version, branch.Name))
+	}
+	if !headOnly {
 		cmd = exec.Command("git", gitArgs...)
 		cmd.Stdin = &bytes.Buffer{}
 		if err := runCmd(cmd); err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -65,7 +65,7 @@ type indexArgs struct {
 // BuildOptions returns a build.Options represented by indexArgs. Note: it
 // doesn't set fields like repository/branch.
 func (o *indexArgs) BuildOptions() *build.Options {
-	return &build.Options{
+	opts := build.Options{
 		// It is important that this RepositoryDescription exactly matches
 		// what the indexer we call will produce. This is to ensure that
 		// IncrementalSkipIndexing returns true if nothing needs to be done.
@@ -83,6 +83,9 @@ func (o *indexArgs) BuildOptions() *build.Options {
 		CTagsMustSucceed: o.Symbols,
 		DisableCTags:     !o.Symbols,
 	}
+
+	opts.RepositoryDescription.Branches = append(opts.RepositoryDescription.Branches, o.Branches...)
+	return &opts
 }
 
 func (o *indexArgs) String() string {

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -171,6 +171,22 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 		return err
 	}
 
+	// we assume the first branch is always HEAD
+	if len(o.Branches) > 1 {
+		gitArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--no-tags", cloneURL}
+		for _, branch := range o.Branches {
+			if branch.Name == "HEAD" {
+				continue
+			}
+			gitArgs = append(gitArgs, fmt.Sprintf("+${%s}:refs/heads/%s", branch.Version, branch.Name))
+		}
+		cmd = exec.Command("git", gitArgs...)
+		cmd.Stdin = &bytes.Buffer{}
+		if err := runCmd(cmd); err != nil {
+			return err
+		}
+	}
+
 	args := []string{
 		"-submodules=false",
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -110,9 +110,8 @@ func TestIndex(t *testing.T) {
 			IndexDir:    "/data/index",
 			Parallelism: 4,
 			FileLimit:   123,
-			Branch:      "HEAD",
 			Branches: []zoekt.RepositoryBranch{
-				{Name: "foo", Version: "abcd"}, {Name: "bar", Version: "efgh"},
+				{Name: "HEAD"}, {Name: "foo", Version: "abcd"}, {Name: "bar", Version: "efgh"},
 			},
 			DownloadLimitMBPS: "1000",
 			LargeFiles:        []string{"foo", "bar"},

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -135,7 +135,7 @@ func TestIndex(t *testing.T) {
 		wantGit: []string{
 			"git -c protocol.version=2 clone --depth=1 --bare http://api.test/.internal/git/test/repo $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
-			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --no-tags http://api.test/.internal/git/test/repo +${abcd}:refs/heads/foo +${efgh}:refs/heads/bar",
+			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --no-tags http://api.test/.internal/git/test/repo +abcd:refs/heads/foo +efgh:refs/heads/bar",
 			"zoekt-git-index -submodules=false -incremental -branches HEAD,foo,bar " +
 				"-file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
 				"$TMPDIR/test%2Frepo.git",

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -135,6 +135,7 @@ func TestIndex(t *testing.T) {
 		wantGit: []string{
 			"git -c protocol.version=2 clone --depth=1 --bare http://api.test/.internal/git/test/repo $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
+			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --no-tags http://api.test/.internal/git/test/repo +${abcd}:refs/heads/foo +${efgh}:refs/heads/bar",
 			"zoekt-git-index -submodules=false -incremental -branches HEAD,foo,bar " +
 				"-file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
 				"$TMPDIR/test%2Frepo.git",

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -136,7 +136,7 @@ func TestIndex(t *testing.T) {
 		wantGit: []string{
 			"git -c protocol.version=2 clone --depth=1 --bare http://api.test/.internal/git/test/repo $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
-			"zoekt-git-index -submodules=false -incremental -branches HEAD -branches foo -branches bar " +
+			"zoekt-git-index -submodules=false -incremental -branches HEAD,foo,bar " +
 				"-file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
 				"$TMPDIR/test%2Frepo.git",
 		},

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -243,6 +243,9 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 	runCmd := func(cmd *exec.Cmd) error { return s.loggedRun(tr, cmd) }
 	f := s.Indexer
+	if len(args.Branches) > 0 {
+		f = gitIndex
+	}
 	if f == nil {
 		f = archiveIndex
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/net/trace"
 
+	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/keegancsmith/tmpfriend"
@@ -259,7 +260,7 @@ func (s *Server) defaultArgs() *indexArgs {
 		Parallelism: s.CPUCount,
 
 		Incremental: true,
-		Branch:      "HEAD",
+		Branches:    []zoekt.RepositoryBranch{{Name: "HEAD"}},
 
 		// 1 MB; match https://sourcegraph.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/cmd/symbols/internal/symbols/search.go#L22
 		FileLimit: 1 << 20,

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
 )
 
 func TestServer_defaultArgs(t *testing.T) {
@@ -23,7 +24,7 @@ func TestServer_defaultArgs(t *testing.T) {
 		IndexDir:          "/testdata/index",
 		Parallelism:       6,
 		Incremental:       true,
-		Branch:            "HEAD",
+		Branches:          []zoekt.RepositoryBranch{{Name: "HEAD"}},
 		FileLimit:         1 << 20,
 		DownloadLimitMBPS: "1000",
 	}


### PR DESCRIPTION
This PR lets zoekt-sourcegraph-indexserver get the branches configuration from Sourcegraph's `/.internal/search/configuration` and, if there are any specified, will use the experimental `gitIndex` to index them.