### PR TITLE
zoekt-git-index: fix ParseGitModules BOM scanner to work with empty files

### DIFF
--- a/gitindex/submodule.go
+++ b/gitindex/submodule.go
@@ -16,6 +16,7 @@ package gitindex
 
 import (
 	"bytes"
+	"io"
 
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 )
@@ -35,7 +36,7 @@ func ParseGitModules(content []byte) (map[string]*SubmoduleEntry, error) {
 	// otherwise break the scanner.
 	// https://stackoverflow.com/a/21375405
 	r, _, err := buf.ReadRune()
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	if r != '\uFEFF' {

--- a/gitindex/submodule_test.go
+++ b/gitindex/submodule_test.go
@@ -47,6 +47,7 @@ func TestParseGitModules(t *testing.T) {
 					Branch: ".",
 				},
 			}},
+		{"", map[string]*SubmoduleEntry{}},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
sourcegraph/sourcegraph#21865