### PR TITLE
make sourcegraph-indexserver store priorities and shardedsearcher sort by them

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -40,6 +40,9 @@ type IndexOptions struct {
 
 	// RepoID is the Sourcegraph Repository ID.
 	RepoID int32
+
+	// Priority indicates ranking in results, higher first.
+	Priority float64
 }
 
 // indexArgs represents the arguments we pass to zoekt-archive-index
@@ -78,6 +81,10 @@ func (o *indexArgs) BuildOptions() *build.Options {
 		// NOTE(keegan): 2020-08-13 This is currently not read anywhere. We are
 		// setting it so in a few releases all indexes should have it set.
 		rawConfig["repoid"] = strconv.Itoa(int(o.IndexOptions.RepoID))
+	}
+
+	if o.Priority != 0 {
+		rawConfig["priority"] = strconv.FormatFloat(o.Priority, 'g', -1, 64)
 	}
 
 	return &build.Options{

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -268,6 +269,8 @@ func (s *Server) Run(queue *Queue) {
 			tr := trace.New("getIndexOptions", "")
 			tr.LazyPrintf("getting index options for %d repos", len(repos))
 
+			newPriorities := make(map[string]float64)
+
 			// We ask the frontend to get index options in batches.
 			for repos := range batched(repos, 1000) {
 				start := time.Now()
@@ -287,9 +290,14 @@ func (s *Server) Run(queue *Queue) {
 						tr.SetError()
 						continue
 					}
+					if opt.Priority != 0 {
+						newPriorities[name] = opt.Priority
+					}
 					queue.AddOrUpdate(name, opt.IndexOptions)
 				}
 			}
+			s.maybeUpdatePriorities(repos, newPriorities)
+
 			metricResolveRevisionsDuration.Observe(time.Since(start).Seconds())
 			tr.Finish()
 
@@ -319,6 +327,58 @@ func (s *Server) Run(queue *Queue) {
 			log.Printf("updated index %s in %v", args.String(), time.Since(start))
 		}
 		queue.SetIndexed(name, opts, state)
+	}
+}
+
+// Update priority.json given new entries, and remove no longer tracked repos.
+// This doesn't simply write newPriorities because a transient getIndexOptions failure
+// would cause the associated repo to get deprioritized.
+func (s *Server) maybeUpdatePriorities(names []string, newPriorities map[string]float64) {
+	priorityPath := path.Join(s.IndexDir, "priority.json")
+	priorities := map[string]float64{}
+	buf, err := ioutil.ReadFile(priorityPath)
+	if err == nil {
+		err = json.Unmarshal(buf, &priorities)
+		if err != nil {
+			log.Printf("error loading old priority.json: %v", err)
+		}
+	}
+
+	// maybe remove no-longer-tracked repos from the priorities list
+	if len(names) != len(priorities) {
+		set := make(map[string]struct{}, len(names))
+		for _, name := range names {
+			set[name] = struct{}{}
+		}
+		for name := range priorities {
+			if _, ok := set[name]; !ok {
+				delete(priorities, name)
+			}
+		}
+	}
+
+	for name, priority := range newPriorities {
+		priorities[name] = priority
+	}
+
+	newBuf, err := json.Marshal(priorities)
+	if err != nil {
+		log.Printf("error marshaling new priority.json: %v", err)
+	}
+	newBuf = append(newBuf, '\n') // prettier
+
+	if bytes.Equal(buf, newBuf) {
+		return // no need to rewrite priority.json
+	}
+
+	err = ioutil.WriteFile(priorityPath+".tmp", newBuf, 0644)
+	if err != nil {
+		log.Printf("error writing new priority.json: %v", err)
+	}
+
+	err = os.Rename(priorityPath+".tmp", priorityPath)
+	if err != nil {
+		log.Printf("error renaming new priority.json into place: %v", err)
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -72,6 +72,16 @@ var (
 		Help: "Number of repos assigned to this indexer by code host",
 	}, []string{"codehost"})
 
+	metricNumPriorities = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_priorities_total",
+		Help: "Number of indexed repos with non-zero priorities",
+	})
+
+	metricNumPriorityUpdates = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "index_priorities_update_total",
+		Help: "Total number of times repo ranking has been written to priority.json",
+	})
+
 	metricFailingTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "index_failing_total",
 		Help: "Counts failures to index (indexing activity, should be used with rate())",
@@ -361,6 +371,8 @@ func (s *Server) maybeUpdatePriorities(names []string, newPriorities map[string]
 		priorities[name] = priority
 	}
 
+	metricNumPriorities.Set(float64(len(priorities)))
+
 	newBuf, err := json.Marshal(priorities)
 	if err != nil {
 		log.Printf("error marshaling new priority.json: %v", err)
@@ -381,6 +393,8 @@ func (s *Server) maybeUpdatePriorities(names []string, newPriorities map[string]
 	if err != nil {
 		log.Printf("error renaming new priority.json into place: %v", err)
 	}
+
+	metricNumPriorityUpdates.Inc()
 }
 
 func batched(slice []string, size int) <-chan []string {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -340,7 +340,7 @@ func (s *Server) maybeUpdatePriorities(names []string, newPriorities map[string]
 	if err == nil {
 		err = json.Unmarshal(buf, &priorities)
 		if err != nil {
-			log.Printf("error loading old priority.json: %v", err)
+			log.Printf("warning: error loading old priority.json, treating as empty: %v", err)
 		}
 	}
 
@@ -374,6 +374,7 @@ func (s *Server) maybeUpdatePriorities(names []string, newPriorities map[string]
 	err = ioutil.WriteFile(priorityPath+".tmp", newBuf, 0644)
 	if err != nil {
 		log.Printf("error writing new priority.json: %v", err)
+		return
 	}
 
 	err = os.Rename(priorityPath+".tmp", priorityPath)


### PR DESCRIPTION
Depends on sourcegraph/sourcegraph#20543 for functionality to work,
but can be safely deployed without it.

zoekt-sourcegraph-reposerver receives floating-point repo priorities as
part of the sync loop running getIndexOptions, and persists them to
priority.json in the index dir.

zoekt-webserver initializes shardedSearcher which loads priority.json
and watches for changes, and sorts by priority first and then by name.