### PR TITLE
indexserver: write public.txt

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -43,6 +43,9 @@ type IndexOptions struct {
 
 	// Priority indicates ranking in results, higher first.
 	Priority float64
+
+	// Public is true if the repository is public.
+	Public bool
 }
 
 // indexArgs represents the arguments we pass to zoekt-archive-index
@@ -78,13 +81,15 @@ type indexArgs struct {
 func (o *indexArgs) BuildOptions() *build.Options {
 	rawConfig := map[string]string{}
 	if o.IndexOptions.RepoID > 0 {
-		// NOTE(keegan): 2020-08-13 This is currently not read anywhere. We are
-		// setting it so in a few releases all indexes should have it set.
 		rawConfig["repoid"] = strconv.Itoa(int(o.IndexOptions.RepoID))
 	}
 
 	if o.Priority != 0 {
 		rawConfig["priority"] = strconv.FormatFloat(o.Priority, 'g', -1, 64)
+	}
+
+	if o.Public {
+		rawConfig["public"] = "1"
 	}
 
 	return &build.Options{

--- a/cmd/zoekt-sourcegraph-indexserver/public.go
+++ b/cmd/zoekt-sourcegraph-indexserver/public.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const publicSetFileName = "public.txt"
+
+var (
+	metricNumPublicSet = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_num_public_set",
+		Help: "Number of indexed repos that are in the public set.",
+	})
+
+	metricPublicSetUpdate = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "index_public_set_update_total",
+		Help: "Total number of times the public set has been updated.",
+	})
+)
+
+// writePublicSet will write public to public.txt. It will first read the
+// existing public.txt file and include those repos in failed. This is to
+// prevent intermittent failures polling for options removing a repository
+// from the public corpus. The assumption is we will converge to a working get
+// option.
+//
+// public.txt is a sorted list of repository names, one per line. This format
+// was chosen for easy introspection with command line tools.
+func writePublicSet(dir string, public []string, failed map[string]struct{}) error {
+	// We want to keep values that used to be marked public, but we failed to
+	// find out the current visibility state. We treat getIndexOpts as best
+	// effort, so when it fails we use the old visibility.
+	var old []string
+	err := readPublicSetFunc(dir, func(repo string) {
+		old = append(old, repo)
+		if _, ok := failed[repo]; ok {
+			public = append(public, repo)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed parsing public.txt: %w", err)
+	}
+
+	metricNumPublicSet.Set(float64(len(public)))
+
+	sort.Strings(old)
+	sort.Strings(public)
+
+	// Check if we need to update.
+	if len(public) == len(old) {
+		same := true
+		for i := range public {
+			if public[i] != old[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			return nil
+		}
+	}
+
+	// write to temp file first so we can do atomic update.
+	dst := filepath.Join(dir, publicSetFileName)
+	out, err := os.OpenFile(dst+".tmp", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write public.txt.tmp: %w", err)
+	}
+	defer os.Remove(dst + ".tmp")
+	defer out.Close()
+
+	w := bufio.NewWriter(out)
+	for _, repo := range public {
+		// can ignore error since it will be returned by flush
+		_, _ = w.WriteString(repo)
+		_ = w.WriteByte('\n')
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("failed to write public.txt.tmp: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to write public.txt.tmp: %w", err)
+	}
+
+	if err := os.Rename(dst+".tmp", dst); err != nil {
+		return fmt.Errorf("failed to write public.txt: %w", err)
+	}
+
+	metricPublicSetUpdate.Inc()
+
+	return nil
+}
+
+func readPublicSetFunc(dir string, f func(string)) error {
+	file, err := os.Open(filepath.Join(dir, publicSetFileName))
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		repo := strings.TrimSpace(scanner.Text())
+		if repo != "" {
+			f(repo)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/zoekt-sourcegraph-indexserver/public_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/public_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPublicSet(t *testing.T) {
+	// We test by creating a sequence of updates, and testing at each step that
+	// what we read back matches what we simulate.
+	steps := []struct{ desc, public, failed, want string }{{
+		desc: "empty",
+		want: "",
+	}, {
+		desc:   "add 1 repo",
+		public: "public",
+		want:   "public",
+	}, {
+		desc:   "noop",
+		public: "public",
+		want:   "public",
+	}, {
+		desc:   "ignore failed repo, we don't know if it is public",
+		public: "public",
+		failed: "failed",
+		want:   "public",
+	}, {
+		desc:   "failed to update public, but keep it in the set",
+		public: "",
+		failed: "failed public",
+		want:   "public",
+	}, {
+		desc:   "add in new_public",
+		public: "new_public",
+		failed: "failed public",
+		want:   "public new_public",
+	}, {
+		desc:   "everything changes",
+		public: "new_world",
+		want:   "new_world",
+	}, {
+		desc:   "test going to nothing public",
+		failed: "public",
+		want:   "",
+	}}
+
+	dir := t.TempDir()
+	for i, step := range steps {
+		public := strings.Split(step.public, " ")
+		failed := map[string]struct{}{}
+		for _, v := range strings.Split(step.failed, " ") {
+			failed[v] = struct{}{}
+		}
+
+		err := writePublicSet(dir, public, failed)
+		if err != nil {
+			t.Fatalf("failed at step %d: %s: %v", i, step.desc, err)
+		}
+
+		var got []string
+		err = readPublicSetFunc(dir, func(v string) {
+			got = append(got, v)
+		})
+		if err != nil {
+			t.Fatalf("failed at step %d: %s: %v", i, step.desc, err)
+		}
+
+		want := strings.Split(step.want, " ")
+		if step.want == "" {
+			want = nil
+		}
+
+		sort.Strings(got)
+		sort.Strings(want)
+		if d := cmp.Diff(want, got); d != "" {
+			t.Fatalf("failed at step %d: %s: (-want, +got):\n%s", i, step.desc, d)
+		}
+	}
+}


### PR DESCRIPTION
This commit will write a file public.txt which contains all public repositories for this replica. The intention is that zoekt-webserver will read this file and support filtering based on if a repository is in this set.

We chose a simple format for public.txt to make it easy to inspect, which we have been finding very useful in practice. We take a similiar approach as to priorities where we handle intermittent failures in option fetching.
