### PR TITLE
indexserver: prefer items that index in queue 

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -353,8 +353,6 @@ func (s *Server) Run(queue *Queue) {
 		metricIndexDuration.WithLabelValues(string(state)).Observe(time.Since(start).Seconds())
 		if err != nil {
 			log.Printf("error indexing %s: %s", args.String(), err)
-			queue.SetLastIndexFailed(name)
-			continue
 		}
 		if state == indexStateSuccess {
 			log.Printf("updated index %s in %v", args.String(), time.Since(start))

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -199,11 +199,18 @@ func (pq pqueue) Less(i, j int) bool {
 	// they are either equal priority or y is more urgent.
 	x := pq[i]
 	y := pq[j]
-	if x.indexed == y.indexed {
-		// tie breaker is to prefer the item added to the queue first
-		return x.seq < y.seq
+	if x.indexed != y.indexed {
+		return !x.indexed
 	}
-	return !x.indexed
+
+	if xFail, yFail := x.indexState == indexStateFail, y.indexState == indexStateFail; xFail != yFail {
+		// if you failed to index, you are likely to fail again. So prefer
+		// non-failed.
+		return !xFail
+	}
+
+	// tie breaker is to prefer the item added to the queue first
+	return x.seq < y.seq
 }
 
 func (pq pqueue) Swap(i, j int) {

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -94,20 +94,14 @@ func (q *Queue) AddOrUpdate(repoName string, opts IndexOptions) {
 func (q *Queue) SetIndexed(repoName string, opts IndexOptions, state indexState) {
 	q.mu.Lock()
 	item := q.get(repoName)
-	item.indexed = reflect.DeepEqual(opts, item.opts)
 	item.setIndexState(state)
+	if state != indexStateFail {
+		item.indexed = reflect.DeepEqual(opts, item.opts)
+	}
 	if item.heapIdx >= 0 {
 		// We only update the position in the queue, never add it.
 		heap.Fix(&q.pq, item.heapIdx)
 	}
-	q.mu.Unlock()
-}
-
-// SetLastIndexFailed will update our metrics to track that this repository is
-// not up to date.
-func (q *Queue) SetLastIndexFailed(repoName string) {
-	q.mu.Lock()
-	q.get(repoName).setIndexState(indexStateFail)
 	q.mu.Unlock()
 }
 


### PR DESCRIPTION
Currently if an item fails to index, it normally will continue to fail
to index. We get some perverse behaviour since they will never move to
the "indexed=true" state, so they will always be at the front of the
queue.

This commit updates the priority queue to prefer items that need
indexing which are not in a failed state.

