### PR TITLE
build: enforce that repoid is up to date

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -293,7 +293,23 @@ func (o *Options) IncrementalSkipIndexing() bool {
 		return false
 	}
 
+	// Sourcegraph specific. Ensure we have the correct repository ID set.
+	if !rawConfigEqual(repo.RawConfig, o.RepositoryDescription.RawConfig, "repoid") {
+		return false
+	}
+
 	return reflect.DeepEqual(repo.Branches, o.RepositoryDescription.Branches)
+}
+
+func rawConfigEqual(m1, m2 map[string]string, key string) bool {
+	var v1, v2 string
+	if m1 != nil {
+		v1 = m1[key]
+	}
+	if m2 != nil {
+		v2 = m2[key]
+	}
+	return v1 == v2
 }
 
 // IgnoreSizeMax determines whether the max size should be ignored.


### PR DESCRIPTION
We want to enforce this in our next release of Sourcegraph to ensure all
indexes have the Sourcegraph repository ID set. In the last release we
would only have the repoid set if we re-indexed. This would only occur
if the repository was updated.

This should only be landed midway through our development cycle.
