### PR TITLE
indexserver: save fork and archived to rawConfig

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -46,6 +46,12 @@ type IndexOptions struct {
 
 	// Public is true if the repository is public.
 	Public bool
+
+	// Fork is true if the repository is a fork.
+	Fork bool
+
+	// Archived is true if the repository is archived.
+	Archived bool
 }
 
 // indexArgs represents the arguments we pass to zoekt-archive-index
@@ -90,6 +96,14 @@ func (o *indexArgs) BuildOptions() *build.Options {
 
 	if o.Public {
 		rawConfig["public"] = "1"
+	}
+
+	if o.Fork {
+		rawConfig["fork"] = "1"
+	}
+
+	if o.Archived {
+		rawConfig["archived"] = "1"
 	}
 
 	return &build.Options{


### PR DESCRIPTION
We receive "fork" and "archived" data from Sourcegraph and persist it in
rawConfig. For now the data is not read anywhere. In a follow-up PR we
will add a query atom that addresses rawConfig directly.