### PR TITLE
web: fix operation name for traceAwareSearcher

### DIFF
--- a/web/trace.go
+++ b/web/trace.go
@@ -18,18 +18,18 @@ type traceAwareSearcher struct {
 }
 
 func (s traceAwareSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	ctx, finish := getTraceContext(ctx, opts.Trace, opts.SpanContext)
+	ctx, finish := getTraceContext(ctx, "zoekt.traceAwareSearcher.Search", opts.Trace, opts.SpanContext)
 	defer finish()
 	return s.Searcher.Search(ctx, q, opts)
 }
 
 func (s traceAwareSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) error {
-	ctx, finish := getTraceContext(ctx, opts.Trace, opts.SpanContext)
+	ctx, finish := getTraceContext(ctx, "zoekt.traceAwareSearcher.StreamSearch", opts.Trace, opts.SpanContext)
 	defer finish()
 	return s.Searcher.StreamSearch(ctx, q, opts, sender)
 }
 
-func getTraceContext(ctx context.Context, traceEnabled bool, spanContext map[string]string) (context.Context, func()) {
+func getTraceContext(ctx context.Context, opName string, traceEnabled bool, spanContext map[string]string) (context.Context, func()) {
 	ctx = trace.WithOpenTracingEnabled(ctx, traceEnabled)
 	finish := func() {}
 	if traceEnabled && spanContext != nil {
@@ -38,7 +38,7 @@ func getTraceContext(ctx context.Context, traceEnabled bool, spanContext map[str
 			log.Printf("Error extracting span from opts: %s", err)
 		}
 		if spanContext != nil {
-			span, newCtx := opentracing.StartSpanFromContext(ctx, "zoekt.traceAwareSearcher.Search", opentracing.ChildOf(spanContext))
+			span, newCtx := opentracing.StartSpanFromContext(ctx, opName, opentracing.ChildOf(spanContext))
 			finish = span.Finish
 			ctx = newCtx
 		}


### PR DESCRIPTION
For `traceAwareSearcher`, both `Search` and `StreamingSearch` had the same 
operation name which was confusing to read in the traces.

Now
<img width="419" alt="Screenshot 2021-03-02 at 10 43 06" src="https://user-images.githubusercontent.com/26413131/109629780-7e300180-7b44-11eb-8108-3a143f2ea742.png">
