### PR TITLE
indexdata: convert ngrams from a map into a two-level slice-based index.

### DIFF
--- a/hititer.go
+++ b/hititer.go
@@ -128,7 +128,7 @@ func (d *indexData) trigramHitIterator(ng ngram, caseSensitive, fileName bool) (
 			continue
 		}
 
-		sec := d.ngrams[v]
+		sec := d.ngrams.Get(v)
 		blob, err := d.readSectionBlob(sec)
 		if err != nil {
 			return nil, err

--- a/indexdata.go
+++ b/indexdata.go
@@ -33,7 +33,7 @@ type indexData struct {
 
 	file IndexFile
 
-	ngrams map[ngram]simpleSection
+	ngrams arrayNgramOffset
 
 	newlinesStart uint32
 	newlinesIndex []uint32
@@ -244,7 +244,7 @@ func (d *indexData) memoryUse() int {
 	}
 	sz += 8 * len(d.runeDocSections)
 	sz += 8 * len(d.fileBranchMasks)
-	sz += 12 * len(d.ngrams)
+	sz += d.ngrams.SizeBytes()
 	for _, v := range d.fileNameNgrams {
 		sz += 4*len(v) + 4
 	}
@@ -282,7 +282,7 @@ func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
 		return uint32(len(data.fileNameNgrams[ng]))
 	}
 
-	return data.ngrams[ng].sz
+	return data.ngrams.Get(ng).sz
 }
 
 type ngramIterationResults struct {

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -1,0 +1,114 @@
+// Copyright 2021 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zoekt
+
+import (
+	"sort"
+)
+
+type topOffset struct {
+	top, off uint32
+}
+
+// arrayNgramOffset splits ngrams into two 32-bit parts and uses binary search
+// to satisfy requests. A three-level trie (over the runes of an ngram) uses 20%
+// more memory than this simple two-level split.
+type arrayNgramOffset struct {
+	// tops specify where the bottom halves of ngrams with the 32-bit top half begin.
+	// The offset of the next value is used to find where the bottom section ends.
+	tops []topOffset
+
+	// bots are bottom halves of an ngram, referenced by tops
+	bots []uint32
+
+	// offsets is values from simpleSection.off, simpleSection.sz is computed by subtracting
+	// adjacent offsets.
+	offsets []uint32
+}
+
+func makeArrayNgramOffset(ngrams []ngram, offsets []uint32) arrayNgramOffset {
+	arr := arrayNgramOffset{
+		bots:    make([]uint32, 0, len(ngrams)),
+		offsets: make([]uint32, len(offsets)),
+	}
+	copy(arr.offsets, offsets) // copy to ensure offsets is minimally sized
+
+	lastTop := uint32(0xffffffff)
+	lastStart := uint32(0)
+	for i, v := range ngrams {
+		curTop := uint32(v >> 32)
+		if curTop != lastTop {
+			if lastTop != 0xffffffff {
+				arr.tops = append(arr.tops, topOffset{lastTop, lastStart})
+			}
+			lastTop = curTop
+			lastStart = uint32(i)
+		}
+		arr.bots = append(arr.bots, uint32(v))
+	}
+	// add a sentinel value to make it simple to compute sizes
+	arr.tops = append(arr.tops, topOffset{lastTop, lastStart}, topOffset{0xffffffff, uint32(len(arr.bots))})
+
+	// shrink arr.tops to minimal size
+	tops := make([]topOffset, len(arr.tops))
+	copy(tops, arr.tops)
+	arr.tops = tops
+
+	return arr
+}
+
+func (a *arrayNgramOffset) Get(gram ngram) simpleSection {
+	if a.tops == nil {
+		return simpleSection{}
+	}
+
+	top, bot := uint32(uint64(gram)>>32), uint32(gram)
+
+	topIdx := sort.Search(len(a.tops)-1, func(i int) bool { return a.tops[i].top >= top })
+	if topIdx == len(a.tops)-1 || a.tops[topIdx].top != top {
+		return simpleSection{}
+	}
+
+	botsSec := a.bots[a.tops[topIdx].off:a.tops[topIdx+1].off]
+	botIdx := sort.Search(len(botsSec), func(i int) bool { return botsSec[i] >= bot })
+	if botIdx == len(botsSec) || botsSec[botIdx] != bot {
+		return simpleSection{}
+	}
+	idx := botIdx + int(a.tops[topIdx].off)
+	return simpleSection{
+		off: a.offsets[idx],
+		sz:  a.offsets[idx+1] - a.offsets[idx],
+	}
+}
+
+func (a *arrayNgramOffset) DumpMap() map[ngram]simpleSection {
+	m := make(map[ngram]simpleSection, len(a.offsets)-1)
+	for i := 0; i < len(a.tops)-1; i++ {
+		top, botStart, botEnd := a.tops[i].top, a.tops[i].off, a.tops[i+1].off
+		botSec := a.bots[botStart:botEnd]
+		for j, bot := range botSec {
+			idx := int(botStart) + j
+			m[ngram(uint64(top)<<32|uint64(bot))] = simpleSection{
+				off: a.offsets[idx],
+				sz:  a.offsets[idx+1] - a.offsets[idx],
+			}
+		}
+	}
+	return m
+}
+
+func (a *arrayNgramOffset) SizeBytes() int {
+	return 8*len(a.tops) + 4*len(a.bots) + 4*len(a.offsets)
+}

--- a/ngramoffset_test.go
+++ b/ngramoffset_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zoekt
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMakeArrayNgramOffset(t *testing.T) {
+	for n, tc := range []struct {
+		ngrams  []string
+		offsets []uint32
+	}{
+		{nil, nil},
+		{[]string{"ant", "any", "awl", "big", "bin", "bit", "can", "con"}, []uint32{0, 2, 5, 8, 10, 14, 18, 25, 30}},
+	} {
+		ngrams := []ngram{}
+		for _, s := range tc.ngrams {
+			ngrams = append(ngrams, stringToNGram(s))
+		}
+		m := makeArrayNgramOffset(ngrams, tc.offsets)
+		t.Logf("makeNgramOffset(%v, %v) => %s", tc.ngrams, tc.offsets, &m)
+		failn := stringToNGram("foo")
+		if getFail := m.Get(failn); getFail != (simpleSection{}) {
+			t.Errorf("#%d: Get(%q) got %v, want zero", n, failn, getFail)
+		}
+		for i := 0; i < len(tc.offsets)-1; i++ {
+			want := simpleSection{tc.offsets[i], tc.offsets[i+1] - tc.offsets[i]}
+			got := m.Get(ngrams[i])
+			if want != got {
+				t.Errorf("#%d.%d: Get(%q) got %v, want %v", n, i, tc.ngrams[i], got, want)
+			}
+			failn := ngram(uint64(ngrams[i] - 1))
+			if getFail := m.Get(failn); getFail != (simpleSection{}) {
+				t.Errorf("#%d.%d: Get(%q) got %v, want zero", n, i, failn, getFail)
+			}
+			failn = ngram(uint64(ngrams[i] + 1))
+			if getFail := m.Get(failn); getFail != (simpleSection{}) {
+				t.Errorf("#%d.%d: Get(%q) got %v, want zero", n, i, failn, getFail)
+			}
+		}
+	}
+}
+
+func (a *arrayNgramOffset) String() string {
+	o := "arrayNgramOffset{tops:{"
+	for i, p := range a.tops {
+		if i > 0 {
+			o += ", "
+		}
+		if p.top&1023 == 0 {
+			// only one rune is represented here
+			o += fmt.Sprintf("%s: %d", string(rune(p.top>>10)), p.off)
+		} else {
+			o += fmt.Sprintf("%x: %d", p.top>>10, p.off)
+		}
+	}
+	o += "}, bots: {"
+	for i, p := range a.bots {
+		if i > 0 {
+			o += ", "
+		}
+		if p < (256 << 21) {
+			// two ascii-ish runes (probably)
+			o += fmt.Sprintf("%s%s", string(rune(p>>21)), string(rune(p&runeMask)))
+		} else {
+			o += fmt.Sprintf("%x", p)
+		}
+	}
+	o += fmt.Sprintf("}, offsets: %v}", a.offsets)
+	return o
+}

--- a/read_test.go
+++ b/read_test.go
@@ -64,12 +64,12 @@ func TestReadWrite(t *testing.T) {
 		t.Errorf("got filename %q, want %q", got, "filename")
 	}
 
-	if len(data.ngrams) != 3 {
+	if len(data.ngrams.DumpMap()) != 3 {
 		t.Fatalf("got ngrams %v, want 3 ngrams", data.ngrams)
 	}
 
-	if _, ok := data.ngrams[stringToNGram("bcq")]; ok {
-		t.Errorf("found ngram bcd in %v", data.ngrams)
+	if sec := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
+		t.Errorf("found ngram bcq (%v) in %v", uint64(stringToNGram("bcq")), data.ngrams)
 	}
 }
 


### PR DESCRIPTION
It has O(log(N)) lookups instead of O(1), but also a good deal less
memory usage-- corpus RAM usage for ngram offsets went from 14.5GB (90%)
to 3.5GB (68% of total).

For comparison, simply storing the ngrams and offsets in slices uses
5.1GB of RAM (75% of total).

Also, optimize index load by not building an intermediate ngram map.
This cuts CPU time to load the test corpus from 70s to 15s.