### PR TITLE
all: support mutable metadata files for shards 

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -451,12 +451,16 @@ func (b *Builder) deleteRemainingShards() {
 		shard := b.nextShardNum
 		b.nextShardNum++
 		name := b.opts.shardName(shard)
-		if err := os.Remove(name); os.IsNotExist(err) {
+		// best effort: we get an error paths is empty and we assume there is
+		// nothing more to cleanup.
+		paths, _ := zoekt.IndexFilePaths(name)
+		if len(paths) == 0 {
 			break
-		} else {
-			_ = os.Remove(name + ".meta")
-			b.shardLog("remove", name)
 		}
+		for _, p := range paths {
+			_ = os.Remove(p)
+		}
+		b.shardLog("remove", name)
 	}
 }
 

--- a/build/builder.go
+++ b/build/builder.go
@@ -451,7 +451,7 @@ func (b *Builder) deleteRemainingShards() {
 		shard := b.nextShardNum
 		b.nextShardNum++
 		name := b.opts.shardName(shard)
-		// best effort: we get an error paths is empty and we assume there is
+		// best effort: we get an error if paths is empty and we assume there is
 		// nothing more to cleanup.
 		paths, _ := zoekt.IndexFilePaths(name)
 		if len(paths) == 0 {

--- a/build/builder.go
+++ b/build/builder.go
@@ -454,6 +454,7 @@ func (b *Builder) deleteRemainingShards() {
 		if err := os.Remove(name); os.IsNotExist(err) {
 			break
 		} else {
+			_ = os.Remove(name + ".meta")
 			b.shardLog("remove", name)
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -177,6 +177,7 @@ func removeIncompleteShards(dir string) {
 			if err := os.Remove(path); err != nil {
 				debug.Printf("failed to remove incomplete shard %s: %v", path, err)
 			} else {
+				os.Remove(path + ".meta")
 				debug.Printf("cleaned up incomplete shard %s", path)
 			}
 		}
@@ -194,6 +195,7 @@ func removeAll(shards []shard) {
 			// trash + an admin re-adding a repository.
 			debug.Printf("failed to remove shard %s: %v", shard.Path, err)
 		}
+		os.Remove(shard.Path + ".meta")
 	}
 }
 
@@ -205,6 +207,7 @@ func moveAll(dstDir string, shards []shard) {
 			removeAll(shards)
 			return
 		}
+		_ = os.Rename(shard.Path+".meta", dst+".meta")
 		// update path so that partial failure removes the dst path
 		shards[i].Path = dst
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -196,9 +196,11 @@ func TestRemoveIncompleteShards(t *testing.T) {
 		"test.zoekt",
 		"foo.zoekt",
 		"bar.zoekt",
+		"bar.zoekt.meta",
 	}, []string{
 		"incomplete.zoekt123",
 		"crash.zoekt567",
+		"metacrash.zoekt789.meta",
 	}
 	sort.Strings(shards)
 

--- a/read.go
+++ b/read.go
@@ -145,14 +145,15 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		branchNames:    []map[uint]string{},
 	}
 
-	if repo, md, err := r.readMetadata(toc); md != nil && md.IndexFormatVersion != IndexFormatVersion {
+	repo, md, err := r.readMetadata(toc)
+	if md != nil && md.IndexFormatVersion != IndexFormatVersion {
 		return nil, fmt.Errorf("file is v%d, want v%d", md.IndexFormatVersion, IndexFormatVersion)
 	} else if err != nil {
 		return nil, err
-	} else {
-		d.metaData = *md
-		d.repoMetaData = []Repository{*repo}
 	}
+
+	d.metaData = *md
+	d.repoMetaData = []Repository{*repo}
 
 	d.boundariesStart = toc.fileContents.data.off
 	d.boundaries = toc.fileContents.relativeIndex()
@@ -161,7 +162,6 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	d.docSectionsStart = toc.fileSections.data.off
 	d.docSectionsIndex = toc.fileSections.relativeIndex()
 
-	var err error
 	if d.metaData.IndexFormatVersion == 16 {
 		d.symbols.symKindIndex = toc.symbolKindMap.relativeIndex()
 		d.fileEndSymbol, err = readSectionU32(d.file, toc.fileEndSymbol)

--- a/read.go
+++ b/read.go
@@ -461,6 +461,24 @@ func ReadMetadata(inf IndexFile) (*Repository, *IndexMetadata, error) {
 	return rd.readMetadata(&toc)
 }
 
+// IndexFilePaths returns all paths for the IndexFile at filepath p that
+// exist. Note: if no files exist this will return an empty slice and nil
+// error.
+//
+// This is p and the ".meta" file for p.
+func IndexFilePaths(p string) ([]string, error) {
+	paths := []string{p, p + ".meta"}
+	exist := paths[:0]
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			exist = append(exist, p)
+		} else if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return exist, nil
+}
+
 func loadIndexData(r IndexFile) (*indexData, error) {
 	rd := &reader{r: r}
 

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -132,6 +132,14 @@ func (s *DirectoryWatcher) scan() error {
 		}
 
 		ts[fn] = fi.ModTime()
+
+		fiMeta, err := os.Lstat(fn + ".meta")
+		if err != nil {
+			continue
+		}
+		if fiMeta.ModTime().After(fi.ModTime()) {
+			ts[fn] = fiMeta.ModTime()
+		}
 	}
 
 	var toLoad []string


### PR DESCRIPTION
We introduce a `.meta` file which is the `repoMetaData` toc section. It marshals over the existing one if present. In v17 of our file format we will remove repoMetadata from the toc and purely rely on the `.meta` files.

This is how we can have mutable data alongside our shards. This main target for this is tombstones.

There are a few other approaches to this we have debated a bit. This approach leads to relatively minor changes to the code. The main thing I like is the "read path" is kept simple and data related to an individual shard remains "close" to the shard and decoupled to other shards.

Other approaches:
- single file in indexdir storing metadata for all shards. This requires more changes. It will require extra bookkeeping if we move to a design where shards can more easily move between replicas.
- mutating the file. This approach is appealing. We can't just mutate due to extra complication around synchronization. So we will need some sort of appending to end of file. This requires bigger changes to the file format. Additionally it is useful to treat the bulk of indexdata as immutable. However, this may be a useful approach in the future.
