### PR TITLE
indexserver: prevent HEAD pointing to master

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -213,7 +213,7 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 		// use a random default branch. This is so that HEAD isn't a symref to a
 		// branch that is indexed. For example if you are indexing
 		// HEAD,master. Then HEAD would be pointing to master by default.
-		"-c", "init.defaultBranch=BB0FOFCH32",
+		"-c", "init.defaultBranch=nonExistentBranchBB0FOFCH32",
 		"init",
 		// we don't need a working copy
 		"--bare",

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -209,7 +209,15 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 	// clone. So don't defer os.RemoveAll here
 
 	// Create a repo to fetch into
-	cmd := exec.CommandContext(ctx, "git", "init", "--bare", gitDir)
+	cmd := exec.CommandContext(ctx, "git",
+		// use a random default branch. This is so that HEAD isn't a symref to a
+		// branch that is indexed. For example if you are indexing
+		// HEAD,master. Then HEAD would be pointing to master by default.
+		"-c", "init.defaultBranch=BB0FOFCH32",
+		"init",
+		// we don't need a working copy
+		"--bare",
+		gitDir)
 	cmd.Stdin = &bytes.Buffer{}
 	if err := runCmd(cmd); err != nil {
 		return err

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -106,7 +106,7 @@ func TestIndex(t *testing.T) {
 			"zoekt-archive-index -name test/repo -commit deadbeef -branch HEAD -disable_ctags http://api.test/.internal/git/test/repo/tar/deadbeef",
 		},
 		wantGit: []string{
-			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=nonExistentBranchBB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
@@ -126,7 +126,7 @@ func TestIndex(t *testing.T) {
 			"zoekt-archive-index -name test/repo -commit deadbeef -branch HEAD -disable_ctags http://api.test/.internal/git/test/repo/tar/deadbeef",
 		},
 		wantGit: []string{
-			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=nonExistentBranchBB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
@@ -168,7 +168,7 @@ func TestIndex(t *testing.T) {
 			"http://api.test/.internal/git/test/repo/tar/deadbeef",
 		}, " ")},
 		wantGit: []string{
-			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=nonExistentBranchBB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef feebdaed",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref refs/heads/dev feebdaed",

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -106,7 +106,7 @@ func TestIndex(t *testing.T) {
 			"zoekt-archive-index -name test/repo -commit deadbeef -branch HEAD -disable_ctags http://api.test/.internal/git/test/repo/tar/deadbeef",
 		},
 		wantGit: []string{
-			"git init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
@@ -126,7 +126,7 @@ func TestIndex(t *testing.T) {
 			"zoekt-archive-index -name test/repo -commit deadbeef -branch HEAD -disable_ctags http://api.test/.internal/git/test/repo/tar/deadbeef",
 		},
 		wantGit: []string{
-			"git init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
@@ -168,7 +168,7 @@ func TestIndex(t *testing.T) {
 			"http://api.test/.internal/git/test/repo/tar/deadbeef",
 		}, " ")},
 		wantGit: []string{
-			"git init --bare $TMPDIR/test%2Frepo.git",
+			"git -c init.defaultBranch=BB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
 			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef feebdaed",
 			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
 			"git -C $TMPDIR/test%2Frepo.git update-ref refs/heads/dev feebdaed",


### PR DESCRIPTION
If master is not your default branch, but you are indexing it then we
would not index the default branch. This happened because in the git
repo with synthesize we run `update-ref HEAD foo` then `update-ref
master bar`. Because `HEAD` pointed to `refs/heads/master` we would have
a final value of `bar` for HEAD.

This commit changes the default branch to a random string which
shouldn't be indexed. Now `HEAD` will point to the random string,
preventing this issue.

Change-Id: I3d8906287f73d44925abf51303a80ad55a89a47e