### PR TITLE
indexserver: Add an endpoint to enqueue a repo index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmd/zoekt-mirror-github/zoekt-mirror-github
 cmd/zoekt-server/zoekt-server
 cmd/zoekt-git-index/zoekt-git-index
 .envrc
+.idea

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -225,11 +225,10 @@ func codeHostFromName(repoName string) string {
 }
 
 // Run the sync loop. This blocks forever.
-func (s *Server) Run() {
+func (s *Server) Run(queue *Queue) {
 	removeIncompleteShards(s.IndexDir)
 	waitForFrontend(s.Root)
 
-	queue := &Queue{}
 
 	// Start a goroutine which updates the queue with commits to index.
 	go func() {
@@ -464,6 +463,31 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	repoTmpl.Execute(w, data)
+}
+
+func (s *Server) enqueueForIndex(queue *Queue)  func (rw http.ResponseWriter, r *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method  != "POST" {
+			http.Error(rw, "not found", http.StatusNotFound)
+			return
+		}
+		err := r.ParseForm()
+		if err != nil {
+			http.Error(rw, "error parsing form", http.StatusBadRequest)
+			return
+		}
+		name := r.Form.Get("repo")
+		if name == "" {
+			http.Error(rw, "missing repo", http.StatusBadRequest)
+			return
+		}
+		opts, err := getIndexOptions(s.Root, name)
+		if err != nil || opts[0].Error != "" {
+			http.Error(rw, "fetching index options", http.StatusInternalServerError)
+			return
+		}
+		queue.AddOrUpdate(name, opts[0].IndexOptions)
+	}
 }
 
 // forceIndex will run the index job for repo name now. It will return always
@@ -711,15 +735,18 @@ func main() {
 		os.Exit(0)
 	}
 
+	queue := &Queue{}
+
 	if *listen != "" {
 		go func() {
 			mux := http.NewServeMux()
 			debugserver.AddHandlers(mux, true)
 			mux.Handle("/", s)
+			mux.HandleFunc("/enqueueforindex", s.enqueueForIndex(queue))
 			debug.Printf("serving HTTP on %s", *listen)
 			log.Fatal(http.ListenAndServe(*listen, mux))
 		}()
 	}
 
-	s.Run()
+	s.Run(queue)
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -80,6 +80,11 @@ var (
 		Name: "index_indexing_total",
 		Help: "Counts indexings (indexing activity, should be used with rate())",
 	})
+
+	metricsEnqueueRepoForIndex = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "enqueue_repo_for_index_total",
+		Help: "Counts the number of time /enqueueforindex is called",
+	})
 )
 
 type indexState string
@@ -474,6 +479,7 @@ func (s *Server) enqueueForIndex(queue *Queue)  func (rw http.ResponseWriter, r 
 			http.Error(rw, "not found", http.StatusNotFound)
 			return
 		}
+		metricsEnqueueRepoForIndex.Inc()
 		err := r.ParseForm()
 		if err != nil {
 			http.Error(rw, "error parsing form", http.StatusBadRequest)
@@ -484,6 +490,7 @@ func (s *Server) enqueueForIndex(queue *Queue)  func (rw http.ResponseWriter, r 
 			http.Error(rw, "missing repo", http.StatusBadRequest)
 			return
 		}
+		debug.Printf("enqueueRepoForIndex called with repo: %q", name)
 		opts, err := getIndexOptions(s.Root, name)
 		if err != nil || opts[0].Error != "" {
 			http.Error(rw, "fetching index options", http.StatusInternalServerError)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -465,6 +465,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	repoTmpl.Execute(w, data)
 }
 
+// enqueueForIndex is expected to be called by other services in order to trigger an index.
+// We expect repo-updater to call this endpoint when a new repo has been added to an instance that
+// we wish to index and don't want to wait for polling to happen.
 func (s *Server) enqueueForIndex(queue *Queue)  func (rw http.ResponseWriter, r *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method  != "POST" {


### PR DESCRIPTION
We'd like to use this to trigger indexing of a new repo instead of
waiting for the index server to poll for changes.