### PR TITLE
indexserver: update meta file if only RawConfig changes

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -294,7 +294,7 @@ func (o *Options) IncrementalSkipIndexing() bool {
 func (o *Options) IndexState() IndexState {
 	fn := o.shardName(0)
 
-	repo, index, err := readMetadata(fn)
+	repo, index, err := zoekt.ReadMetadataPath(fn)
 	if os.IsNotExist(err) {
 		return IndexStateMissing
 	} else if err != nil {
@@ -329,22 +329,6 @@ func (o *Options) IndexState() IndexState {
 	}
 
 	return IndexStateEqual
-}
-
-func readMetadata(p string) (*zoekt.Repository, *zoekt.IndexMetadata, error) {
-	f, err := os.Open(p)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer f.Close()
-
-	iFile, err := zoekt.NewIndexFile(f)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer iFile.Close()
-
-	return zoekt.ReadMetadata(iFile)
 }
 
 func rawConfigEqual(m1, m2 map[string]string, key string) bool {
@@ -742,7 +726,7 @@ func MergeMeta(o *Options) error {
 	for i := 0; ; i++ {
 		fn := o.shardName(i)
 
-		repo, _, err := readMetadata(fn)
+		repo, _, err := zoekt.ReadMetadataPath(fn)
 		if os.IsNotExist(err) {
 			break
 		} else if err != nil {

--- a/build/builder.go
+++ b/build/builder.go
@@ -316,6 +316,7 @@ func (o *Options) IndexState() IndexState {
 	if updated, err := repo.MergeMutable(&o.RepositoryDescription); err != nil {
 		// non-nil err means we are trying to update an immutable field =>
 		// reindex content.
+		log.Printf("warn: immutable field changed, requires re-index: %s", err)
 		return IndexStateContent
 	} else if updated {
 		return IndexStateMeta

--- a/build/builder.go
+++ b/build/builder.go
@@ -324,17 +324,6 @@ func (o *Options) IndexState() IndexState {
 	return IndexStateEqual
 }
 
-func rawConfigEqual(m1, m2 map[string]string, key string) bool {
-	var v1, v2 string
-	if m1 != nil {
-		v1 = m1[key]
-	}
-	if m2 != nil {
-		v2 = m2[key]
-	}
-	return v1 == v2
-}
-
 // IgnoreSizeMax determines whether the max size should be ignored.
 func (o *Options) IgnoreSizeMax(name string) bool {
 	for _, pattern := range o.LargeFiles {

--- a/build/builder.go
+++ b/build/builder.go
@@ -779,7 +779,7 @@ func MergeMeta(o *Options) error {
 	return renameErr
 }
 
-// jsonMarshalFileTmp will marshal v to the temporary file p + ".*.tmp" and
+// jsonMarshalFileTmp marshals v to the temporary file p + ".*.tmp" and
 // returns the file name.
 //
 // Note: .tmp is the same suffix used by Builder. indexserver knows to clean

--- a/build/builder.go
+++ b/build/builder.go
@@ -262,7 +262,7 @@ func hashString(s string) string {
 }
 
 // ShardName returns the name the given index shard.
-func (o *Options) shardName(n int) string {
+func (o *Options) ShardName(n int) string {
 	abs := url.QueryEscape(o.RepositoryDescription.Name)
 	if len(abs) > 200 {
 		abs = abs[:200] + hashString(abs)[:8]
@@ -292,7 +292,7 @@ func (o *Options) IncrementalSkipIndexing() bool {
 // IndexState checks how the index present on disk compares to the build
 // options.
 func (o *Options) IndexState() IndexState {
-	fn := o.shardName(0)
+	fn := o.ShardName(0)
 
 	repo, index, err := zoekt.ReadMetadataPath(fn)
 	if os.IsNotExist(err) {
@@ -465,7 +465,7 @@ func (b *Builder) deleteRemainingShards() error {
 	for {
 		shard := b.nextShardNum
 		b.nextShardNum++
-		name := b.opts.shardName(shard)
+		name := b.opts.ShardName(shard)
 		paths, err := zoekt.IndexFilePaths(name)
 		if err != nil {
 			return err
@@ -641,7 +641,7 @@ func (b *Builder) buildShard(todo []*zoekt.Document, nextShardNum int) (*finishe
 		}
 	}
 
-	name := b.opts.shardName(nextShardNum)
+	name := b.opts.ShardName(nextShardNum)
 
 	shardBuilder, err := b.newShardBuilder()
 	if err != nil {
@@ -720,7 +720,7 @@ func MergeMeta(o *Options) error {
 	// implementation.
 	var todo map[string]string
 	for i := 0; ; i++ {
-		fn := o.shardName(i)
+		fn := o.ShardName(i)
 
 		repo, _, err := zoekt.ReadMetadataPath(fn)
 		if os.IsNotExist(err) {

--- a/build/builder.go
+++ b/build/builder.go
@@ -18,7 +18,6 @@ package build
 
 import (
 	"crypto/sha1"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -706,91 +705,3 @@ func (b *Builder) writeShard(fn string, ib *zoekt.IndexBuilder) (*finishedShard,
 
 // umask holds the Umask of the current process
 var umask os.FileMode
-
-// MergeMeta updates the .meta files for the shards on disk for o.
-//
-// This process is best effort. If anything fails we return on the first
-// failure. This means you might have an inconsistent state on disk if an
-// error is returned. It is recommended to fallback to re-indexing in that
-// case.
-func MergeMeta(o *Options) error {
-	// TODO should this logic live in the zoekt pkg rather than the build pkg?
-	// Argument for build is its the only place we deal with writing to multiple
-	// shards. Argument for zoekt is it's the only place that understands meta
-	// implementation.
-	var todo map[string]string
-	for i := 0; ; i++ {
-		fn := o.ShardName(i)
-
-		repo, _, err := zoekt.ReadMetadataPath(fn)
-		if os.IsNotExist(err) {
-			break
-		} else if err != nil {
-			return err
-		}
-
-		if updated, err := repo.MergeMutable(&o.RepositoryDescription); err != nil {
-			return err
-		} else if !updated {
-			// This shouldn't happen, but ignore it if it does. We may be working on
-			// an interrupted shard. This helps us converge to something correct.
-			continue
-		}
-
-		dst := fn + ".meta"
-		tmp, err := jsonMarshalTmpFile(repo, dst)
-		if err != nil {
-			return err
-		}
-
-		todo[tmp] = dst
-
-		// if we fail to rename, this defer will attempt to remove the tmp file.
-		defer os.Remove(tmp)
-	}
-
-	// best effort once we get here. Rename everything. Return error of last
-	// failure.
-	var renameErr error
-	for tmp, dst := range todo {
-		if err := os.Rename(tmp, dst); err != nil {
-			renameErr = err
-		}
-	}
-
-	return renameErr
-}
-
-// jsonMarshalFileTmp marshals v to the temporary file p + ".*.tmp" and
-// returns the file name.
-//
-// Note: .tmp is the same suffix used by Builder. indexserver knows to clean
-// them up.
-func jsonMarshalTmpFile(v interface{}, p string) (_ string, err error) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-
-	f, err := ioutil.TempFile(filepath.Dir(p), filepath.Base(p)+".*.tmp")
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		f.Close()
-		if err != nil {
-			_ = os.Remove(f.Name())
-		}
-	}()
-
-	if runtime.GOOS != "windows" {
-		if err := f.Chmod(0o666 &^ umask); err != nil {
-			return "", err
-		}
-	}
-	if _, err := f.Write(b); err != nil {
-		return "", err
-	}
-
-	return f.Name(), f.Close()
-}

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -98,7 +98,7 @@ func TestBasic(t *testing.T) {
 	t.Run("meta file", func(t *testing.T) {
 		// Add a .meta file for each shard with repo.Name set to "repo-mutated"
 		for _, p := range fs {
-			repo, err := shardRepoMetadata(p)
+			repo, _, err := zoekt.ReadMetadataPath(p)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -171,27 +171,6 @@ func retryTest(t *testing.T, f func(fatalf func(format string, args ...interface
 
 	// final run for the test, using the real t.Fatalf
 	f(t.Fatalf)
-}
-
-func shardRepoMetadata(path string) (*zoekt.Repository, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	ifile, err := zoekt.NewIndexFile(f)
-	if err != nil {
-		return nil, err
-	}
-	defer ifile.Close()
-
-	repo, _, err := zoekt.ReadMetadata(ifile)
-	if err != nil {
-		return nil, err
-	}
-
-	return repo, nil
 }
 
 func TestLargeFileOption(t *testing.T) {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -140,19 +140,7 @@ func getShards(dir string) map[string][]shard {
 }
 
 func shardRepoName(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	ifile, err := zoekt.NewIndexFile(f)
-	if err != nil {
-		return "", err
-	}
-	defer ifile.Close()
-
-	repo, _, err := zoekt.ReadMetadata(ifile)
+	repo, _, err := zoekt.ReadMetadataPath(path)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -95,10 +95,6 @@ func (o *indexArgs) BuildOptions() *build.Options {
 			ID:       uint32(o.IndexOptions.RepoID),
 			Name:     o.Name,
 			Branches: o.Branches,
-			// Always specify every field since incremental meta data updates ignore
-			// missing fields.
-			//
-			// Ensure this matches the fields in build Options.IndexState.
 			RawConfig: map[string]string{
 				"repoid":   strconv.Itoa(int(o.IndexOptions.RepoID)),
 				"priority": strconv.FormatFloat(o.Priority, 'g', -1, 64),

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -87,15 +87,18 @@ type indexArgs struct {
 // doesn't set fields like repository/branch.
 func (o *indexArgs) BuildOptions() *build.Options {
 	return &build.Options{
-		// It is important that this RepositoryDescription exactly matches
-		// what the indexer we call will produce. This is to ensure that
-		// IncrementalSkipIndexing returns true if nothing needs to be done.
+		// It is important that this RepositoryDescription exactly matches what
+		// the indexer we call will produce. This is to ensure that
+		// IncrementalSkipIndexing and IndexState can correctly calculate if
+		// nothing needs to be done.
 		RepositoryDescription: zoekt.Repository{
 			ID:       uint32(o.IndexOptions.RepoID),
 			Name:     o.Name,
 			Branches: o.Branches,
 			// Always specify every field since incremental meta data updates ignore
 			// missing fields.
+			//
+			// Ensure this matches the fields in build Options.IndexState.
 			RawConfig: map[string]string{
 				"repoid":   strconv.Itoa(int(o.IndexOptions.RepoID)),
 				"priority": strconv.FormatFloat(o.Priority, 'g', -1, 64),

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -494,6 +494,9 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 			} else {
 				return indexStateSuccess, nil
 			}
+
+		case build.IndexStateCorrupt:
+			log.Printf("falling back to full update: corrupt index: %s", args.String())
 		}
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -489,7 +489,11 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		case build.IndexStateMeta:
 			debug.Printf("updating index.meta %s", args.String())
 
-			return indexStateSuccess, build.MergeMeta(bo)
+			if err := build.MergeMeta(bo); err != nil {
+				log.Printf("falling back to full update: failed to update index.meta %s: %s", args.String(), err)
+			} else {
+				return indexStateSuccess, nil
+			}
 		}
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -491,7 +491,7 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 			return indexStateNoop, nil
 
 		case build.IndexStateMeta:
-			debug.Printf("updating index.meta %s", args.String())
+			log.Printf("updating index.meta %s", args.String())
 
 			if err := mergeMeta(bo); err != nil {
 				log.Printf("falling back to full update: failed to update index.meta %s: %s", args.String(), err)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -479,9 +479,9 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	if args.Incremental {
 		bo := args.BuildOptions()
 		bo.SetDefaults()
-		state := bo.IndexState()
-		metricIndexIncrementalIndexState.WithLabelValues(string(state)).Inc()
-		switch state {
+		incrementalState := bo.IndexState()
+		metricIndexIncrementalIndexState.WithLabelValues(string(incrementalState)).Inc()
+		switch incrementalState {
 		case build.IndexStateEqual:
 			debug.Printf("%s index already up to date", args.String())
 			return indexStateNoop, nil

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -489,7 +489,7 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		case build.IndexStateMeta:
 			debug.Printf("updating index.meta %s", args.String())
 
-			if err := build.MergeMeta(bo); err != nil {
+			if err := mergeMeta(bo); err != nil {
 				log.Printf("falling back to full update: failed to update index.meta %s: %s", args.String(), err)
 			} else {
 				return indexStateSuccess, nil

--- a/cmd/zoekt-sourcegraph-indexserver/meta.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/build"
+)
+
+// mergeMeta updates the .meta files for the shards on disk for o.
+//
+// This process is best effort. If anything fails we return on the first
+// failure. This means you might have an inconsistent state on disk if an
+// error is returned. It is recommended to fallback to re-indexing in that
+// case.
+func mergeMeta(o *build.Options) error {
+	var todo map[string]string
+	for i := 0; ; i++ {
+		fn := o.ShardName(i)
+
+		repo, _, err := zoekt.ReadMetadataPath(fn)
+		if os.IsNotExist(err) {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if updated, err := repo.MergeMutable(&o.RepositoryDescription); err != nil {
+			return err
+		} else if !updated {
+			// This shouldn't happen, but ignore it if it does. We may be working on
+			// an interrupted shard. This helps us converge to something correct.
+			continue
+		}
+
+		dst := fn + ".meta"
+		tmp, err := jsonMarshalTmpFile(repo, dst)
+		if err != nil {
+			return err
+		}
+
+		todo[tmp] = dst
+
+		// if we fail to rename, this defer will attempt to remove the tmp file.
+		defer os.Remove(tmp)
+	}
+
+	// best effort once we get here. Rename everything. Return error of last
+	// failure.
+	var renameErr error
+	for tmp, dst := range todo {
+		if err := os.Rename(tmp, dst); err != nil {
+			renameErr = err
+		}
+	}
+
+	return renameErr
+}
+
+// jsonMarshalFileTmp marshals v to the temporary file p + ".*.tmp" and
+// returns the file name.
+//
+// Note: .tmp is the same suffix used by Builder. indexserver knows to clean
+// them up.
+func jsonMarshalTmpFile(v interface{}, p string) (_ string, err error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := ioutil.TempFile(filepath.Dir(p), filepath.Base(p)+".*.tmp")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		f.Close()
+		if err != nil {
+			_ = os.Remove(f.Name())
+		}
+	}()
+
+	if err := f.Chmod(0o666 &^ umask); err != nil {
+		return "", err
+	}
+	if _, err := f.Write(b); err != nil {
+		return "", err
+	}
+
+	return f.Name(), f.Close()
+}
+
+// respect process umask. build does this.
+var umask os.FileMode
+
+func init() {
+	umask = os.FileMode(syscall.Umask(0))
+	syscall.Umask(int(umask))
+}

--- a/cmd/zoekt-sourcegraph-indexserver/meta.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta.go
@@ -18,7 +18,7 @@ import (
 // error is returned. It is recommended to fallback to re-indexing in that
 // case.
 func mergeMeta(o *build.Options) error {
-	var todo map[string]string
+	todo := map[string]string{}
 	for i := 0; ; i++ {
 		fn := o.ShardName(i)
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -223,6 +223,9 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 		}
 	}
 
+	id, _ := strconv.ParseUint(sec.Options.Get("repoid"), 10, 32)
+	desc.ID = uint32(id)
+
 	if desc.RawConfig == nil {
 		desc.RawConfig = map[string]string{}
 	}

--- a/read.go
+++ b/read.go
@@ -456,6 +456,25 @@ func ReadMetadata(inf IndexFile) (*Repository, *IndexMetadata, error) {
 	return rd.readMetadata(&toc)
 }
 
+// ReadMetadataPath returns the metadata of index shard at p without reading
+// the index data. ReadMetadataPath is a helper for ReadMetadata which opens
+// the IndexFile at p.
+func ReadMetadataPath(p string) (*Repository, *IndexMetadata, error) {
+	f, err := os.Open(p)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	iFile, err := NewIndexFile(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer iFile.Close()
+
+	return ReadMetadata(iFile)
+}
+
 // IndexFilePaths returns all paths for the IndexFile at filepath p that
 // exist. Note: if no files exist this will return an empty slice and nil
 // error.


### PR DESCRIPTION
This commit allows us to add/update fields like public and priority without requiring a full re-index. It uses the recently introduced ".meta" file to accomplish this.

We currently use an allowlist on fields which trigger updates. This is what we did previously, but the list has been expanded to all RawConfig fields Sourcegraph cares about. We didn't extend this functionality to all fields on Repository since some fields change between builds / it would be more work. Additionally we can't use all fields in RawConfig since some are set by the index tools themselves.

I validated the above assumptions by patching indexserver and running it on indexed-search-0 in production. See the patch and an example of the Repository diff here: https://gist.github.com/keegancsmith/0121e0cce7fb93daede78f2c0373f2cd

This commit is still missing tests. I will be adding them soon, but I have tested manually and would appreciate a review. I may merge in and follow-up with tests. Additionally there are some TODOs left in to spark some discussion. Would love to hear feedback.

Depends on https://github.com/sourcegraph/zoekt/pull/112
