### PR TITLE
webserver: slow query logging with traceID

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -454,11 +454,6 @@ func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchO
 		return
 	}
 
-	minDuration, _ := time.ParseDuration(os.Getenv("SRC_HTTP_LOG_MIN_DURATION"))
-	if minDuration == 0 {
-		minDuration = time.Second
-	}
-
 	log.Printf(
 		"DBUG: search traceID=%s q=%s Options{EstimateDocCount=%v Whole=%v ShardMaxMatchCount=%v TotalMaxMatchCount=%v ShardMaxImportantMatch=%v TotalMaxImportantMatch=%v MaxWallTime=%v MaxDocDisplayCount=%v} Stats{ContentBytesLoaded=%v IndexBytesLoaded=%v Crashes=%v Duration=%v FileCount=%v ShardFilesConsidered=%v FilesConsidered=%v FilesLoaded=%v FilesSkipped=%v ShardsSkipped=%v MatchCount=%v NgramMatches=%v Wait=%v}",
 		id,

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -246,7 +246,10 @@ func main() {
 		log.Println("watchdog disabled")
 	}
 
-	srv := &http.Server{Addr: *listen, Handler: handler}
+	srv := &http.Server{
+		Addr: *listen,
+		Handler: web.HTTPTraceMiddleware(handler),
+	}
 
 	go func() {
 		if debug {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -248,7 +248,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:    *listen,
-		Handler: web.HTTPTraceMiddleware(handler),
+		Handler: handler,
 	}
 
 	go func() {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -247,7 +247,7 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr: *listen,
+		Addr:    *listen,
 		Handler: web.HTTPTraceMiddleware(handler),
 	}
 
@@ -405,18 +405,28 @@ type loggedSearcher struct {
 	zoekt.Streamer
 }
 
-func (s *loggedSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
-	sr, err := s.Streamer.Search(ctx, q, opts)
-	if err != nil {
-		log.Printf("EROR: search failed q=%s: %s", q.String(), err.Error())
-	}
-	if sr != nil {
-		log.Printf("DBUG: search q=%s Options{EstimateDocCount=%v Whole=%v ShardMaxMatchCount=%v TotalMaxMatchCount=%v ShardMaxImportantMatch=%v TotalMaxImportantMatch=%v MaxWallTime=%v MaxDocDisplayCount=%v} Stats{ContentBytesLoaded=%v IndexBytesLoaded=%v Crashes=%v Duration=%v FileCount=%v ShardFilesConsidered=%v FilesConsidered=%v FilesLoaded=%v FilesSkipped=%v ShardsSkipped=%v MatchCount=%v NgramMatches=%v Wait=%v}", q.String(), opts.EstimateDocCount, opts.Whole, opts.ShardMaxMatchCount, opts.TotalMaxMatchCount, opts.ShardMaxImportantMatch, opts.TotalMaxImportantMatch, opts.MaxWallTime, opts.MaxDocDisplayCount, sr.Stats.ContentBytesLoaded, sr.Stats.IndexBytesLoaded, sr.Stats.Crashes, sr.Stats.Duration, sr.Stats.FileCount, sr.Stats.ShardFilesConsidered, sr.Stats.FilesConsidered, sr.Stats.FilesLoaded, sr.Stats.FilesSkipped, sr.Stats.ShardsSkipped, sr.Stats.MatchCount, sr.Stats.NgramMatches, sr.Stats.Wait)
-	}
-	return sr, err
+func (s *loggedSearcher) Search(
+	ctx context.Context,
+	q query.Q,
+	opts *zoekt.SearchOptions,
+) (sr *zoekt.SearchResult, err error) {
+	defer func() {
+		var stats *zoekt.Stats
+		if sr != nil {
+			stats = &sr.Stats
+		}
+		s.log(ctx, q, opts, stats, err)
+	}()
+
+	return s.Streamer.Search(ctx, q, opts)
 }
 
-func (s *loggedSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) error {
+func (s *loggedSearcher) StreamSearch(
+	ctx context.Context,
+	q query.Q,
+	opts *zoekt.SearchOptions,
+	sender zoekt.Sender,
+) error {
 	var (
 		mu    sync.Mutex
 		stats zoekt.Stats
@@ -427,11 +437,72 @@ func (s *loggedSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoek
 		mu.Unlock()
 		sender.Send(event)
 	}))
-	if err != nil {
-		log.Printf("EROR: search failed q=%s: %s", q.String(), err.Error())
-	}
-	log.Printf("DBUG: search q=%s Options{EstimateDocCount=%v Whole=%v ShardMaxMatchCount=%v TotalMaxMatchCount=%v ShardMaxImportantMatch=%v TotalMaxImportantMatch=%v MaxWallTime=%v MaxDocDisplayCount=%v} Stats{ContentBytesLoaded=%v IndexBytesLoaded=%v Crashes=%v Duration=%v FileCount=%v ShardFilesConsidered=%v FilesConsidered=%v FilesLoaded=%v FilesSkipped=%v ShardsSkipped=%v MatchCount=%v NgramMatches=%v Wait=%v}", q.String(), opts.EstimateDocCount, opts.Whole, opts.ShardMaxMatchCount, opts.TotalMaxMatchCount, opts.ShardMaxImportantMatch, opts.TotalMaxImportantMatch, opts.MaxWallTime, opts.MaxDocDisplayCount, stats.ContentBytesLoaded, stats.IndexBytesLoaded, stats.Crashes, stats.Duration, stats.FileCount, stats.ShardFilesConsidered, stats.FilesConsidered, stats.FilesLoaded, stats.FilesSkipped, stats.ShardsSkipped, stats.MatchCount, stats.NgramMatches, stats.Wait)
+
+	s.log(ctx, q, opts, &stats, err)
+
 	return err
+}
+
+func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, st *zoekt.Stats, err error) {
+	id := traceID(ctx)
+	if err != nil {
+		log.Printf("EROR: search failed traceID=%s q=%s: %s", id, q.String(), err.Error())
+		return
+	}
+
+	if st == nil {
+		return
+	}
+
+	minDuration, _ := time.ParseDuration(os.Getenv("SRC_HTTP_LOG_MIN_DURATION"))
+	if minDuration == 0 {
+		minDuration = time.Second
+	}
+
+	log.Printf(
+		"DBUG: search traceID=%s q=%s Options{EstimateDocCount=%v Whole=%v ShardMaxMatchCount=%v TotalMaxMatchCount=%v ShardMaxImportantMatch=%v TotalMaxImportantMatch=%v MaxWallTime=%v MaxDocDisplayCount=%v} Stats{ContentBytesLoaded=%v IndexBytesLoaded=%v Crashes=%v Duration=%v FileCount=%v ShardFilesConsidered=%v FilesConsidered=%v FilesLoaded=%v FilesSkipped=%v ShardsSkipped=%v MatchCount=%v NgramMatches=%v Wait=%v}",
+		id,
+		q.String(),
+		opts.EstimateDocCount,
+		opts.Whole,
+		opts.ShardMaxMatchCount,
+		opts.TotalMaxMatchCount,
+		opts.ShardMaxImportantMatch,
+		opts.TotalMaxImportantMatch,
+		opts.MaxWallTime,
+		opts.MaxDocDisplayCount,
+		st.ContentBytesLoaded,
+		st.IndexBytesLoaded,
+		st.Crashes,
+		st.Duration,
+		st.FileCount,
+		st.ShardFilesConsidered,
+		st.FilesConsidered,
+		st.FilesLoaded,
+		st.FilesSkipped,
+		st.ShardsSkipped,
+		st.MatchCount,
+		st.NgramMatches,
+		st.Wait,
+	)
+}
+
+// traceID returns a trace ID, if any, found in the given context.
+func traceID(ctx context.Context) string {
+	span := opentracing.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	return traceIDFromSpan(span)
+}
+
+// traceIDFromSpan returns a trace ID, if any, found in the given span.
+func traceIDFromSpan(span opentracing.Span) string {
+	spanCtx, ok := span.Context().(jaeger.SpanContext)
+	if !ok {
+		return ""
+	}
+	return spanCtx.TraceID().String()
 }
 
 func initializeJaeger() {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
+	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/procfs v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,9 @@ github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/opentracing-contrib/go-stdlib v1.0.0 h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=
+github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
@@ -75,7 +76,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// mu protects aggStats and concurrent writes to the stream.
 	mu := sync.Mutex{}
-	var aggStats = zoekt.Stats{}
+	aggStats := zoekt.Stats{}
 	send := func(zsr *zoekt.SearchResult) {
 		err := eventWriter.event(eventMatches, zsr)
 		if err != nil {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"

--- a/web/trace.go
+++ b/web/trace.go
@@ -3,11 +3,15 @@ package web
 import (
 	"context"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/trace"
+	othttp "github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
 )
 
 // traceAwareSearcher wraps a zoekt.Searcher instance so that the tracing context item is set in the
@@ -17,23 +21,38 @@ type traceAwareSearcher struct {
 	Searcher zoekt.Streamer
 }
 
-func (s traceAwareSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+func (s traceAwareSearcher) Search(
+	ctx context.Context,
+	q query.Q,
+	opts *zoekt.SearchOptions,
+) (*zoekt.SearchResult, error) {
 	ctx, finish := getTraceContext(ctx, "zoekt.traceAwareSearcher.Search", opts.Trace, opts.SpanContext)
 	defer finish()
 	return s.Searcher.Search(ctx, q, opts)
 }
 
-func (s traceAwareSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) error {
+func (s traceAwareSearcher) StreamSearch(
+	ctx context.Context,
+	q query.Q,
+	opts *zoekt.SearchOptions,
+	sender zoekt.Sender,
+) error {
 	ctx, finish := getTraceContext(ctx, "zoekt.traceAwareSearcher.StreamSearch", opts.Trace, opts.SpanContext)
 	defer finish()
 	return s.Searcher.StreamSearch(ctx, q, opts, sender)
 }
 
-func getTraceContext(ctx context.Context, opName string, traceEnabled bool, spanContext map[string]string) (context.Context, func()) {
+func getTraceContext(
+	ctx context.Context,
+	opName string,
+	traceEnabled bool,
+	spanContext map[string]string,
+) (context.Context, func()) {
 	ctx = trace.WithOpenTracingEnabled(ctx, traceEnabled)
 	finish := func() {}
 	if traceEnabled && spanContext != nil {
-		spanContext, err := trace.GetOpenTracer(ctx, nil).Extract(opentracing.TextMap, opentracing.TextMapCarrier(spanContext))
+		spanContext, err := trace.GetOpenTracer(ctx, nil).
+			Extract(opentracing.TextMap, opentracing.TextMapCarrier(spanContext))
 		if err != nil {
 			log.Printf("Error extracting span from opts: %s", err)
 		}
@@ -45,8 +64,26 @@ func getTraceContext(ctx context.Context, opName string, traceEnabled bool, span
 	}
 	return ctx, finish
 }
+
 func (s traceAwareSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListOptions) (*zoekt.RepoList, error) {
 	return s.Searcher.List(ctx, q, opts)
 }
 func (s traceAwareSearcher) Close()         { s.Searcher.Close() }
 func (s traceAwareSearcher) String() string { return s.Searcher.String() }
+
+func HTTPTraceMiddleware(next http.Handler) http.Handler {
+	tracer := opentracing.GlobalTracer()
+	return othttp.MiddlewareFunc(tracer, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		began := time.Now()
+		next.ServeHTTP(w, r)
+		duration := time.Since(began)
+
+		traceID := ""
+		span := opentracing.SpanFromContext(r.Context())
+		if span != nil {
+			traceID = span.Context().(jaeger.SpanContext).TraceID().String()
+		}
+
+		log.Printf("method=%s url=%s traceid=%s duration=%s", r.Method, r.URL, traceID, duration)
+	}))
+}


### PR DESCRIPTION
This changeset adds slow query logging with a traceID which should
help us jump from logs to traces when using Grafana Cloud, and find
trace ids of past requests that were slow.