### PR TITLE
remove v15 read support

### DIFF
--- a/read.go
+++ b/read.go
@@ -77,7 +77,7 @@ func (r *reader) readTOC(toc *indexTOC) error {
 		return err
 	}
 
-	secs := toc.sectionsHACK(sectionCount)
+	secs := toc.sections()
 
 	if len(secs) != int(sectionCount) {
 		return fmt.Errorf("section count mismatch: got %d want %d", sectionCount, len(secs))
@@ -154,11 +154,7 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	ensureSourcegraphSymbolsHack()
-
-	// Once we are not on version 16 use this code again
-	// if d.metaData.IndexFormatVersion != IndexFormatVersion {
-	if d.metaData.IndexFormatVersion != 16 && d.metaData.IndexFormatVersion != 15 {
+	if d.metaData.IndexFormatVersion != IndexFormatVersion {
 		return nil, fmt.Errorf("file is v%d, want v%d", d.metaData.IndexFormatVersion, IndexFormatVersion)
 	}
 

--- a/read_test.go
+++ b/read_test.go
@@ -142,7 +142,7 @@ func TestReadSearch(t *testing.T) {
 		&query.Symbol{Expr: &query.Regexp{Regexp: mustParseRE("sage$")}},
 	}
 
-	shards := []string{"ctagsrepo_v16.00000", "repo_v15.00000", "repo_v16.00000"}
+	shards := []string{"ctagsrepo_v16.00000", "repo_v16.00000"}
 	for _, name := range shards {
 		shard, err := loadShard("testdata/shards/" + name + ".zoekt")
 		if err != nil {

--- a/toc.go
+++ b/toc.go
@@ -42,23 +42,6 @@ const IndexFormatVersion = 16
 // 9: Store ctags metadata & bump default max file size
 const FeatureVersion = 9
 
-func init() {
-	ensureSourcegraphSymbolsHack()
-}
-
-func ensureSourcegraphSymbolsHack() {
-	if IndexFormatVersion != 16 {
-		panic(`Sourcegraph: While we are on version 16 we have added code into
-	read.go which supports reading IndexFormatVersion 15. If you change the
-	IndexFormatVersion please reach out to Kevin and Keegan.`)
-	}
-	if FeatureVersion != 9 {
-		panic(`Sourcegraph: While we are on FeatureVersion 9 we have added code into
-	read.go which supports reading FeatureVersion 8. If you change the
-	FeatureVersion please reach out to Kevin and Keegan.`)
-	}
-}
-
 type indexTOC struct {
 	fileContents compoundSection
 	fileNames    compoundSection
@@ -86,39 +69,6 @@ type indexTOC struct {
 	nameEndRunes     simpleSection
 	contentChecksums simpleSection
 	runeDocSections  simpleSection
-}
-
-func (t *indexTOC) sectionsHACK(expectedSectionCount uint32) []section {
-	ensureSourcegraphSymbolsHack()
-
-	// Sourcegraph hack for v15.
-	if expectedSectionCount == 19 {
-		return []section{
-			// This must be first, so it can be reliably read across
-			// file format versions.
-			&t.metaData,
-			&t.repoMetaData,
-			&t.fileContents,
-			&t.fileNames,
-			&t.fileSections,
-			&t.newlines,
-			&t.ngramText,
-			&t.postings,
-			&t.nameNgramText,
-			&t.namePostings,
-			&t.branchMasks,
-			&t.subRepos,
-			&t.runeOffsets,
-			&t.nameRuneOffsets,
-			&t.fileEndRunes,
-			&t.nameEndRunes,
-			&t.contentChecksums,
-			&t.languages,
-			&t.runeDocSections,
-		}
-	}
-
-	return t.sections()
 }
 
 func (t *indexTOC) sections() []section {


### PR DESCRIPTION
We have had this backwards compatible code for 2 years. We can remove it. It is possible (but unlikely) an instance still has v15 shard(s). In that case they will all get updated.
