### PR TITLE
add query type RepoRegex

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -410,6 +410,15 @@ func (d *indexData) List(ctx context.Context, q query.Q) (rl *RepoList, err erro
 		tr.Finish()
 	}()
 
+	if c, ok := q.(*query.RepoRegex); ok {
+		pattern, err := c.Compile()
+		if err != nil {
+			return nil, err
+		}
+		matched := pattern.MatchString(d.repoListEntry.Repository.Name)
+		return d.maybeRepoList(matched), nil
+	}
+
 	q = d.simplify(q)
 	tr.LazyLog(q, true)
 	if c, ok := q.(*query.Const); ok {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -128,6 +128,7 @@ func registerGob() {
 		gob.Register(&query.Regexp{})
 		gob.Register(&query.RepoSet{})
 		gob.Register(&query.RepoBranches{})
+		gob.Register(&query.RepoRegex{})
 		gob.Register(&query.Repo{})
 		gob.Register(&query.Substring{})
 		gob.Register(&query.Symbol{})


### PR DESCRIPTION
Adds the new query type `RepoRegex` that allows us to search for repo names by regex pattern. From Sourcegraph's frontend, we can search for repositories like this
```
repoList, err := args.Zoekt.Client.List(ctx, &zoektquery.RepoRegex{Pattern: patternRe})
```