### PR TITLE
ngramoffset: add a dense asciiNgramOffset mapper

### DIFF
--- a/indexdata.go
+++ b/indexdata.go
@@ -33,7 +33,7 @@ type indexData struct {
 
 	file IndexFile
 
-	ngrams arrayNgramOffset
+	ngrams combinedNgramOffset
 
 	newlinesStart uint32
 	newlinesIndex []uint32

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -18,6 +18,17 @@ import (
 	"sort"
 )
 
+// shrinkUint32Slice copies slices with excess capacity to precisely seized ones
+// to avoid wasting memory. It should be used on slices with long static durations.
+func shrinkUint32Slice(a []uint32) []uint32 {
+	if cap(a)-len(a) < 32 {
+		return a
+	}
+	out := make([]uint32, len(a))
+	copy(out, a)
+	return out
+}
+
 type topOffset struct {
 	top, off uint32
 }
@@ -40,10 +51,9 @@ type arrayNgramOffset struct {
 
 func makeArrayNgramOffset(ngrams []ngram, offsets []uint32) arrayNgramOffset {
 	arr := arrayNgramOffset{
-		bots:    make([]uint32, 0, len(ngrams)),
-		offsets: make([]uint32, len(offsets)),
+		bots: make([]uint32, 0, len(ngrams)),
 	}
-	copy(arr.offsets, offsets) // copy to ensure offsets is minimally sized
+	arr.offsets = shrinkUint32Slice(offsets)
 
 	lastTop := uint32(0xffffffff)
 	lastStart := uint32(0)
@@ -111,4 +121,238 @@ func (a *arrayNgramOffset) DumpMap() map[ngram]simpleSection {
 
 func (a *arrayNgramOffset) SizeBytes() int {
 	return 8*len(a.tops) + 4*len(a.bots) + 4*len(a.offsets)
+}
+
+// combinedNgramOffset combines an ascii ngram mapping with a unicode ngram mapping,
+// falling back on unicode for unicode ngrams or ascii ngrams with excessive lengths.
+type combinedNgramOffset struct {
+	asc *asciiNgramOffset
+	uni *arrayNgramOffset
+}
+
+func makeCombinedNgramOffset(ngrams []ngram, offsets []uint32) combinedNgramOffset {
+	// split ngrams & offsets into ascii ngrams and unicode ngrams,
+	// since ascii ngrams can be represented much more compactly (21b instead of 63b)
+
+	// allocate these arrays based off of rough measurements of what their typical
+	// sizes are-- source code is mostly ASCII with a little bit of Unicode.
+	// Allocating 101% of the total number of ngrams gives a little space for the
+	// duplicate entries used to mark section ends.
+	ngramsAscii := make([]ngramAscii, 0, len(ngrams)*101/100)
+	offsetsAscii := make([]uint32, 0, len(ngrams)*101/100)
+
+	ngramsUnicode := make([]ngram, 0, len(ngrams)*11/100)
+	offsetsUnicode := make([]uint32, 0, len(ngrams)*11/100)
+
+	for i, ng := range ngrams {
+		if ng&ngramAsciiMask == ng { // is ngram ascii-only?
+			ngp := ngramAsciiToPacked(ng)
+			if i == len(ngrams)-1 || ngrams[i+1]&ngramAsciiMask != ngrams[i+1] {
+				// at the end of a section we insert an extra offset with the same ngram,
+				// so the size of the segment can be calculated properly
+				ngramsAscii = append(ngramsAscii, ngp, ngp)
+				offsetsAscii = append(offsetsAscii, offsets[i], offsets[i+1])
+			} else {
+				ngramsAscii = append(ngramsAscii, ngp)
+				offsetsAscii = append(offsetsAscii, offsets[i])
+			}
+			// note: len(offsets) == len(ngrams) + 1
+			if offsets[i+1]-offsets[i] >= ngramAsciiMaxSectionLength {
+				// max-length ascii sections can't be represented properly in the ascii mapping,
+				// and are duplicated in the normal unicode entries.
+				ngramsUnicode = append(ngramsUnicode, ng, ng)
+				offsetsUnicode = append(offsetsUnicode, offsets[i], offsets[i+1])
+			}
+		} else {
+			if i == len(ngrams)-1 || ngrams[i+1]&ngramAsciiMask == ngrams[i+1] {
+				ngramsUnicode = append(ngramsUnicode, ng, ng)
+				offsetsUnicode = append(offsetsUnicode, offsets[i], offsets[i+1])
+			} else {
+				ngramsUnicode = append(ngramsUnicode, ng)
+				offsetsUnicode = append(offsetsUnicode, offsets[i])
+			}
+		}
+	}
+
+	// The last segment always has an extra trailing ngram entry that we don't need, and
+	// is only present for spacing and alignment. Trim it.
+	if len(ngramsAscii) > 0 {
+		ngramsAscii = ngramsAscii[:len(ngramsAscii)-1]
+	}
+	if len(ngramsUnicode) > 0 {
+		ngramsUnicode = ngramsUnicode[:len(ngramsUnicode)-1]
+	}
+
+	asc := makeAsciiNgramOffset(ngramsAscii, offsetsAscii)
+	uni := makeArrayNgramOffset(ngramsUnicode, offsetsUnicode)
+
+	return combinedNgramOffset{asc, &uni}
+}
+
+// Get returns a simpleSection with sz=0 if no entry, otherwise the appropriate
+// offset based on the underlying ASCII or Unicode offset index.
+func (a combinedNgramOffset) Get(gram ngram) simpleSection {
+	if a.asc == nil {
+		return simpleSection{}
+	}
+
+	var sec simpleSection
+	if gram&ngramAsciiMask == gram {
+		sec = a.asc.Get(gram)
+		if sec.sz == ngramAsciiMaxSectionLength {
+			// Fallback: this section's length was too long to store in the
+			// ASCII map, find it in the Unicode map.
+			sec = a.uni.Get(gram)
+		}
+	} else {
+		sec = a.uni.Get(gram)
+	}
+
+	return sec
+}
+
+func (a combinedNgramOffset) DumpMap() map[ngram]simpleSection {
+	m := a.asc.DumpMap()
+	for k, v := range a.uni.DumpMap() {
+		m[k] = v
+	}
+	return m
+}
+
+func (a combinedNgramOffset) SizeBytes() int {
+	return a.asc.SizeBytes() + a.uni.SizeBytes()
+}
+
+const ngramAsciiMask = 127 | 127<<21 | 127<<42
+
+// Ascii mapping packs 3*7b chars and 11 bits of lengths, with this as the set maximum.
+// We could save another ~3% of total RAM / 5% of combinedNgramOffset RAM by switching to
+// a 40b packing with 19-bit lengths, but the code would be significantly uglier so it doesn't
+// seem worth it.
+const ngramAsciiMaxSectionLength = (1 << 11) - 1
+
+type ngramAscii uint32
+
+func ngramAsciiToPacked(ng ngram) ngramAscii {
+	return ngramAscii(uint32(ng&127) | uint32((ng>>(21-7))&(127<<7)) | uint32((ng>>(42-14))&(127<<14)))
+}
+
+func ngramAsciiPackedToNgram(ng ngramAscii) ngram {
+	return ngram(ng&127) | ngram(ng&(127<<7))<<(21-7) | ngram(ng&(127<<14))<<(42-14)
+}
+
+// asciiNgramOffset stores ascii trigrams packed together with short lengths,
+// using offsets for a chunk of entries to limit the number of lengths that must
+// be summed to compute a section's offset.
+type asciiNgramOffset struct {
+	entries      []uint32 // (chara << 25 | charb << 18 | charc << 11 | length)
+	chunkOffsets []uint32 // offset for entries[i*asciiNgramOffsetChunkLength]
+}
+
+// asciiNgramOffsetChunkLength specifies how many entries share one initial offset.
+// It must be a power of 2, and was chosen empirically by measuring RAM usage:
+// 8: 4132MB, 16: 4047MB, 32: 4006MB, 64: 3992MB, 128: 3990MB
+const asciiNgramOffsetChunkLength = 32
+
+func makeAsciiNgramOffset(ngrams []ngramAscii, offsets []uint32) *asciiNgramOffset {
+	ao := &asciiNgramOffset{
+		entries:      make([]uint32, 0, len(ngrams)),
+		chunkOffsets: make([]uint32, 0, len(ngrams)/asciiNgramOffsetChunkLength),
+	}
+
+	for i, ng := range ngrams {
+		if len(ao.entries)%asciiNgramOffsetChunkLength == 0 {
+			ao.chunkOffsets = append(ao.chunkOffsets, offsets[i])
+		}
+		length := offsets[i+1] - offsets[i]
+
+		for {
+			if length < ngramAsciiMaxSectionLength {
+				ao.entries = append(ao.entries, uint32(ng)<<11|length)
+				break
+			} else {
+				// entries with lengths that are too long can't be represented fully in this
+				// map, but we repeatedly insert offsets to make the next entry's offset computable
+				// by summing the offsets in the preceding entries in the chunk, including
+				// this invalid one.
+				ao.entries = append(ao.entries, uint32(ng)<<11|ngramAsciiMaxSectionLength)
+				length -= ngramAsciiMaxSectionLength
+				if len(ao.entries)%asciiNgramOffsetChunkLength == 0 {
+					// We reached the end of the chunk, so there's no need to reach the
+					// offset for the next entry.
+					break
+				}
+			}
+		}
+	}
+
+	ao.entries = shrinkUint32Slice(ao.entries)
+	ao.chunkOffsets = shrinkUint32Slice(ao.chunkOffsets)
+
+	return ao
+}
+
+// Get returns a simpleSection with sz=0 if no entry, or sz=ngramAsciiMaxSectionLength
+// if the length of the ngram is too large for this type and it should cascade to the next entry.
+func (a *asciiNgramOffset) Get(gram ngram) simpleSection {
+	if gram&ngramAsciiMask != gram {
+		return simpleSection{}
+	}
+	g := uint32(ngramAsciiToPacked(gram) << 11)
+
+	idx := sort.Search(len(a.entries), func(i int) bool {
+		return a.entries[i] >= g
+	})
+
+	if idx == len(a.entries) || a.entries[idx]>>11 != g>>11 {
+		return simpleSection{}
+	}
+
+	length := a.entries[idx] & ngramAsciiMaxSectionLength
+	if length == ngramAsciiMaxSectionLength {
+		// this ascii ngram's section length is too large to be represented;
+		// repeate the Get() on the unicode map to get the correct result.
+		return simpleSection{
+			off: 0,
+			sz:  ngramAsciiMaxSectionLength,
+		}
+	}
+
+	chunkNum := idx / asciiNgramOffsetChunkLength
+	chunkBase := chunkNum * asciiNgramOffsetChunkLength
+	offset := a.chunkOffsets[chunkNum]
+	for i := chunkBase; i < idx; i++ {
+		offset += a.entries[i] & ngramAsciiMaxSectionLength
+	}
+
+	return simpleSection{
+		off: offset,
+		sz:  length,
+	}
+}
+
+func (a *asciiNgramOffset) DumpMap() map[ngram]simpleSection {
+	m := make(map[ngram]simpleSection, len(a.entries))
+	off := uint32(0)
+	for i, ent := range a.entries {
+		if i%asciiNgramOffsetChunkLength == 0 {
+			off = a.chunkOffsets[i/asciiNgramOffsetChunkLength]
+		}
+		length := ent & ngramAsciiMaxSectionLength
+		if length == ngramAsciiMaxSectionLength {
+			// This entry is an ascii gram with a section too long
+			// to be represented, so skip the entry.
+			continue
+		}
+		m[ngramAsciiPackedToNgram(ngramAscii(ent>>11))] = simpleSection{
+			off: off,
+			sz:  length,
+		}
+		off += length
+	}
+	return m
+}
+
+func (a *asciiNgramOffset) SizeBytes() int {
+	return 4*len(a.entries) + 4*len(a.chunkOffsets)
 }

--- a/read.go
+++ b/read.go
@@ -318,10 +318,10 @@ func (r *reader) readMetadata(toc *indexTOC) (*Repository, *IndexMetadata, error
 
 const ngramEncoding = 8
 
-func (d *indexData) readNgrams(toc *indexTOC) (arrayNgramOffset, error) {
+func (d *indexData) readNgrams(toc *indexTOC) (combinedNgramOffset, error) {
 	textContent, err := d.readSectionBlob(toc.ngramText)
 	if err != nil {
-		return arrayNgramOffset{}, err
+		return combinedNgramOffset{}, err
 	}
 	postingsIndex := toc.postings.relativeIndex()
 
@@ -335,7 +335,7 @@ func (d *indexData) readNgrams(toc *indexTOC) (arrayNgramOffset, error) {
 		ngrams = append(ngrams, ng)
 	}
 
-	return makeArrayNgramOffset(ngrams, postingsIndex), nil
+	return makeCombinedNgramOffset(ngrams, postingsIndex), nil
 }
 
 func (d *indexData) readFileNameNgrams(toc *indexTOC) (map[ngram][]byte, error) {


### PR DESCRIPTION
Most ngrams are of ASCII text and have small amounts of data. This
exploits this by packing three 7-bit runes and an 11-bit length into a
single 32-bit entry, with some extra logic to have periodic offsets to
easily reconstruct simpleSection{offset, length} with a fixed maximum
amount of extra computation.

This drops ngramOffset RAM from 3.6GB (69% of total) to 2.3GB (59%),
with asciiNgramOffsets taking 1.7GB (44%) and arrayNgramOffsets taking
0.6GB (15%).

Unfortunately, this increases CPU usage when loading the index--
readIndexData increases from 13s to 18s, with the main call of
readNgrams cpu time doubling from 5s to 10s.

This also adds a more comprehensive test to exercise the various
boundary conditions of the ascii/unicode splitting logic.

---

\>95% of running zoekt-webserver memory usage is due to indexData structs, so this will effectively shrink the steady-state memory usage of zoekt servers hosting many shards.

These memory optimizations have two main methods:

1) lazily decode deltas during search time when possible (filenameNgrams, runeDocSections). These attributes are only used for somewhat uncommon search types `file:` and `symbol:`, and the volume of decoded deltas is still _far_ less than the amount of deltas that are decoded during a normal indexed search operation, so the impact should be negligible.

2) convert some excessively large indexes with `O(1)` access times to smaller `O(log(n))` access time indexes (ngrams, runeOffsets). This is the motivation for the patch series, where the overhead of `map[ngram]simpleSection` (a 64 bit to 64 bit map) could be greatly reduced. The slightly increased time complexity _shouldn't_ matter, given that most search CPU time is spent processing the actual trigram lists.

As a bonus, index loading is 2.2x faster, going from 5.6s->2.5s wall clock and 54s->22s cpu time.

In terms of memory usage, loading 18855 shards from popular repositories (all the shards on one node of sourcegraph.com) went from this:
![image](https://user-images.githubusercontent.com/211868/122507163-ef44d900-cfbc-11eb-8051-50b5e4104649.png)

To this:
![image](https://user-images.githubusercontent.com/211868/122506983-9c6b2180-cfbc-11eb-8a3d-bc944cceab47.png)