### PR TITLE
gob: register query.Visibility

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -138,5 +138,6 @@ func RegisterGob() {
 		gob.Register(&query.Substring{})
 		gob.Register(&query.Symbol{})
 		gob.Register(&query.Type{})
+		gob.Register(&query.Visibility{})
 	})
 }


### PR DESCRIPTION
This is a follow-up to #103

We need to register `query.Visibility` to be able to 
use it with the rpc and streaming clients.