### PR TITLE
support visibility queries

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -304,6 +304,11 @@ func (o *Options) IncrementalSkipIndexing() bool {
 		return false
 	}
 
+	// Sourcegraph specific. Ensure we have public set correctly.
+	if !rawConfigEqual(repo.RawConfig, o.RepositoryDescription.RawConfig, "public") {
+		return false
+	}
+
 	return reflect.DeepEqual(repo.Branches, o.RepositoryDescription.Branches)
 }
 

--- a/matchtree.go
+++ b/matchtree.go
@@ -965,7 +965,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			repoVisible = append(repoVisible, (r.RawConfig["public"] == "1") == wantPublic)
 		}
 		return &docMatchTree{
-			reason:  fmt.Sprintf("Visibility:%s", s.Value),
+			reason:  s.String(),
 			numDocs: d.numDocs(),
 			predicate: func(docID uint32) bool {
 				return repoVisible[d.repos[docID]]

--- a/matchtree.go
+++ b/matchtree.go
@@ -957,6 +957,16 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 				return reposWant[d.repos[docID]]
 			},
 		}, nil
+
+	case *query.Visibility:
+		public := s.Value == "public"
+		return &docMatchTree{
+			reason:  "Visibility",
+			numDocs: d.numDocs(),
+			predicate: func(docID uint32) bool {
+				return (d.repoMetaData[d.repos[docID]].RawConfig["public"] == "1") == public
+			},
+		}, nil
 	}
 	log.Panicf("type %T", q)
 	return nil, nil

--- a/matchtree.go
+++ b/matchtree.go
@@ -959,12 +959,16 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 		}, nil
 
 	case *query.Visibility:
-		public := s.Value == "public"
+		wantPublic := s.Value == "public"
+		repoVisible := make([]bool, 0, len(d.repoMetaData))
+		for _, r := range d.repoMetaData {
+			repoVisible = append(repoVisible, (r.RawConfig["public"] == "1") == wantPublic)
+		}
 		return &docMatchTree{
-			reason:  "Visibility",
+			reason:  fmt.Sprintf("Visibility:%s", s.Value),
 			numDocs: d.numDocs(),
 			predicate: func(docID uint32) bool {
-				return (d.repoMetaData[d.repos[docID]].RawConfig["public"] == "1") == public
+				return repoVisible[d.repos[docID]]
 			},
 		}, nil
 	}

--- a/query/parse.go
+++ b/query/parse.go
@@ -210,6 +210,13 @@ func parseExpr(in []byte) (Q, int, error) {
 		// Later we will lift this into a root, like we do for caseQ
 		expr = &Type{Type: t, Child: nil}
 
+	case tokVis:
+		switch text {
+		case "public", "private":
+			expr = &Visibility{text}
+		default:
+			return nil, 0, fmt.Errorf("query: unknown visibility argument %q, want {public, private}", text)
+		}
 	}
 
 	return expr, len(in) - len(b), nil
@@ -358,6 +365,7 @@ const (
 	tokLang       = 12
 	tokSym        = 13
 	tokType       = 14
+	tokVis        = 15
 )
 
 var tokNames = map[int]string{
@@ -375,23 +383,26 @@ var tokNames = map[int]string{
 	tokLang:       "Language",
 	tokSym:        "Symbol",
 	tokType:       "Type",
+	tokVis:        "Visibility",
 }
 
 var prefixes = map[string]int{
-	"b:":       tokBranch,
-	"branch:":  tokBranch,
-	"c:":       tokContent,
-	"case:":    tokCase,
-	"content:": tokContent,
-	"f:":       tokFile,
-	"file:":    tokFile,
-	"r:":       tokRepo,
-	"regex:":   tokRegex,
-	"repo:":    tokRepo,
-	"lang:":    tokLang,
-	"sym:":     tokSym,
-	"t:":       tokType,
-	"type:":    tokType,
+	"b:":          tokBranch,
+	"branch:":     tokBranch,
+	"c:":          tokContent,
+	"case:":       tokCase,
+	"content:":    tokContent,
+	"f:":          tokFile,
+	"file:":       tokFile,
+	"r:":          tokRepo,
+	"regex:":      tokRegex,
+	"repo:":       tokRepo,
+	"lang:":       tokLang,
+	"sym:":        tokSym,
+	"t:":          tokType,
+	"type:":       tokType,
+	"v:":          tokVis,
+	"visibility:": tokVis,
 }
 
 var reservedWords = map[string]int{

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -116,6 +116,16 @@ func TestParseQuery(t *testing.T) {
 		{"def or or abc", nil},
 
 		{"", &Const{Value: true}},
+
+		// visibility.
+		{"abc v:public", NewAnd(
+			&Substring{Pattern: "abc"},
+			&Visibility{Value: "public"},
+		)},
+		{"abc visibility:private", NewAnd(
+			&Substring{Pattern: "abc"},
+			&Visibility{Value: "private"},
+		)},
 	} {
 		got, err := Parse(c.in)
 		if (c.want == nil) != (err != nil) {
@@ -153,6 +163,8 @@ func TestTokenize(t *testing.T) {
 		{"o\"r\" bla", tokText, "or"},
 		{"or bla", tokOr, "or"},
 		{"ar bla", tokText, "ar"},
+		{"v:bla", tokVis, "bla"},
+		{"visibility:bla", tokVis, "bla"},
 	}
 	for _, c := range cases {
 		tok, err := nextToken([]byte(c.in))

--- a/query/query.go
+++ b/query/query.go
@@ -30,6 +30,13 @@ var _ = log.Println
 type Q interface {
 	String() string
 }
+type Visibility struct {
+	Value string
+}
+
+func (v *Visibility) String() string {
+	return fmt.Sprintf("visibility:%s", v.Value)
+}
 
 // RegexpQuery is a query looking for regular expressions matches.
 type Regexp struct {


### PR DESCRIPTION
This adds atoms v:/visibility: to the query language.

We already save visibility data in the rawConfig of repoMetaData and we
can use that to create a docMatchTree that filters for visibility.

We add a check to incrementalSkipIndexing to make sure that repos we
haven't indexed recently will be reindexed with proper visibility.

If a repo switches from public to private, or vice versa,
incrementalSkipIndexing will return false and trigger a reindex because
the new rawConfig and the existing rawConfig in indexData don't match.
We expect this to be a rare event.