### PR TITLE
index: set git-index as default

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -591,7 +591,7 @@ func main() {
 	debugList := flag.Bool("debug-list", false, "do not start the indexserver, rather list the repositories owned by this indexserver then quit.")
 	debugIndex := flag.String("debug-index", "", "do not start the indexserver, rather index the repositories then quit.")
 
-	expGitIndex := flag.Bool("exp-git-index", os.Getenv("SRC_GIT_INDEX") != "", "use experimental indexing via shallow clones and zoekt-git-index")
+	expGitIndex := flag.Bool("exp-git-index", true, "use experimental indexing via shallow clones and zoekt-git-index")
 
 	flag.Parse()
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -591,7 +591,7 @@ func main() {
 	debugList := flag.Bool("debug-list", false, "do not start the indexserver, rather list the repositories owned by this indexserver then quit.")
 	debugIndex := flag.String("debug-index", "", "do not start the indexserver, rather index the repositories then quit.")
 
-	expGitIndex := flag.Bool("exp-git-index", true, "use experimental indexing via shallow clones and zoekt-git-index")
+	expGitIndex := flag.Bool("exp-git-index", os.Getenv("DISABLE_GIT_INDEX") == "", "use experimental indexing via shallow clones and zoekt-git-index")
 
 	flag.Parse()
 


### PR DESCRIPTION
This PR sets git-index as default for all customers.

[We already use git-index as default for Sourcegraph.com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/base/indexed-search/indexed-search.StatefulSet.yaml#L54). The change was deployed 7 days ago and the memory usage by instance for Zoekt Index Server seems unchanged around the deployment ([see monitor](https://sourcegraph.com/-/debug/grafana/d/zoekt-indexserver/zoekt-index-server?viewPanel=7&orgId=1&from=1598832000000&to=1600127999000)). 

Relates to https://github.com/sourcegraph/sourcegraph/issues/6870