### PR TITLE
eval: fix bug where /(foo){2,}/ was equivalent to /foo/

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -533,10 +533,13 @@ func (d *indexData) regexpToMatchTreeRecursive(r *syntax.Regexp, minTextSize int
 		return d.regexpToMatchTreeRecursive(r.Sub[0], minTextSize, fileName, caseSensitive)
 
 	case syntax.OpRepeat:
-		if r.Min >= 1 {
+		if r.Min == 1 {
 			return d.regexpToMatchTreeRecursive(r.Sub[0], minTextSize, fileName, caseSensitive)
+		} else if r.Min > 1 {
+			// (x){2,} can't be expressed precisely by the matchTree
+			mt, _, singleLine, err := d.regexpToMatchTreeRecursive(r.Sub[0], minTextSize, fileName, caseSensitive)
+			return mt, false, singleLine, err
 		}
-
 	case syntax.OpConcat, syntax.OpAlternate:
 		var qs []matchTree
 		isEq := true

--- a/eval_test.go
+++ b/eval_test.go
@@ -102,6 +102,7 @@ func TestRegexpParse(t *testing.T) {
 			substrMT("foo"),
 			substrMT("bar"),
 		}}, false},
+		{"(foo){2,}", substrMT("foo"), false},
 		{"(...)(...)", &bruteForceMatchTree{}, false},
 	}
 


### PR DESCRIPTION
Tested locally and fixes the issue, but it's slower because it has to do full regex evaluation instead of using the pure matchTree to do a speedup. It's not clear whether `andMatchTree(regexpMatchTree,noVisitMatchTree(substringMatchTree))` is any faster than evaluating regexpMatchTree alone.

A future change might optimize these with a conversion pass to turn `foo{2,}` (7212ms eval time) () into `foofoo(?:foo)*` (27ms eval time).

Customer issue: sourcegraph/sourcegraph#23467