### PR TITLE
indexdata: condense runeOffsets into a shorter form.

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -16,6 +16,7 @@ package zoekt
 
 import (
 	"encoding/binary"
+	"sort"
 	"unicode"
 	"unicode/utf8"
 )
@@ -265,4 +266,70 @@ func fromDeltas(data []byte, buf []uint32) []uint32 {
 		buf = append(buf, offset)
 	}
 	return buf
+}
+
+type runeOffsetCorrection struct {
+	runeOffset, byteOffset uint32
+}
+
+// runeOffsetMap converts from rune offsets (with granularity runeOffsetFrequency)
+// to byte offsets, by tracking only the points where a span of runes is non-ASCII,
+// and otherwise interpolating expected byte offsets as one byte per rune.
+//
+// Instead of storing [100, 205, 305], it stores [{x: 200, y: 205}].
+//
+// This is very rarely a slight pessimization on repos where there are frequent
+// non-ASCII characters.
+type runeOffsetMap []runeOffsetCorrection
+
+// makeRuneOffsetMap converts the mostly-predictable runeOffset input
+// into a shorter form tracking the unexpected values.
+//
+// The input is a sequence of y values that we expect to increase by 100 each,
+// so we just store (x, y) points where the expectation is violated.
+func makeRuneOffsetMap(off []uint32) runeOffsetMap {
+	expected := uint32(0)
+	tmp := []runeOffsetCorrection{}
+	for runeOffset, byteOffset := range off {
+		if byteOffset != expected {
+			tmp = append(tmp, runeOffsetCorrection{uint32(runeOffset) * runeOffsetFrequency, byteOffset})
+			expected = byteOffset
+		}
+		expected += runeOffsetFrequency
+	}
+	// copy the slice to ensure it doesn't waste unused trailing capacity
+	out := make([]runeOffsetCorrection, len(tmp))
+	copy(out, tmp)
+	return runeOffsetMap(out)
+}
+
+// lookup converts rune index `off` to a byte offset and a number of additional
+// runes to traverse, given the granularity of runeOffsetFrequency.
+//
+// It does this by finding the nearest point to interpolate from in the map.
+func (m runeOffsetMap) lookup(runeOffset uint32) (uint32, uint32) {
+	left := runeOffset % runeOffsetFrequency
+	runeOffset -= left
+	slen := len(m)
+	if slen == 0 {
+		return runeOffset, left
+	}
+	// sort.Search finds the *first* index for which the predicate is true,
+	// but we want to find the *last* index for which the predicate is true.
+	// This involves some work to reverse the index directions.
+	idx := sort.Search(slen, func(i int) bool {
+		return runeOffset >= m[slen-1-i].runeOffset
+	})
+	idx = slen - 1 - idx
+	// idx is now in the range [-1, len(m))-- -1 indicates that the offset is smaller
+	// than the first entry in the map, so no correction is necessary.
+	byteOff := runeOffset
+	if idx >= 0 {
+		byteOff = m[idx].byteOffset + runeOffset - m[idx].runeOffset
+	}
+	return byteOff, left
+}
+
+func (m runeOffsetMap) sizeBytes() int {
+	return 8 * len(m)
 }

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -107,8 +107,7 @@ func (p *contentProvider) findOffset(filename bool, r uint32) uint32 {
 		absR += runeEnds[p.idx-1]
 	}
 
-	byteOff := sample[absR/runeOffsetFrequency]
-	left := absR % runeOffsetFrequency
+	byteOff, left := sample.lookup(absR)
 
 	var data []byte
 

--- a/indexdata.go
+++ b/indexdata.go
@@ -44,7 +44,7 @@ type indexData struct {
 	runeDocSections []byte
 
 	// rune offset=>byte offset mapping, relative to the start of the content corpus
-	runeOffsets []uint32
+	runeOffsets runeOffsetMap
 
 	// offsets of file contents; includes end of last file
 	boundariesStart uint32
@@ -61,7 +61,7 @@ type indexData struct {
 	fileEndSymbol []uint32
 
 	// rune offset=>byte offset mapping, relative to the start of the filename corpus
-	fileNameRuneOffsets []uint32
+	fileNameRuneOffsets runeOffsetMap
 
 	// rune offsets for the file name boundaries
 	fileNameEndRunes []uint32
@@ -248,12 +248,13 @@ func (d *indexData) memoryUse() int {
 	for _, a := range [][]uint32{
 		d.newlinesIndex, d.docSectionsIndex,
 		d.boundaries, d.fileNameIndex,
-		d.runeOffsets, d.fileNameRuneOffsets,
 		d.fileEndRunes, d.fileNameEndRunes,
 		d.fileEndSymbol, d.symbols.symKindIndex,
 	} {
 		sz += 4 * len(a)
 	}
+	sz += d.runeOffsets.sizeBytes()
+	sz += d.fileNameRuneOffsets.sizeBytes()
 	sz += 8 * len(d.runeDocSections)
 	sz += 8 * len(d.fileBranchMasks)
 	sz += d.ngrams.SizeBytes()

--- a/read.go
+++ b/read.go
@@ -245,10 +245,12 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	}
 	d.runeDocSections = blob
 
+	var runeOffsets, fileNameRuneOffsets []uint32
+
 	for sect, dest := range map[simpleSection]*[]uint32{
 		toc.subRepos:        &d.subRepos,
-		toc.runeOffsets:     &d.runeOffsets,
-		toc.nameRuneOffsets: &d.fileNameRuneOffsets,
+		toc.runeOffsets:     &runeOffsets,
+		toc.nameRuneOffsets: &fileNameRuneOffsets,
 		toc.nameEndRunes:    &d.fileNameEndRunes,
 		toc.fileEndRunes:    &d.fileEndRunes,
 	} {
@@ -258,6 +260,9 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 			*dest = fromSizedDeltas(blob, nil)
 		}
 	}
+
+	d.runeOffsets = makeRuneOffsetMap(runeOffsets)
+	d.fileNameRuneOffsets = makeRuneOffsetMap(fileNameRuneOffsets)
 
 	d.subRepoPaths = make([][]string, 0, len(d.repoMetaData))
 	for i := 0; i < len(d.repoMetaData); i++ {


### PR DESCRIPTION
Instead of storing ys for xs in range(0, len(docs), 100), store the ys
where they aren't a continuation of the previously predictable line.

For example, {0, 105, 205, 305, 430} => {{100, 105}, {400, 430}}.

In a test, this reduces runeOffset memory usage from 2.3GB (12% of
total) to 0.2GB (1% of total).