### PR TITLE
Support ** for LargeFiles patterns.

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/bmatcuk/doublestar"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/ctags"
 )
@@ -316,7 +317,7 @@ func rawConfigEqual(m1, m2 map[string]string, key string) bool {
 func (o *Options) IgnoreSizeMax(name string) bool {
 	for _, pattern := range o.LargeFiles {
 		pattern = strings.TrimSpace(pattern)
-		m, _ := filepath.Match(pattern, name)
+		m, _ := doublestar.PathMatch(pattern, name)
 		if m {
 			return true
 		}
@@ -620,7 +621,7 @@ func (b *Builder) writeShard(fn string, ib *zoekt.IndexBuilder) (*finishedShard,
 		return nil, err
 	}
 
-	f, err := ioutil.TempFile(dir, filepath.Base(fn) + ".*.tmp")
+	f, err := ioutil.TempFile(dir, filepath.Base(fn)+".*.tmp")
 	if err != nil {
 		return nil, err
 	}

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -55,3 +55,60 @@ func TestFlags(t *testing.T) {
 		}
 	}
 }
+
+func TestIgnoreSizeMax(t *testing.T) {
+	cases := []struct {
+		opts Options
+		path string
+		want bool
+	}{
+		{
+			Options{},
+			"/foo",
+			false,
+		},
+		{
+			Options{LargeFiles: []string{"/*.lock"}},
+			"/foo.lock",
+			true,
+		},
+		{
+			Options{LargeFiles: []string{"/*.lock"}},
+			"/bar/foo.lock",
+			false,
+		},
+		{
+			Options{LargeFiles: []string{"**/*.lock"}},
+			"/bar/foo.lock",
+			true,
+		},
+		{
+			Options{LargeFiles: []string{"**/*.lock"}},
+			"/bar/baz/foo.lock",
+			true,
+		},
+		{
+			Options{LargeFiles: []string{"/baz/**/*.lock"}},
+			"/bar/baz/foo.lock",
+			false,
+		},
+		{
+			Options{LargeFiles: []string{"/baz/**/*.lock"}},
+			"/baz/a/b/c/d/foo.lock",
+			true,
+		},
+		{
+			Options{LargeFiles: []string{"**.lock"}},
+			"/baz/a/b/c/d/foo.lock",
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		got := c.opts.IgnoreSizeMax(c.path)
+		if got != c.want {
+			t.Errorf("mismatch for %v %#v (-want +got): %v %v\n",
+				c.opts.LargeFiles, c.path, c.want, got)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/google/zoekt
 
 require (
 	github.com/andygrunwald/go-gerrit v0.0.0-20191101112536-3f5e365ccf57
+	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20200312180434-e5170e3280fb

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
+github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=


### PR DESCRIPTION
This is done by simply changing from filepath.Match to
doublestar.PathMatch. A few minor tests are included.

The only syntax change is that ** now matches any number of directories,
so "**/*.lock" will match a file with a "lock" extension anywhere in the
path. Since "**" had no special meaning before, this change should not
cause any surprising changes.

This should help with sourcegraph/customer#224