### PR TITLE
bump ctags timeout from 5s to 60s

### DIFF
--- a/build/ctags.go
+++ b/build/ctags.go
@@ -81,7 +81,7 @@ func runCTags(bin string, inputs map[string][]byte) ([]*ctags.Entry, error) {
 		err := cmd.Wait()
 		errChan <- err
 	}()
-	timeout := time.After(5 * time.Second)
+	timeout := time.After(60 * time.Second)
 	select {
 	case <-timeout:
 		cmd.Process.Kill()


### PR DESCRIPTION
There's no reason to assume that ctags can complete within 5s for large
repositories.

I was getting local errors because of this.