### PR TITLE
stats: support multiple repos

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -464,9 +464,6 @@ func TestEmptyContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBuilder: %v", err)
 	}
-	b.Add(zoekt.Document{
-		Name: "main.go",
-	})
 	if err := b.Finish(); err != nil {
 		t.Errorf("Finish: %v", err)
 	}

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -464,6 +464,9 @@ func TestEmptyContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewBuilder: %v", err)
 	}
+	b.Add(zoekt.Document{
+		Name: "main.go",
+	})
 	if err := b.Finish(); err != nil {
 		t.Errorf("Finish: %v", err)
 	}

--- a/indexdata.go
+++ b/indexdata.go
@@ -227,9 +227,10 @@ func (d *indexData) calculateStats() {
 // time. However, we find these values very useful to track and computing them
 // outside of load time introduces a lot of complexity.
 func (d *indexData) calculateNewLinesStats(start, end uint32) (count, defaultCount, otherCount uint64) {
-	for i, branchMask := range d.fileBranchMasks[start:end] {
+	for i := start; i < end; i++ {
 		// branchMask is a bitmask of the branches for a document. Zoekt by
 		// convention represents the default branch as the lowest bit.
+		branchMask := d.fileBranchMasks[i]
 		isDefault := (branchMask & 1) == 1
 		others := uint64(bits.OnesCount64(branchMask >> 1))
 

--- a/indexdata.go
+++ b/indexdata.go
@@ -204,7 +204,7 @@ func (d *indexData) calculateStatsForFileRange(start, end uint32) RepoStats {
 	}
 }
 
-func (d *indexData) calculateStats() {
+func (d *indexData) calculateStats() error {
 	d.repoListEntry = make([]RepoListEntry, 0, len(d.repoMetaData))
 	var start, end uint32
 	for repoID, md := range d.repoMetaData {
@@ -212,6 +212,11 @@ func (d *indexData) calculateStats() {
 		for end < uint32(len(d.repos)) && d.repos[end] == uint16(repoID) {
 			end++
 		}
+
+		if start < end && d.repos[start] != uint16(repoID) {
+			return fmt.Errorf("shard documents out of order with respect to repositories: expected document %d to be part of repo %d", start, repoID)
+		}
+
 		d.repoListEntry = append(d.repoListEntry, RepoListEntry{
 			Repository:    md,
 			IndexMetadata: d.metaData,
@@ -219,6 +224,8 @@ func (d *indexData) calculateStats() {
 		})
 		start = end
 	}
+
+	return nil
 }
 
 // calculateNewLinesStats computes some Sourcegraph specific statistics for files

--- a/indexdata.go
+++ b/indexdata.go
@@ -171,7 +171,7 @@ func (d *indexData) calculateStatsForFileRange(start, end uint32) RepoListEntry 
 
 	lastFN := last
 	if len(d.fileNameIndex) > int(end) {
-		lastFN = d.fileNameIndex[len(d.fileNameIndex)-1]
+		lastFN = d.fileNameIndex[end]
 	}
 
 	count, defaultCount, otherCount := d.calculateNewLinesStats(start, end)

--- a/read.go
+++ b/read.go
@@ -291,7 +291,10 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	}
 	d.repos = repos
 
-	d.calculateStats()
+	if err := d.calculateStats(); err != nil {
+		return nil, err
+	}
+
 	return &d, nil
 }
 


### PR DESCRIPTION
This updates calculateStats to support multiple repos. The idea is to
compute the file range for each repo and then compute the stats per file
range. A special case is `memoryUse()` which will still return data for
the entire shard.