### PR TITLE
streaming: handle client-side context error

### DIFF
--- a/stream/client.go
+++ b/stream/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -82,8 +83,11 @@ func (c *Client) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.Search
 		reply := &searchReply{}
 		err := dec.Decode(reply)
 		if err != nil {
-			if ctxErr, ok := stringToContextError(err.Error()); ok {
-				return ctxErr
+			if errors.Is(err, context.Canceled) {
+				return context.Canceled
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				return context.DeadlineExceeded
 			}
 			return fmt.Errorf("error during decoding: %w", err)
 		}


### PR DESCRIPTION
The streaming client did not properly handle the case where the client
cancels the context while the stream is ongoing. Up to now, the client
returned a standard error. With this change the client will return
either `context.Canceled` or `context.DeadlineExceed`.