### PR TITLE
query: binary encoder for repo branches

### DIFF
--- a/query/marshal.go
+++ b/query/marshal.go
@@ -72,6 +72,9 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 		if l := len(branches); l == 1 && branches[0] == "HEAD" {
 			continue
 		} else if l > 255 {
+			// We encode branches len as a byte (saves 11% cpu vs varint). This is
+			// fine sinze Zoekt can only index upto 64 branches (uses a bitmask on a
+			// 64bit int to encode branch information for a document)
 			return nil, fmt.Errorf("can't encode more than 255 branches: %d", l)
 		}
 		for _, branch := range branches {
@@ -95,7 +98,6 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 			continue
 		}
 
-		// length of branches is 64 or less
 		b.WriteByte(byte(len(branches)))
 		for _, branch := range branches {
 			str(branch)

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -34,19 +34,19 @@ import (
 // The above adds up to a huge improvement, worth the extra complexity:
 //
 // name                   old time/op    new time/op    delta
-// RepoBranches_Encode-8    2.37ms ± 3%    0.66ms ± 2%  -72.02%  (p=0.000 n=10+10)
-// RepoBranches_Decode-8    4.19ms ± 2%    0.75ms ± 2%  -82.17%  (p=0.000 n=10+10)
+// RepoBranches_Encode-8    2.37ms ± 3%    0.62ms ± 0%   -73.77%  (p=0.000 n=10+8)
+// RepoBranches_Decode-8    4.19ms ± 2%    0.74ms ± 1%   -82.37%  (p=0.000 n=10+9)
 //
 // name                   old bytes      new bytes      delta
-// RepoBranches_Encode-8     393kB ± 0%     344kB ± 0%  -12.48%  (p=0.000 n=10+10)
+// RepoBranches_Encode-8     393kB ± 0%     344kB ± 0%   -12.48%  (p=0.000 n=10+10)
 //
 // name                   old alloc/op   new alloc/op   delta
-// RepoBranches_Encode-8     726kB ± 0%     344kB ± 0%  -52.59%  (p=0.000 n=10+8)
-// RepoBranches_Decode-8    2.31MB ± 0%    1.44MB ± 0%  -37.51%  (p=0.000 n=9+10)
+// RepoBranches_Encode-8     726kB ± 0%     344kB ± 0%   -52.60%  (p=0.000 n=10+9)
+// RepoBranches_Decode-8    2.31MB ± 0%    1.44MB ± 0%   -37.51%  (p=0.000 n=9+10)
 //
 // name                   old allocs/op  new allocs/op  delta
-// RepoBranches_Encode-8     20.0k ± 0%      0.0k ± 0%  -99.99%  (p=0.000 n=10+10)
-// RepoBranches_Decode-8     50.6k ± 0%      0.4k ± 0%  -99.26%  (p=0.000 n=10+10)
+// RepoBranches_Encode-8     20.0k ± 0%      0.0k ± 0%  -100.00%  (p=0.000 n=10+10)
+// RepoBranches_Decode-8     50.6k ± 0%      0.4k ± 0%   -99.26%  (p=0.000 n=10+10)
 
 // repoBranchesEncode implements an efficient encoder for RepoBranches.
 func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -1,0 +1,177 @@
+package query
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+)
+
+// We implement a custom binary marshaller for a list of repos to
+// branches. When profiling Sourcegraph this is one of the dominant items.
+//
+// Wire-format of map[string][]string is pretty straightforward:
+//
+// byte(1) version
+// uvarint(len(map))
+// for k, vs in map:
+//   str(k)
+//   uvarint(len(vs))
+//   for v in vs:
+//     str(v)
+//
+//  where str(v) is uvarint(len(v)) bytes(v)
+//
+// The above format gives about the same size encoding as gob does. However,
+// gob doesn't have a specialization for map[string][]string so we get to
+// avoid a lot of intermediate allocations.
+//
+// The only other specialization we add is treating []string{"HEAD"} as if it
+// was []string{}. This is the most common value for branches so avoids the
+// need to write it on the wire. This makes us beat gob for encoded size.
+//
+// The above adds up to a huge improvement, worth the extra complexity:
+//
+// name                   old time/op    new time/op    delta
+// RepoBranches_Encode-8    2.21ms ± 3%    0.63ms ± 5%  -71.55%  (p=0.000 n=10+10)
+// RepoBranches_Decode-8    4.08ms ± 5%    1.20ms ± 1%  -70.58%  (p=0.000 n=10+10)
+//
+// name                   old bytes      new bytes      delta
+// RepoBranches_Encode-8     393kB ± 0%     344kB ± 0%  -12.48%  (p=0.000 n=10+10)
+//
+// name                   old alloc/op   new alloc/op   delta
+// RepoBranches_Encode-8     726kB ± 0%     344kB ± 0%  -52.59%  (p=0.000 n=6+9)
+// RepoBranches_Decode-8    2.31MB ± 0%    1.58MB ± 0%  -31.62%  (p=0.000 n=10+10)
+//
+// name                   old allocs/op  new allocs/op  delta
+// RepoBranches_Encode-8     20.0k ± 0%      0.0k ± 0%  -99.99%  (p=0.000 n=10+10)
+// RepoBranches_Decode-8     50.6k ± 0%     20.8k ± 0%  -58.94%  (p=0.000 n=10+10)
+
+// repoBranchesEncode implements an efficient encoder for RepoBranches.
+func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
+	var b bytes.Buffer
+	var enc [8]byte
+	varint := func(n int) {
+		m := binary.PutUvarint(enc[:], uint64(n))
+		b.Write(enc[:m])
+	}
+	str := func(s string) {
+		varint(len(s))
+		b.WriteString(s)
+	}
+	strSize := func(s string) int {
+		return binary.PutUvarint(enc[:], uint64(len(s))) + len(s)
+	}
+
+	// Version
+	b.WriteByte(1)
+
+	// Length
+	varint(len(repoBranches))
+
+	// Calculate size
+	size := 0
+	for name, branches := range repoBranches {
+		size += strSize(name) + 1
+		if l := len(branches); l == 1 && branches[0] == "HEAD" {
+			continue
+		} else if l > 255 {
+			return nil, fmt.Errorf("can't encode more than 255 branches: %d", l)
+		}
+		for _, branch := range branches {
+			size += strSize(branch)
+		}
+	}
+	b.Grow(size)
+
+	for name, branches := range repoBranches {
+		str(name)
+
+		// Special case "HEAD"
+		if len(branches) == 1 && branches[0] == "HEAD" {
+			b.WriteByte(0)
+			continue
+		}
+
+		// length of branches is 64 or less
+		b.WriteByte(byte(len(branches)))
+		for _, branch := range branches {
+			str(branch)
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+// repoBranchesDecode implements an efficient decoder for RepoBranches.
+func repoBranchesDecode(b []byte) (map[string][]string, error) {
+	r := binaryReader{b: b}
+
+	// Version
+	if v := r.byt(); v != 1 {
+		return nil, fmt.Errorf("unsupported RepoBranches encoding version %d", v)
+	}
+
+	// Length
+	l := r.uvarint()
+	repoBranches := make(map[string][]string, l)
+
+	for i := 0; i < l; i++ {
+		name := r.str()
+
+		branchesLen := int(r.byt())
+
+		// Special case "HEAD"
+		if branchesLen == 0 {
+			repoBranches[name] = []string{"HEAD"}
+			continue
+		}
+
+		branches := make([]string, branchesLen)
+		for j := 0; j < branchesLen; j++ {
+			branches[j] = r.str()
+		}
+		repoBranches[name] = branches
+	}
+
+	return repoBranches, r.err
+}
+
+type binaryReader struct {
+	b   []byte
+	err error
+}
+
+func (b *binaryReader) uvarint() int {
+	x, n := binary.Uvarint(b.b)
+	if n < 0 {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return 0
+	}
+	b.b = b.b[n:]
+	return int(x)
+}
+
+func (b *binaryReader) str() string {
+	l := b.uvarint()
+	if l > len(b.b) {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return ""
+	}
+	s := string(b.b[:l])
+	b.b = b.b[l:]
+	return s
+}
+
+func (b *binaryReader) byt() byte {
+	if len(b.b) < 1 {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return 0
+	}
+	x := b.b[0]
+	b.b = b.b[1:]
+	return x
+}

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -51,7 +51,7 @@ import (
 // repoBranchesEncode implements an efficient encoder for RepoBranches.
 func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 	var b bytes.Buffer
-	var enc [8]byte
+	var enc [binary.MaxVarintLen64]byte
 	varint := func(n int) {
 		m := binary.PutUvarint(enc[:], uint64(n))
 		b.Write(enc[:m])

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -64,14 +64,9 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 		return binary.PutUvarint(enc[:], uint64(len(s))) + len(s)
 	}
 
-	// Version
-	b.WriteByte(1)
-
-	// Length
-	varint(len(repoBranches))
-
 	// Calculate size
-	size := 0
+	size := 1 // version
+	size += binary.PutUvarint(enc[:], uint64(len(repoBranches)))
 	for name, branches := range repoBranches {
 		size += strSize(name) + 1
 		if l := len(branches); l == 1 && branches[0] == "HEAD" {
@@ -84,6 +79,12 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 		}
 	}
 	b.Grow(size)
+
+	// Version
+	b.WriteByte(1)
+
+	// Length
+	varint(len(repoBranches))
 
 	for name, branches := range repoBranches {
 		str(name)

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -71,6 +71,9 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 		size += strSize(name) + 1
 		if l := len(branches); l == 1 && branches[0] == "HEAD" {
 			continue
+		} else if l == 0 {
+			// We reserve "0" for the "HEAD" special case.
+			return nil, fmt.Errorf("repo with no branches: %q", name)
 		} else if l > 255 {
 			// We encode branches len as a byte (saves 11% cpu vs varint). This is
 			// fine sinze Zoekt can only index upto 64 branches (uses a bitmask on a

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -94,8 +94,7 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 
 		// Special case "HEAD"
 		if len(branches) == 1 && branches[0] == "HEAD" {
-			b.WriteByte(0)
-			continue
+			branches = nil
 		}
 
 		b.WriteByte(byte(len(branches)))

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -103,6 +103,11 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+// head is the most common slice of branches we search. We re-use it to avoid
+// allocations when decoding. We know that zoekt never mutates the
+// repoBranches slice, so it is safe to share this slice.
+var head = []string{"HEAD"}
+
 // repoBranchesDecode implements an efficient decoder for RepoBranches.
 func repoBranchesDecode(b []byte) (map[string][]string, error) {
 	r := binaryReader{b: b}
@@ -123,7 +128,7 @@ func repoBranchesDecode(b []byte) (map[string][]string, error) {
 
 		// Special case "HEAD"
 		if branchesLen == 0 {
-			repoBranches[name] = []string{"HEAD"}
+			repoBranches[name] = head
 			continue
 		}
 

--- a/query/marshal_test.go
+++ b/query/marshal_test.go
@@ -1,0 +1,106 @@
+package query
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// We benchmark via Gob since that allows us to compare to no custom
+// marshalling.
+
+func BenchmarkRepoBranches_Encode(b *testing.B) {
+	repoBranches := genRepoBranches()
+
+	// do one write to amortize away the cost of gob registration
+	w := &countWriter{}
+	enc := gob.NewEncoder(w)
+	if err := enc.Encode(repoBranches); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.ReportMetric(float64(w.n), "bytes")
+
+	for n := 0; n < b.N; n++ {
+		if err := enc.Encode(repoBranches); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRepoBranches_Decode(b *testing.B) {
+	repoBranches := genRepoBranches()
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(repoBranches); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		// We need to include gob.NewDecoder cost to avoid measuring encoding.
+		var repoBranches RepoBranches
+		if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&repoBranches); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestRepoBranches_Marshal(t *testing.T) {
+	want := genRepoBranches()
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(want); err != nil {
+		t.Fatal(err)
+	}
+
+	var got RepoBranches
+	if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, &got); diff != "" {
+		t.Fatalf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func genRepoBranches() *RepoBranches {
+	genName := func(n int) string {
+		bs := make([]byte, 8)
+		binary.LittleEndian.PutUint64(bs, uint64(n))
+		return fmt.Sprintf("%x", sha256.Sum256(bs))[:10]
+	}
+
+	repoBranches := &RepoBranches{Set: map[string][]string{}}
+	for i := 0; i < 100; i++ {
+		org := genName(i)
+		for j := 0; j < 100; j++ {
+			name := "github.com/" + org + "/" + genName(i*2+j)
+			repoBranches.Set[name] = []string{"HEAD"}
+			if j%50 == 0 {
+				repoBranches.Set[name] = append(repoBranches.Set[name], "more", "branches")
+			}
+		}
+	}
+
+	return repoBranches
+}
+
+type countWriter struct {
+	n int
+}
+
+func (w *countWriter) Write(b []byte) (int, error) {
+	w.n += len(b)
+	return len(b), nil
+}

--- a/query/query.go
+++ b/query/query.go
@@ -151,6 +151,18 @@ func (q *RepoBranches) String() string {
 	return fmt.Sprintf("(reposet %s)", detail)
 }
 
+// GobEncode implements a specialized encoder for RepoBranches.
+func (q *RepoBranches) MarshalBinary() ([]byte, error) {
+	return repoBranchesEncode(q.Set)
+}
+
+// GobDecode implements a specialized decoder for RepoBranches.
+func (q *RepoBranches) UnmarshalBinary(b []byte) error {
+	var err error
+	q.Set, err = repoBranchesDecode(b)
+	return err
+}
+
 // RepoSet is a list of repos to match. It is a Sourcegraph addition and only
 // used in the RPC interface for efficient checking of large repo lists.
 type RepoSet struct {

--- a/query/query.go
+++ b/query/query.go
@@ -151,12 +151,12 @@ func (q *RepoBranches) String() string {
 	return fmt.Sprintf("(reposet %s)", detail)
 }
 
-// GobEncode implements a specialized encoder for RepoBranches.
+// MarshalBinary implements a specialized encoder for RepoBranches.
 func (q *RepoBranches) MarshalBinary() ([]byte, error) {
 	return repoBranchesEncode(q.Set)
 }
 
-// GobDecode implements a specialized decoder for RepoBranches.
+// UnmarshalBinary implements a specialized decoder for RepoBranches.
 func (q *RepoBranches) UnmarshalBinary(b []byte) error {
 	var err error
 	q.Set, err = repoBranchesDecode(b)


### PR DESCRIPTION
We implement a custom binary marshaller for a list of repos to
branches. When profiling Sourcegraph this is one of the dominant items
and this provides a significant improvement.

Note: This PR does not provide a way to roll this change out. I
investigated if this was possible with Gob and its pretty
difficult. This means that while Sourcegraph and Zoekt are out of sync
searches will fail. I am unsure if its worth making this smooth to
rollout.

```
name                   old time/op    new time/op    delta
RepoBranches_Encode-8    2.37ms ± 3%    0.62ms ± 0%   -73.77%  (p=0.000 n=10+8)
RepoBranches_Decode-8    4.19ms ± 2%    0.74ms ± 1%   -82.37%  (p=0.000 n=10+9)

name                   old bytes      new bytes      delta
RepoBranches_Encode-8     393kB ± 0%     344kB ± 0%   -12.48%  (p=0.000 n=10+10)

name                   old alloc/op   new alloc/op   delta
RepoBranches_Encode-8     726kB ± 0%     344kB ± 0%   -52.60%  (p=0.000 n=10+9)
RepoBranches_Decode-8    2.31MB ± 0%    1.44MB ± 0%   -37.51%  (p=0.000 n=9+10)

name                   old allocs/op  new allocs/op  delta
RepoBranches_Encode-8     20.0k ± 0%      0.0k ± 0%  -100.00%  (p=0.000 n=10+10)
RepoBranches_Decode-8     50.6k ± 0%      0.4k ± 0%   -99.26%  (p=0.000 n=10+10)
```