### PR TITLE
streaming: server-side buffering

### DIFF
--- a/api.go
+++ b/api.go
@@ -160,6 +160,26 @@ func (s *Stats) Add(o Stats) {
 	s.Wait += o.Wait
 }
 
+// Zero returns true if stats is empty.
+func (s *Stats) Zero() bool {
+	if s == nil {
+		return true
+	}
+
+	return !(s.ContentBytesLoaded > 0 ||
+		s.IndexBytesLoaded > 0 ||
+		s.Crashes > 0 ||
+		s.FileCount > 0 ||
+		s.FilesConsidered > 0 ||
+		s.FilesLoaded > 0 ||
+		s.FilesSkipped > 0 ||
+		s.MatchCount > 0 ||
+		s.NgramMatches > 0 ||
+		s.ShardFilesConsidered > 0 ||
+		s.ShardsSkipped > 0 ||
+		s.Wait > 0)
+}
+
 // SearchResult contains search matches and extra data
 type SearchResult struct {
 	Stats

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -73,18 +73,46 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	// mu protects possibly concurrent writes to the stream.
+	// mu protects aggStats and concurrent writes to the stream.
 	mu := sync.Mutex{}
-
-	err = h.Searcher.StreamSearch(ctx, args.Q, args.Opts, SenderFunc(func(event *zoekt.SearchResult) {
-		mu.Lock()
-		defer mu.Unlock()
-		err := eventWriter.event(eventMatches, event)
+	var aggStats = zoekt.Stats{}
+	send := func(zsr *zoekt.SearchResult) {
+		err := eventWriter.event(eventMatches, zsr)
 		if err != nil {
 			_ = eventWriter.event(eventError, err)
 			return
 		}
+	}
+
+	err = h.Searcher.StreamSearch(ctx, args.Q, args.Opts, SenderFunc(func(event *zoekt.SearchResult) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		// We don't want to send events over the wire if they just contain stats and no
+		// file matches. Hence, in case we didn't find any results, we will just
+		// aggregate the stats.
+		if len(event.Files) == 0 {
+			aggStats.Add(event.Stats)
+			return
+		}
+
+		// If we have aggregate stats, we merge them with the new event before sending
+		// it, and reset aggStats afterwards.
+		if !aggStats.Zero() {
+			defer func() { aggStats = zoekt.Stats{} }() // reset stats
+			event.Stats.Add(aggStats)
+		}
+		send(event)
+		return
 	}))
+
+	// In case the last shard we searched didn't return matches, aggStats.Zero() = false.
+	if !aggStats.Zero() {
+		finalEvent := new(zoekt.SearchResult)
+		finalEvent.Stats = aggStats
+		send(finalEvent)
+	}
+
 	if err != nil {
 		_ = eventWriter.event(eventError, err)
 		return

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -106,11 +106,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}))
 
-	// In case the last shard we searched didn't return matches, aggStats.Zero() = false.
-	if !aggStats.Zero() {
-		finalEvent := new(zoekt.SearchResult)
-		finalEvent.Stats = aggStats
-		send(finalEvent)
+	if err == nil && !aggStats.Zero() {
+		send(&zoekt.SearchResult{Stats: aggStats})
 	}
 
 	if err != nil {


### PR DESCRIPTION
We add a simple buffering logic to the stream server: events containing
no file matches but only stats are aggregated and sent out with the
first event containing file matches. This approach should reduce the
number of events sent, but still give us the per-shard granularity that
we want.