### PR TITLE
indexData: support multiple repositories

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -404,13 +404,13 @@ func (d *indexData) branchIndex(docID uint32) int {
 func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTree]bool) []string {
 	foundBranchQuery := false
 	var branches []string
-
+	repoIdx := d.repos[docID]
 	visitMatches(mt, known, func(mt matchTree) {
 		bq, ok := mt.(*branchQueryMatchTree)
 		if ok {
 			foundBranchQuery = true
 			branches = append(branches,
-				d.branchNames[d.repos[docID]][uint(bq.mask)])
+				d.branchNames[repoIdx][uint(bq.masks[repoIdx])])
 		}
 	})
 

--- a/eval.go
+++ b/eval.go
@@ -39,7 +39,7 @@ func (m *FileMatch) addScore(what string, s float64) {
 	m.Score += s
 }
 
-// simplifyMultiRepo takes a query and a predicate. It return Const(true) if all
+// simplifyMultiRepo takes a query and a predicate. It returns Const(true) if all
 // repository names fulfill the predicate, Const(false) if none of them do, and q
 // otherwise.
 func (d *indexData) simplifyMultiRepo(q query.Q, predicate func(repoName string) bool) query.Q {

--- a/eval.go
+++ b/eval.go
@@ -51,8 +51,8 @@ func (d *indexData) simplify(in query.Q) query.Q {
 				if strings.Contains(md.Name, r.Pattern) {
 					return q
 				}
-				return &query.Const{Value: false}
 			}
+			return &query.Const{Value: false}
 		case *query.RepoBranches:
 			if simpleShard {
 				return r.Branches(d.repoMetaData[0].Name)
@@ -63,7 +63,6 @@ func (d *indexData) simplify(in query.Q) query.Q {
 				}
 			}
 			return &query.Const{Value: false}
-
 		case *query.RepoSet:
 			if simpleShard {
 				return &query.Const{Value: r.Set[d.repoMetaData[0].Name]}

--- a/eval.go
+++ b/eval.go
@@ -218,10 +218,10 @@ nextFileMatch:
 		}
 
 		if s := d.subRepos[nextDoc]; s > 0 {
-			if s >= uint32(len(d.subRepoPaths)) {
+			if s >= uint32(len(d.subRepoPaths[d.repos[nextDoc]])) {
 				log.Panicf("corrupt index: subrepo %d beyond %v", s, d.subRepoPaths)
 			}
-			path := d.subRepoPaths[s]
+			path := d.subRepoPaths[d.repos[nextDoc]][s]
 			fileMatch.SubRepositoryPath = path
 			sr := md.SubRepoMap[path]
 			fileMatch.SubRepositoryName = sr.Name
@@ -419,7 +419,7 @@ func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTr
 		id := uint32(1)
 		for mask != 0 {
 			if mask&0x1 != 0 {
-				branches = append(branches, d.branchNames[d.repos[docID]][uint(id)])
+				branches = append(branches, d.branchNames[repoIdx][uint(id)])
 			}
 			id <<= 1
 			mask >>= 1

--- a/eval.go
+++ b/eval.go
@@ -44,11 +44,11 @@ func (d *indexData) simplify(in query.Q) query.Q {
 	eval := query.Map(in, func(q query.Q) query.Q {
 		switch r := q.(type) {
 		case *query.Repo:
-			if simpleShard {
-				return &query.Const{Value: strings.Contains(d.repoMetaData[0].Name, r.Pattern)}
-			}
 			for _, md := range d.repoMetaData {
 				if strings.Contains(md.Name, r.Pattern) {
+					if simpleShard {
+						return &query.Const{Value: true}
+					}
 					return q
 				}
 			}
@@ -64,11 +64,11 @@ func (d *indexData) simplify(in query.Q) query.Q {
 			}
 			return &query.Const{Value: false}
 		case *query.RepoSet:
-			if simpleShard {
-				return &query.Const{Value: r.Set[d.repoMetaData[0].Name]}
-			}
 			for _, md := range d.repoMetaData {
 				if r.Set[md.Name] {
+					if simpleShard {
+						return &query.Const{Value: true}
+					}
 					return q
 				}
 			}

--- a/eval_test.go
+++ b/eval_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt/query"
 )
 
@@ -123,5 +124,92 @@ func TestRegexpParse(t *testing.T) {
 			printRegexp(t, r, 0)
 			t.Errorf("regexpToQuery(%q): got %v, want %v", c.in, isEq, c.isEquivalent)
 		}
+	}
+}
+
+func TestSimplifyRepoSet(t *testing.T) {
+	d := &indexData{
+		repoMetaData: []Repository{{Name: "foo"}, {Name: "bar"}},
+	}
+	all := &query.RepoSet{Set: map[string]bool{"foo": true, "bar": true}}
+	some := &query.RepoSet{Set: map[string]bool{"foo": true, "banana": true}}
+	none := &query.RepoSet{Set: map[string]bool{"banana": true}}
+
+	got := d.simplify(all)
+	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	got = d.simplify(some)
+	if d := cmp.Diff(some, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	got = d.simplify(none)
+	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+}
+
+func TestSimplifyRepo(t *testing.T) {
+	d := &indexData{
+		repoMetaData: []Repository{{Name: "foo"}, {Name: "fool"}},
+	}
+	all := &query.Repo{"foo"}
+	some := &query.Repo{"fool"}
+	none := &query.Repo{"bar"}
+
+	got := d.simplify(all)
+	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	got = d.simplify(some)
+	if d := cmp.Diff(some, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	got = d.simplify(none)
+	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+}
+
+func TestSimplifyRepoBranch(t *testing.T) {
+	d := &indexData{
+		repoMetaData: []Repository{{Name: "foo"}, {Name: "bar"}},
+	}
+
+	some := &query.RepoBranches{Set: map[string][]string{"bar": {"branch1"}}}
+	none := &query.Repo{"banana"}
+
+	got := d.simplify(some)
+	if d := cmp.Diff(some, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	got = d.simplify(none)
+	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+}
+
+func TestSimplifyRepoBranchSimple(t *testing.T) {
+	d := &indexData{
+		repoMetaData: []Repository{{Name: "foo"}},
+	}
+	q := &query.RepoBranches{Set: map[string][]string{"foo": {"HEAD", "b1"}, "bar": {"HEAD"}}}
+
+	want := &query.Or{[]query.Q{&query.Branch{
+		Pattern: "HEAD",
+		Exact:   true,
+	}, &query.Branch{
+		Pattern: "b1",
+		Exact:   true,
+	}}}
+
+	got := d.simplify(q)
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
 	}
 }

--- a/indexdata.go
+++ b/indexdata.go
@@ -78,7 +78,7 @@ type indexData struct {
 	repoMetaData []Repository
 
 	subRepos     []uint32
-	subRepoPaths []string
+	subRepoPaths [][]string
 
 	// Checksums for all the files, at 8-byte intervals
 	checksums []byte
@@ -91,7 +91,7 @@ type indexData struct {
 
 	repoListEntry []RepoListEntry
 
-	// repos for all the files.
+	// repository indexes for all the files.
 	repos []uint16
 
 	// maps repository names to their index

--- a/indexdata.go
+++ b/indexdata.go
@@ -93,9 +93,6 @@ type indexData struct {
 
 	// repository indexes for all the files
 	repos []uint16
-
-	// maps repository names to their index
-	repoMap map[string]uint16
 }
 
 type symbolData struct {

--- a/indexdata.go
+++ b/indexdata.go
@@ -91,7 +91,7 @@ type indexData struct {
 
 	repoListEntry []RepoListEntry
 
-	// repository indexes for all the files.
+	// repository indexes for all the files
 	repos []uint16
 
 	// maps repository names to their index
@@ -160,7 +160,8 @@ func (d *indexData) getChecksum(idx uint32) []byte {
 	return d.checksums[start : start+crc64.Size]
 }
 
-// TODO (stefan): Calculate stats per repo.
+// TODO (stefan): Update this function to return meaningful stats for compound
+// shards.
 func (d *indexData) calculateStatsForRepoIndex(i int) RepoListEntry {
 	var last uint32
 	if len(d.boundaries) > 0 {

--- a/matchtree.go
+++ b/matchtree.go
@@ -897,6 +897,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			all:       regexp.String() == "(?i)(?-s:.)*",
 			matchTree: subMT,
 		}, nil
+
 	case *query.RepoBranches:
 		reposBranchesWant := make(map[uint16]uint64)
 		for _, r := range d.repoMetaData {
@@ -948,6 +949,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 		return &docMatchTree{
 			docs: d.filterDocs(pred),
 		}, nil
+
 	case *query.Repo:
 		var reposWant map[uint16]struct{}
 		for _, r := range d.repoMetaData {
@@ -971,9 +973,9 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 	return nil, nil
 }
 
-// filterDocs returns a slice those docIDs for which predicate(docID) = true.
+// filterDocs returns a slice of those docIDs for which predicate(docID) = true.
 func (d *indexData) filterDocs(predicate func(docID uint32) bool) []uint32 {
-	docs := []uint32{}
+	var docs []uint32
 	for i := uint32(0); i < uint32(len(d.fileBranchMasks)); i++ {
 		if predicate(i) {
 			docs = append(docs, i)

--- a/matchtree.go
+++ b/matchtree.go
@@ -624,7 +624,7 @@ func (t *orMatchTree) matches(cp *contentProvider, cost int, known map[matchTree
 }
 
 func (t *branchQueryMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) (bool, bool) {
-	return t.fileMasks[t.docID]&t.masks[t.repos[cp.idx]] != 0, true
+	return t.fileMasks[t.docID]&t.masks[t.repos[t.docID]] != 0, true
 }
 
 func (t *regexpMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) (bool, bool) {

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -225,3 +225,73 @@ func TestSymbolMatchRegexAll(t *testing.T) {
 		}
 	}
 }
+
+func TestRepoSet(t *testing.T) {
+	d := &indexData{
+		repoMetaData:    []Repository{{Name: "r0"}, {Name: "r1"}, {Name: "r2"}, {Name: "r3"}},
+		fileBranchMasks: []uint64{1, 1, 1, 1, 1, 1},
+		repos:           []uint16{0, 0, 1, 2, 3, 3},
+	}
+	mt, err := d.newMatchTree(&query.RepoSet{Set: map[string]bool{"r1": true, "r3": true, "r99": true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint32{2, 4, 5}
+	for i := 0; i < len(want); i++ {
+		nextDoc := mt.nextDoc()
+		if nextDoc != want[i] {
+			t.Fatalf("want %d, got %d", want[i], nextDoc)
+		}
+		mt.prepare(nextDoc)
+	}
+	if mt.nextDoc() != maxUInt32 {
+		t.Fatalf("expected %d document, but got at least 1 more", len(want))
+	}
+}
+
+func TestRepo(t *testing.T) {
+	d := &indexData{
+		repoMetaData:    []Repository{{Name: "foo"}, {Name: "bar"}},
+		fileBranchMasks: []uint64{1, 1, 1, 1, 1},
+		repos:           []uint16{0, 0, 1, 0, 1},
+	}
+	mt, err := d.newMatchTree(&query.Repo{"ar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint32{2, 4}
+	for i := 0; i < len(want); i++ {
+		nextDoc := mt.nextDoc()
+		if nextDoc != want[i] {
+			t.Fatalf("want %d, got %d", want[i], nextDoc)
+		}
+		mt.prepare(nextDoc)
+	}
+	if mt.nextDoc() != maxUInt32 {
+		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
+	}
+}
+
+func TestRepoBranches(t *testing.T) {
+	d := &indexData{
+		repoMetaData:    []Repository{{Name: "foo"}, {Name: "bar"}},
+		fileBranchMasks: []uint64{1, 1, 1, 2, 1, 2, 1},
+		repos:           []uint16{0, 0, 1, 1, 1, 1, 1},
+		branchIDs:       []map[string]uint{{"HEAD": 1}, {"HEAD": 1, "b1": 2}},
+	}
+	mt, err := d.newMatchTree(&query.RepoBranches{Set: map[string][]string{"bar": {"b1", "b2"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint32{3, 5}
+	for i := 0; i < len(want); i++ {
+		nextDoc := mt.nextDoc()
+		if nextDoc != want[i] {
+			t.Fatalf("want %d, got %d", want[i], nextDoc)
+		}
+		mt.prepare(nextDoc)
+	}
+	if mt.nextDoc() != maxUInt32 {
+		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
+	}
+}

--- a/read.go
+++ b/read.go
@@ -291,13 +291,6 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	}
 	d.repos = repos
 
-	// This doesn't need to be stored on disk. We can recreate it on read.
-	rm := make(map[string]uint16)
-	for i, md := range d.repoMetaData {
-		rm[md.Name] = uint16(i)
-	}
-	d.repoMap = rm
-
 	d.calculateStats()
 	return &d, nil
 }

--- a/read.go
+++ b/read.go
@@ -283,8 +283,8 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	// This is a hack for now. We should store "repos" in the shard with
-	// indexBuilder.
+	// This is a hack for now to keep the shard format unchanged. To support shard
+	// merging we will store "repos" in the shard.
 	repos := make([]uint16, 0, len(d.fileBranchMasks))
 	for i := 0; i < len(d.fileBranchMasks); i++ {
 		repos = append(repos, 0) // just support 1 repo for now.

--- a/read.go
+++ b/read.go
@@ -15,7 +15,6 @@
 package zoekt
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -168,18 +167,9 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	// This is not required once all shards save repoMetaData as lists.
-	x := bytes.TrimLeft(blob, " \t\r\n")
-	isObject := len(x) > 0 && x[0] == '{'
-	if isObject {
-		d.repoMetaData = make([]Repository, 1)
-		if err := json.Unmarshal(blob, &d.repoMetaData[0]); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := json.Unmarshal(blob, &d.repoMetaData); err != nil {
-			return nil, err
-		}
+	d.repoMetaData = make([]Repository, 1)
+	if err := json.Unmarshal(blob, &d.repoMetaData[0]); err != nil {
+		return nil, err
 	}
 
 	d.boundariesStart = toc.fileContents.data.off

--- a/read.go
+++ b/read.go
@@ -293,7 +293,8 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	// This is a hack for now. We should store it in the shard with indexBuilder.
+	// This is a hack for now. We should store "repos" in the shard with
+	// indexBuilder.
 	repos := make([]uint16, 0, len(d.fileBranchMasks))
 	for i := 0; i < len(d.fileBranchMasks); i++ {
 		repos = append(repos, 0) // just support 1 repo for now.

--- a/read.go
+++ b/read.go
@@ -168,10 +168,9 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	// Not required once all shards are saved a lists of objects.
+	// This is not required once all shards save repoMetaData as lists.
 	x := bytes.TrimLeft(blob, " \t\r\n")
 	isObject := len(x) > 0 && x[0] == '{'
-
 	if isObject {
 		d.repoMetaData = make([]Repository, 1)
 		if err := json.Unmarshal(blob, &d.repoMetaData[0]); err != nil {
@@ -275,13 +274,14 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		}
 	}
 
+	d.subRepoPaths = make([][]string, 0, len(d.repoMetaData))
 	for i := 0; i < len(d.repoMetaData); i++ {
-		var keys []string
+		keys := make([]string, 0, len(d.repoMetaData[i].SubRepoMap))
 		for k := range d.repoMetaData[i].SubRepoMap {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)
-		d.subRepoPaths = append(d.subRepoPaths, keys...)
+		d.subRepoPaths = append(d.subRepoPaths, keys)
 	}
 
 	d.languageMap = map[byte]string{}

--- a/read.go
+++ b/read.go
@@ -293,14 +293,14 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	// This is a hack for now. We should read this from disk.
+	// This is a hack for now. We should store it in the shard with indexBuilder.
 	repos := make([]uint16, 0, len(d.fileBranchMasks))
 	for i := 0; i < len(d.fileBranchMasks); i++ {
 		repos = append(repos, 0) // just support 1 repo for now.
 	}
 	d.repos = repos
 
-	// This doesn't need to be stored on disk. It can be recreated on read.
+	// This doesn't need to be stored on disk. We can recreate it on read.
 	rm := make(map[string]uint16)
 	for i, md := range d.repoMetaData {
 		rm[md.Name] = uint16(i)


### PR DESCRIPTION
This changes `indexData` to support multiple repositories. 

Some fields of `indexData`, such as `fileBranchMask`, are document-based and
naturally support multiple repos. For other fields, such as `branchNames`, we
convert old types to slices, where each item corresponds to a repository stored
in the shard. 

As a consequence we have to update `simplify` and support those query types, which
where previously removed by simplify (Repo, RepoBranches, RepoSet).

The on-disk format of shards is unchanged, but we update `readIndexData` to read
existing shard into the new format.

Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>