### PR TITLE
metadata: just save RawConfig to .meta

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -434,9 +434,15 @@ func (b *Builder) Finish() error {
 	}
 
 	for tmp, final := range b.finishedShards {
-		if err := os.Rename(tmp, final); err != nil {
+		err := os.Rename(tmp, final)
+		if err != nil {
 			b.buildError = err
-		} else {
+		}
+		err = os.Remove(final + ".meta")
+		if err != nil && !os.IsNotExist(err) {
+			b.buildError = err
+		}
+		if err == nil {
 			b.shardLog("upsert", final)
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/meta.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta.go
@@ -38,7 +38,7 @@ func mergeMeta(o *build.Options) error {
 		}
 
 		dst := fn + ".meta"
-		tmp, err := jsonMarshalTmpFile(repo, dst)
+		tmp, err := jsonMarshalMetadata(repo, dst)
 		if err != nil {
 			return err
 		}
@@ -61,12 +61,17 @@ func mergeMeta(o *build.Options) error {
 	return renameErr
 }
 
-// jsonMarshalFileTmp marshals v to the temporary file p + ".*.tmp" and
-// returns the file name.
+// jsonMarshalMetadata marshals repo to the temporary file p + ".*.tmp" and
+// returns the file name. Only a subset of the fields of repo will be written
+// to the metadata file.
 //
 // Note: .tmp is the same suffix used by Builder. indexserver knows to clean
 // them up.
-func jsonMarshalTmpFile(v interface{}, p string) (_ string, err error) {
+func jsonMarshalMetadata(repo *zoekt.Repository, p string) (_ string, err error) {
+	type metadata struct {
+		RawConfig map[string]string
+	}
+	v := &metadata{RawConfig: repo.RawConfig}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This is supposed to fix a bug where we saved branch data to the .meta
file. Since the .meta overwrites Repository.RawConfig on read, we never
updated the sha which means the reported sha was out of sync with the
actual line matches.