### PR TITLE
streaming: remove special casing of context errors

### DIFF
--- a/stream/client.go
+++ b/stream/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/gob"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
@@ -93,13 +92,7 @@ func (c *Client) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.Search
 			}
 		case eventError:
 			if errString, ok := reply.Data.(string); ok {
-				if strings.Contains(errString, "context canceled") {
-					return context.Canceled
-				} else if strings.Contains(errString, "context deadline exceeded") {
-					return context.DeadlineExceeded
-				} else {
-					return fmt.Errorf(errString)
-				}
+				return fmt.Errorf("error received from zoekt: %s", errString)
 			} else {
 				return fmt.Errorf("data for event of type %s could not be converted to string", eventError.string())
 			}


### PR DESCRIPTION
This changes how we handle context errors returned from the server:
Instead of translating context errors, which were serialized as string,
back to context errors, we treat them the same way as any other error.
To not confuse `fmt.Errorf("context canceled")` with `context.Canceled`
during debugging, we add the prefix "error received from zoekt".