### PR TITLE
monitoring: run debug server and expose more metrics

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -20,9 +20,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/zoekt/debugserver"
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/net/trace"
 
@@ -31,7 +33,6 @@ import (
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -52,6 +53,26 @@ var (
 		Help:    "A histogram of latencies for indexing a repository.",
 		Buckets: prometheus.ExponentialBuckets(.1, 10, 7), // 100ms -> 27min
 	}, []string{"state"}) // state is an indexState
+
+	metricQueueLen = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "index_queue_len",
+		Help: "Current length of indexing queue by code host",
+	}, []string{"codehost"})
+
+	metricNumIndexed = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "index_num_indexed",
+		Help: "Number of indexed repos by code host",
+	}, []string{"codehost"})
+
+	metricFailedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "index_failed_total",
+		Help: "Counts failures to index",
+	})
+
+	metricIndexedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "index_indexed_total",
+		Help: "Counts indexings",
+	})
 )
 
 type indexState string
@@ -121,6 +142,15 @@ func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) error {
 	return nil
 }
 
+func codeHostFromName(repoName string) string {
+	parts := strings.Split(repoName, "/")
+	codehost := "unknown"
+	if len(parts) > 1 {
+		codehost = parts[0]
+	}
+	return codehost
+}
+
 // Run the sync loop. This blocks forever.
 func (s *Server) Run() {
 	removeIncompleteShards(s.IndexDir)
@@ -172,7 +202,10 @@ func (s *Server) Run() {
 						return
 					}
 					metricResolveRevisionDuration.WithLabelValues("true").Observe(time.Since(start).Seconds())
-					queue.AddOrUpdate(name, commit)
+					added := queue.AddOrUpdate(name, commit)
+					if added {
+						metricQueueLen.WithLabelValues(codeHostFromName(name)).Add(1.0)
+					}
 				}(name)
 			}
 			sem.Wait()
@@ -190,7 +223,7 @@ func (s *Server) Run() {
 			time.Sleep(time.Second)
 			continue
 		}
-
+		metricQueueLen.WithLabelValues(codeHostFromName(name)).Add(-1.0)
 		start := time.Now()
 		args := s.defaultArgs()
 		args.Name = name
@@ -213,10 +246,12 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	tr := trace.New("index", args.Name)
 
 	defer func() {
+		metricIndexedTotal.Inc()
 		if err != nil {
 			tr.SetError()
 			tr.LazyPrintf("error: %v", err)
 			state = indexStateFail
+			metricFailedTotal.Inc()
 		}
 		tr.LazyPrintf("state: %s", state)
 		tr.Finish()
@@ -345,10 +380,16 @@ func (s *Server) forceIndex(name string) (string, error) {
 func listIndexed(indexDir string) []string {
 	index := getShards(indexDir)
 	repoNames := make([]string, 0, len(index))
+	countsByHost := make(map[string]int)
 	for name := range index {
 		repoNames = append(repoNames, name)
+		codeHost := codeHostFromName(name)
+		countsByHost[codeHost] += 1
 	}
 	sort.Strings(repoNames)
+	for codeHost, count := range countsByHost {
+		metricNumIndexed.WithLabelValues(codeHost).Set(float64(count))
+	}
 	return repoNames
 }
 
@@ -577,22 +618,11 @@ func main() {
 
 	if *listen != "" {
 		go func() {
-			trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
-				return true, true
-			}
-			prom := promhttp.Handler()
-			h := func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/debug/requests":
-					trace.Traces(w, r)
-				case "/metrics":
-					prom.ServeHTTP(w, r)
-				default:
-					s.ServeHTTP(w, r)
-				}
-			}
+			pp := http.NewServeMux()
+			debugserver.AddHandlers(pp, true)
+			pp.Handle("/", s)
 			debug.Printf("serving HTTP on %s", *listen)
-			log.Fatal(http.ListenAndServe(*listen, http.HandlerFunc(h)))
+			log.Fatal(http.ListenAndServe(*listen, pp))
 		}()
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -618,11 +618,11 @@ func main() {
 
 	if *listen != "" {
 		go func() {
-			pp := http.NewServeMux()
-			debugserver.AddHandlers(pp, true)
-			pp.Handle("/", s)
+			mux := http.NewServeMux()
+			debugserver.AddHandlers(mux, true)
+			mux.Handle("/", s)
 			debug.Printf("serving HTTP on %s", *listen)
-			log.Fatal(http.ListenAndServe(*listen, pp))
+			log.Fatal(http.ListenAndServe(*listen, mux))
 		}()
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -62,11 +62,13 @@ func (q *Queue) Len() int {
 
 // AddOrUpdate sets which commit to index next for repoName. If repoName is
 // already in the queue, it is updated.
-func (q *Queue) AddOrUpdate(repoName, commit string) {
+func (q *Queue) AddOrUpdate(repoName, commit string) bool {
+	added := false
 	q.mu.Lock()
 	item := q.get(repoName)
 	item.latestCommit = commit
 	if item.heapIdx < 0 {
+		added = true
 		q.seq++
 		item.seq = q.seq
 		heap.Push(&q.pq, item)
@@ -74,6 +76,7 @@ func (q *Queue) AddOrUpdate(repoName, commit string) {
 		heap.Fix(&q.pq, item.heapIdx)
 	}
 	q.mu.Unlock()
+	return added
 }
 
 // SetIndexed sets what the currently indexed commit is for repoName.

--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -1,0 +1,44 @@
+package debugserver
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/net/trace"
+)
+
+func AddHandlers(pp *http.ServeMux, enablePprof bool) {
+	trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
+		return true, true
+	}
+
+	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`
+				<a href="vars">Vars</a><br>
+				<a href="debug/pprof/">PProf</a><br>
+				<a href="metrics">Metrics</a><br>
+				<a href="debug/requests">Requests</a><br>
+				<a href="debug/events">Events</a><br>
+			`))
+		_, _ = w.Write([]byte(`
+				<br>
+				<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>
+				<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
+			`))
+	})
+	pp.Handle("/debug", index)
+	pp.Handle("/vars", http.HandlerFunc(expvarHandler))
+	pp.Handle("/gc", http.HandlerFunc(gcHandler))
+	pp.Handle("/freeosmemory", http.HandlerFunc(freeOSMemoryHandler))
+	if enablePprof {
+		pp.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		pp.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		pp.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		pp.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	}
+	pp.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
+	pp.Handle("/debug/events", http.HandlerFunc(trace.Events))
+	pp.Handle("/metrics", promhttp.Handler())
+}

--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/net/trace"
 )
 
-func AddHandlers(pp *http.ServeMux, enablePprof bool) {
+func AddHandlers(mux *http.ServeMux, enablePprof bool) {
 	trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
 		return true, true
 	}
@@ -27,18 +27,18 @@ func AddHandlers(pp *http.ServeMux, enablePprof bool) {
 				<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
 			`))
 	})
-	pp.Handle("/debug", index)
-	pp.Handle("/vars", http.HandlerFunc(expvarHandler))
-	pp.Handle("/gc", http.HandlerFunc(gcHandler))
-	pp.Handle("/freeosmemory", http.HandlerFunc(freeOSMemoryHandler))
+	mux.Handle("/debug", index)
+	mux.Handle("/vars", http.HandlerFunc(expvarHandler))
+	mux.Handle("/gc", http.HandlerFunc(gcHandler))
+	mux.Handle("/freeosmemory", http.HandlerFunc(freeOSMemoryHandler))
 	if enablePprof {
-		pp.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
-		pp.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-		pp.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-		pp.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-		pp.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+		mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+		mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+		mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+		mux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+		mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	}
-	pp.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
-	pp.Handle("/debug/events", http.HandlerFunc(trace.Events))
-	pp.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/debug/requests", http.HandlerFunc(trace.Traces))
+	mux.Handle("/debug/events", http.HandlerFunc(trace.Events))
+	mux.Handle("/metrics", promhttp.Handler())
 }

--- a/debugserver/expvar.go
+++ b/debugserver/expvar.go
@@ -1,0 +1,48 @@
+package debugserver
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+	"runtime"
+	"runtime/debug"
+	"time"
+)
+
+// expvarHandler is copied from package expvar and exported so that it
+// can be mounted on any ServeMux, not just http.DefaultServeMux.
+func expvarHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintln(w, "{")
+	first := true
+	expvar.Do(func(kv expvar.KeyValue) {
+		if !first {
+			fmt.Fprintln(w, ",")
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	fmt.Fprintln(w, "\n}")
+}
+
+func gcHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "only POST is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	t0 := time.Now()
+	runtime.GC()
+	fmt.Fprintf(w, "GC took %s\n", time.Since(t0))
+}
+
+func freeOSMemoryHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "only POST is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	t0 := time.Now()
+	debug.FreeOSMemory()
+	fmt.Fprintf(w, "FreeOSMemory took %s\n", time.Since(t0))
+}


### PR DESCRIPTION
now that we have reverse-proxy in  instrumentation  to reach both webserver and indexserver, we can run the debug page

also prometheus scrapes both so we can add more metrics

https://github.com/sourcegraph/deploy-sourcegraph/pull/735