### PR TITLE
shards: optimize RepoBranches when all branches are the same

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -45,17 +45,7 @@ func (d *indexData) simplify(in query.Q) query.Q {
 		case *query.Repo:
 			return &query.Const{Value: strings.Contains(d.repoMetaData.Name, r.Pattern)}
 		case *query.RepoBranches:
-			branches, ok := r.Set[d.repoMetaData.Name]
-			if !ok {
-				return &query.Const{Value: false}
-			}
-
-			// New sub query is (or (branch branches[0]) ...)
-			qs := make([]query.Q, len(branches))
-			for i, branch := range branches {
-				qs[i] = &query.Branch{Pattern: branch, Exact: true}
-			}
-			return query.NewOr(qs...)
+			return r.Branches(d.repoMetaData.Name)
 		case *query.RepoSet:
 			return &query.Const{Value: r.Set[d.repoMetaData.Name]}
 		case *query.Language:

--- a/query/query.go
+++ b/query/query.go
@@ -148,7 +148,7 @@ func (q *RepoBranches) String() string {
 		sort.Strings(repos)
 		detail = strings.Join(repos, " ")
 	}
-	return fmt.Sprintf("(reposet %s)", detail)
+	return fmt.Sprintf("(repobranches %s)", detail)
 }
 
 // Branches returns a query representing the branches to search for name.

--- a/query/query.go
+++ b/query/query.go
@@ -151,6 +151,21 @@ func (q *RepoBranches) String() string {
 	return fmt.Sprintf("(reposet %s)", detail)
 }
 
+// Branches returns a query representing the branches to search for name.
+func (q *RepoBranches) Branches(name string) Q {
+	branches, ok := q.Set[name]
+	if !ok {
+		return &Const{Value: false}
+	}
+
+	// New sub query is (or (branch branches[0]) ...)
+	qs := make([]Q, len(branches))
+	for i, branch := range branches {
+		qs[i] = &Branch{Pattern: branch, Exact: true}
+	}
+	return NewOr(qs...)
+}
+
 // RepoSet is a list of repos to match. It is a Sourcegraph addition and only
 // used in the RPC interface for efficient checking of large repo lists.
 type RepoSet struct {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -238,6 +238,12 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 			continue
 		}
 
+		// setSize may be larger than the number of shards we have. The size of
+		// filtered is bounded by min(len(set), len(shards))
+		if setSize > len(shards) {
+			setSize = len(shards)
+		}
+
 		filtered := make([]rankedShard, 0, setSize)
 
 		for _, s := range shards {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -333,7 +333,9 @@ func (ss *shardedSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Se
 	start = time.Now()
 
 	shards := ss.getShards()
+	tr.LazyPrintf("before selectRepoSet shards:%d", len(shards))
 	shards, q = selectRepoSet(shards, q)
+	tr.LazyPrintf("after selectRepoSet shards:%d %s", len(shards), q)
 
 	all := make(chan shardResult, len(shards))
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -247,11 +247,8 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 		filtered := make([]rankedShard, 0, setSize)
 
 		for _, s := range shards {
-			if repositorer, ok := s.Searcher.(repositorer); ok {
-				repo := repositorer.Repository()
-				if hasRepo(repo.Name) {
-					filtered = append(filtered, s)
-				}
+			if hasRepo(s.name) {
+				filtered = append(filtered, s)
 			}
 		}
 


### PR DESCRIPTION
This is the same idea behind the optimization for reposet. We can avoid
the work of running simplify per shard if we know every shard in
filtered will be searching the same branches.

See individual commits.