### PR TITLE
build: remove check for "public"

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -304,11 +304,6 @@ func (o *Options) IncrementalSkipIndexing() bool {
 		return false
 	}
 
-	// Sourcegraph specific. Ensure we have public set correctly.
-	if !rawConfigEqual(repo.RawConfig, o.RepositoryDescription.RawConfig, "public") {
-		return false
-	}
-
 	return reflect.DeepEqual(repo.Branches, o.RepositoryDescription.Branches)
 }
 


### PR DESCRIPTION
Because we have mutable metadata we don't have to reindex anymore. Let's remove
this check before this week's branch cut.