### PR TITLE
shards: introduce a scheduler abstraction

### DIFF
--- a/shards/sched.go
+++ b/shards/sched.go
@@ -1,0 +1,78 @@
+package shards
+
+import (
+	"context"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// Note: This is a Sourcegraph specific addition to allow long running queries
+// along normal interactive queries.
+
+// scheduler is for managing concurrent searches. Its goals are:
+//
+//   1. Limit the number of concurrent searches.
+//   2. Allow exclusive access.
+//
+// ### Limit the number of concurrent searches
+//
+// Searching is CPU bound, so we can't do better than #CPU queries
+// concurrently. If we do so, we just create more memory pressure.
+//
+// ### Allow exclusive access
+//
+// During the time the shard list is accessed and a search is actually done on
+// a shard it can't be closed. As such while a search is running we do not
+// allow any closing of shards. However, we do need to close and add shards as
+// the indexer proceeds. To do this we have an exclusive process which will be
+// the only one running. This is like a Lock on a RWMutex, while a normal
+// search is a RLock.
+type scheduler struct {
+	throttle *semaphore.Weighted
+	capacity int64
+}
+
+func newScheduler(capacity int64) *scheduler {
+	return &scheduler{
+		throttle: semaphore.NewWeighted(capacity),
+		capacity: capacity,
+	}
+}
+
+// Acquire blocks until a normal process is created (ie for a search
+// request). See process documentation. It will only return an error if the
+// context expires.
+func (s *scheduler) Acquire(ctx context.Context) (*process, error) {
+	return s.acquire(ctx, 1)
+}
+
+// Exclusive blocks until an exclusive process is created. An exclusive
+// process is the only running process. See process documentation.
+func (s *scheduler) Exclusive() *process {
+	// won't error since context.Background won't expire
+	proc, _ := s.acquire(context.Background(), s.capacity)
+	return proc
+}
+
+func (s *scheduler) acquire(ctx context.Context, weight int64) (*process, error) {
+	if err := s.throttle.Acquire(ctx, weight); err != nil {
+		return nil, err
+	}
+	return &process{
+		sched:  s,
+		weight: weight,
+	}, nil
+}
+
+// process represents a running search query or an exclusive process. When the
+// process is done a call to Release is required.
+type process struct {
+	sched  *scheduler
+	weight int64
+}
+
+// Release the resources/locks/semaphores associated with this process. Can
+// only be called once.
+func (p *process) Release() {
+	p.sched.throttle.Release(p.weight)
+}

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -216,7 +216,7 @@ func (s *semaphoreScheduler) Acquire(ctx context.Context) (*process, error) {
 
 // Exclusive implements scheduler.Exclusive.
 func (s *semaphoreScheduler) Exclusive() *process {
-	// won't error since context.Background won't expire
+	// Won't error since context.Background won't expire.
 	proc, _ := s.acquire(context.Background(), s.capacity)
 	return proc
 }

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -118,7 +118,7 @@ type multiScheduler struct {
 func newMultiScheduler(capacity int64) *multiScheduler {
 	batchdiv := zoektSched["batchdiv"]
 	if batchdiv == 0 {
-		// Burst upto 1/4 of interactive capacity for batch.
+		// Burst up to 1/4 of interactive capacity for batch.
 		batchdiv = 4
 	} else {
 		log.Printf("ZOEKTSCHED=batchdiv=%d specified. Batch queue size 1/%d of %d.", batchdiv, batchdiv, capacity)

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -96,10 +96,10 @@ func newScheduler(capacity int64) scheduler {
 //
 // ## Design
 //
-// We use semaphores to limit the number of running processes. An exclusive
-// process acquires the full semaphore. A process represents something which
-// has acquired on the semaphore. Every process is either fast or slow. A
-// process starts as fast, but is downgraded to slow after a period of
+// We use semaphores to limit the number of running processes. A process
+// represents something which has acquired from the semaphore. An exclusive
+// process acquires the full semaphore. Every process is either fast or slow. A
+// process starts as fast, but is downgraded to slow after a period of time.
 // time. Downgrading relies on a process co-operatively deciding to downgrade.
 //
 // We intentionally keep the algorithm simple, but have a general interface to

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -33,7 +33,7 @@ type scheduler interface {
 // scheduler. It is a comma-separated list of name=val pairs setting these
 // named variables:
 //
-//   disable: setting disable=1 will use the old zoekt scheduler.
+//   enable: setting enable=1 will use the new zoekt scheduler.
 //
 //   batchdiv: settings batchDiv=X will make the batch queue size 1/X of the
 //   interactive queue size. By default it is 4.
@@ -51,13 +51,13 @@ var zoektSched = parseTuneables(os.Getenv("ZOEKTSCHED"))
 // multiScheduler unless that has been disabled with the environment variable
 // SCHED_DISABLE. If so it will an equivalent scheduler as upstream zoekt.
 func newScheduler(capacity int64) scheduler {
-	if zoektSched["disable"] == 1 {
-		log.Println("ZOEKTSCHED=disable=1 specified. Using old zoekt scheduler.")
+	if zoektSched["enable"] != 1 {
 		return &semaphoreScheduler{
 			throttle: semaphore.NewWeighted(capacity),
 			capacity: capacity,
 		}
 	}
+	log.Println("ZOEKTSCHED=enable=1 specified. Using new zoekt scheduler.")
 	return newMultiScheduler(capacity)
 }
 

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -66,8 +66,7 @@ type scheduler struct {
 }
 
 func newScheduler(capacity int64) *scheduler {
-	// Burst upto 1/4 of CPUs for batch. This means we now can use upto 1.25 the
-	// amount of CPU.
+	// Burst upto 1/4 of interactive capacity for batch.
 	batchCap := capacity / 4
 	if batchCap == 0 {
 		batchCap = 1

--- a/shards/sched.go
+++ b/shards/sched.go
@@ -2,6 +2,7 @@ package shards
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/sync/semaphore"
 )
@@ -13,6 +14,8 @@ import (
 //
 //   1. Limit the number of concurrent searches.
 //   2. Allow exclusive access.
+//   3. Co-operatively limit long running searches.
+//   4. No tuneables.
 //
 // ### Limit the number of concurrent searches
 //
@@ -27,15 +30,46 @@ import (
 // the indexer proceeds. To do this we have an exclusive process which will be
 // the only one running. This is like a Lock on a RWMutex, while a normal
 // search is a RLock.
+//
+// ### Co-operatively limit long running searches
+//
+// Some searches are slow. Either due to a hard to execute search query (can't
+// use trigram index) or a large number of results. We want to support this
+// use case while still allowing interactive queries to be fast.
+//
+// ### No tuneables
+//
+// We want to avoid the need to tune the scheduler depending on the workload /
+// instance. As such we use a simple design whose inputs are time and number
+// of CPUs.
+//
+// ## Design
+//
+// We use semaphores to limit the number of running processes. An exclusive
+// process acquires the full semaphore. A process represents something which
+// has acquired on the semaphore. Every process is either fast or slow. A
+// process starts as fast, but is downgraded to slow after a period of
+// time. Downgrading relies on a process co-operatively deciding to downgrade.
+//
+// We intentionally keep the algorithm simple, but have a general interface to
+// allow improvements as we learn more.
 type scheduler struct {
 	throttle *semaphore.Weighted
+
+	// capacity is the max concurrent searches we allow.
 	capacity int64
+
+	// interactiveDuration is how long we run a search query at interactive
+	// priority before downgrading it to a batch/slow query.
+	interactiveDuration time.Duration
 }
 
 func newScheduler(capacity int64) *scheduler {
 	return &scheduler{
 		throttle: semaphore.NewWeighted(capacity),
 		capacity: capacity,
+
+		interactiveDuration: 5 * time.Second,
 	}
 }
 
@@ -43,7 +77,17 @@ func newScheduler(capacity int64) *scheduler {
 // request). See process documentation. It will only return an error if the
 // context expires.
 func (s *scheduler) Acquire(ctx context.Context) (*process, error) {
-	return s.acquire(ctx, 1)
+	proc, err := s.acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	proc.yieldTimer = newDeadlineTimer(time.Now().Add(s.interactiveDuration))
+	proc.yieldFunc = func(ctx context.Context) error {
+		// will be implemented next commit.
+		return nil
+	}
+	return proc, nil
 }
 
 // Exclusive blocks until an exclusive process is created. An exclusive
@@ -51,6 +95,8 @@ func (s *scheduler) Acquire(ctx context.Context) (*process, error) {
 func (s *scheduler) Exclusive() *process {
 	// won't error since context.Background won't expire
 	proc, _ := s.acquire(context.Background(), s.capacity)
+	// exclusive processes will never yield, so we leave yieldTimer and
+	// yieldFunc nil.
 	return proc
 }
 
@@ -59,20 +105,94 @@ func (s *scheduler) acquire(ctx context.Context, weight int64) (*process, error)
 		return nil, err
 	}
 	return &process{
-		sched:  s,
-		weight: weight,
+		releaseFunc: func() {
+			s.throttle.Release(weight)
+		},
 	}, nil
 }
 
 // process represents a running search query or an exclusive process. When the
 // process is done a call to Release is required.
 type process struct {
-	sched  *scheduler
-	weight int64
+	// yieldTimer ensures we only call yieldFunc once after a deadline.
+	yieldTimer *deadlineTimer
+	// yieldFunc is called once by Yield.
+	yieldFunc func(context.Context) error
+
+	// releaseFunc is called once by Release
+	releaseFunc func()
 }
 
 // Release the resources/locks/semaphores associated with this process. Can
 // only be called once.
 func (p *process) Release() {
-	p.sched.throttle.Release(p.weight)
+	if p.yieldTimer != nil {
+		p.yieldTimer.Stop()
+	}
+
+	p.releaseFunc()
+}
+
+// Yield may block to allow another process to run. This should be called
+// relatively often by a search to allow other processes to run. This can not
+// be called concurrently.
+//
+// The only error it will return is a context error if ctx expires.
+func (p *process) Yield(ctx context.Context) error {
+	if p.yieldTimer == nil || !p.yieldTimer.Exceeded() {
+		return nil
+	}
+
+	// Try to yield. This can return an error if our context expired.
+	err := p.yieldFunc(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Successfully yielded. Stop our timer and mark it nil so we don't call
+	// yieldFunc again.
+	p.yieldTimer.Stop()
+	p.yieldTimer = nil
+
+	return nil
+}
+
+// newDeadlineTimer returns a timer which fires after deadline. Once it fires
+// Exceeded will always return true. Callers must call Stop when done to
+// release resources.
+func newDeadlineTimer(deadline time.Time) *deadlineTimer {
+	return &deadlineTimer{
+		t: time.NewTimer(deadline.Sub(time.Now())),
+	}
+}
+
+type deadlineTimer struct {
+	// t.C fires after deadline. Once it fires we set to nil to indicate it has
+	// fired.
+	t *time.Timer
+}
+
+// Exceeded returns true if time is after the deadline.
+func (t *deadlineTimer) Exceeded() bool {
+	if t.t == nil {
+		return true
+	}
+	select {
+	case <-t.t.C:
+	default:
+		return false
+	}
+
+	t.Stop()
+
+	return true
+}
+
+// Stop stops the underlying timer. Can be called multiple times.
+func (t *deadlineTimer) Stop() {
+	if t.t == nil {
+		return
+	}
+	t.t.Stop()
+	t.t = nil
 }

--- a/shards/sched_test.go
+++ b/shards/sched_test.go
@@ -1,0 +1,110 @@
+package shards
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func BenchmarkYield(b *testing.B) {
+	// Use quanta longer than the benchmark runs
+	quanta := time.Minute
+
+	// Benchmark of the raw primitive we are using to tell if we should yield.
+	b.Run("timer", func(b *testing.B) {
+		t := time.NewTimer(quanta)
+		defer t.Stop()
+
+		for n := 0; n < b.N; n++ {
+			select {
+			case <-t.C:
+				b.Fatal("done")
+			default:
+			}
+		}
+	})
+
+	// Benchmark of an alternative approach to timer. It is _much_ slower.
+	b.Run("now", func(b *testing.B) {
+		deadline := time.Now().Add(quanta)
+
+		for n := 0; n < b.N; n++ {
+			if time.Now().After(deadline) {
+				b.Fatal("done")
+			}
+		}
+	})
+
+	// Benchmark of our wrapper around time.Timer
+	b.Run("deadlineTimer", func(b *testing.B) {
+		t := newDeadlineTimer(time.Now().Add(quanta))
+		defer t.Stop()
+
+		for n := 0; n < b.N; n++ {
+			if t.Exceeded() {
+				b.Fatal("done")
+			}
+		}
+	})
+
+	// Bencmark of actual yield function
+	b.Run("yield", func(b *testing.B) {
+		ctx := context.Background()
+		sched := newScheduler(1)
+		sched.interactiveDuration = quanta
+		proc, err := sched.Acquire(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer proc.Release()
+
+		for n := 0; n < b.N; n++ {
+			proc.Yield(ctx)
+		}
+	})
+}
+
+func TestYield(t *testing.T) {
+	ctx := context.Background()
+	quanta := 10 * time.Millisecond
+	deadline := time.Now().Add(quanta)
+
+	sched := newScheduler(1)
+	sched.interactiveDuration = quanta
+	proc, err := sched.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer proc.Release()
+
+	called := false
+	oldYieldFunc := proc.yieldFunc
+	proc.yieldFunc = func(ctx context.Context) error {
+		if called {
+			t.Fatal("yieldFunc called more than once")
+		}
+		called = true
+		if time.Now().Before(deadline) {
+			t.Fatal("yieldFunc called before deadline")
+		}
+		return oldYieldFunc(ctx)
+	}
+
+	var pre, post int
+	for post < 10 {
+		if err := proc.Yield(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		if called {
+			post++
+		} else {
+			pre++
+		}
+	}
+
+	// We can't assert anything based on time since it will run into race
+	// conditions with the runtime. So we just log the pre and post values so we
+	// can eyeball them sometimes :)
+	t.Logf("pre=%d post=%d", pre, post)
+}

--- a/shards/sched_test.go
+++ b/shards/sched_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func BenchmarkYield(b *testing.B) {
-	// Use quanta longer than the benchmark runs
-	quanta := time.Minute
+	// Use quantum longer than the benchmark runs
+	quantum := time.Minute
 
 	// Benchmark of the raw primitive we are using to tell if we should yield.
 	b.Run("timer", func(b *testing.B) {
-		t := time.NewTimer(quanta)
+		t := time.NewTimer(quantum)
 		defer t.Stop()
 
 		for n := 0; n < b.N; n++ {
@@ -26,7 +26,7 @@ func BenchmarkYield(b *testing.B) {
 
 	// Benchmark of an alternative approach to timer. It is _much_ slower.
 	b.Run("now", func(b *testing.B) {
-		deadline := time.Now().Add(quanta)
+		deadline := time.Now().Add(quantum)
 
 		for n := 0; n < b.N; n++ {
 			if time.Now().After(deadline) {
@@ -37,7 +37,7 @@ func BenchmarkYield(b *testing.B) {
 
 	// Benchmark of our wrapper around time.Timer
 	b.Run("deadlineTimer", func(b *testing.B) {
-		t := newDeadlineTimer(time.Now().Add(quanta))
+		t := newDeadlineTimer(time.Now().Add(quantum))
 		defer t.Stop()
 
 		for n := 0; n < b.N; n++ {
@@ -51,7 +51,7 @@ func BenchmarkYield(b *testing.B) {
 	b.Run("yield", func(b *testing.B) {
 		ctx := context.Background()
 		sched := newScheduler(1)
-		sched.interactiveDuration = quanta
+		sched.interactiveDuration = quantum
 		proc, err := sched.Acquire(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -66,11 +66,11 @@ func BenchmarkYield(b *testing.B) {
 
 func TestYield(t *testing.T) {
 	ctx := context.Background()
-	quanta := 10 * time.Millisecond
-	deadline := time.Now().Add(quanta)
+	quantum := 10 * time.Millisecond
+	deadline := time.Now().Add(quantum)
 
 	sched := newScheduler(1)
-	sched.interactiveDuration = quanta
+	sched.interactiveDuration = quantum
 	proc, err := sched.Acquire(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -445,6 +445,11 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 	// number of parallel searches. This reduces the peak working
 	// set, which hopefully stops https://cs.bazel.build from crashing
 	// when looking for the string "com".
+	//
+	// We do yield inside of the feeder. This means we could have num_workers +
+	// cap(feeder) searches run while yield blocks. However, doing it this way
+	// avoids needing to have synchronization in yield, so is done for
+	// simplicity.
 	feeder := make(chan zoekt.Searcher, runtime.GOMAXPROCS(0))
 	g.Go(func() error {
 		defer close(feeder)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -139,7 +139,7 @@ type shardedSearcher struct {
 	// CPU bound, we can't do better than #CPU queries in
 	// parallel.  If we do so, we just create more memory
 	// pressure.
-	sched *scheduler
+	sched scheduler
 
 	shards map[string]rankedShard
 


### PR DESCRIPTION
This PR introduces a scheduler abstraction for searches to use. Every search now starts in the "interactive" queue. But after 5s will move to the "batch" queue. The idea here is to have simple approach of allowing long running queries to run without impacting interactive queries.

We use WeightedSemaphore as the "queue" (internally has a FIFO queue). Before this PR we just had one WeightedSemaphore with size #CPUs. In this PR that semaphore becomes the "interactive" queue. The "batch" queue is a new semaphore with size 1/4 #CPUs. This doesn't limit the amount of CPU a search can consume, but rather we use number of CPUs as a guide for the number of concurrent searches that can be running.

This commit changes a few things, so is intended to be reviewed commit by commit.

What is still missing is some observability. That will be done as part of this PR so we can monitor the effects.

Part of https://github.com/sourcegraph/sourcegraph/issues/18305