### PR TITLE
ctags: timeout parse requests after a minute

### DIFF
--- a/ctags/json.go
+++ b/ctags/json.go
@@ -16,6 +16,7 @@ package ctags
 
 import (
 	"log"
+	"os"
 	"strings"
 	"sync"
 
@@ -28,9 +29,14 @@ type Parser = goctags.Parser
 type Entry = goctags.Entry
 
 func newProcess(bin string) (Parser, error) {
-	return goctags.New(goctags.Options{
-		Bin: bin,
-	})
+	opts := goctags.Options{
+		Bin:  bin,
+		Info: log.New(os.Stderr, "CTAGS INF: ", log.LstdFlags),
+	}
+	if debug {
+		opts.Debug = log.New(os.Stderr, "CTAGS DBG: ", log.LstdFlags)
+	}
+	return goctags.New(opts)
 }
 
 type lockedParser struct {

--- a/ctags/json.go
+++ b/ctags/json.go
@@ -15,10 +15,12 @@
 package ctags
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	goctags "github.com/sourcegraph/go-ctags"
 )
@@ -28,44 +30,107 @@ const debug = false
 type Parser = goctags.Parser
 type Entry = goctags.Entry
 
-func newProcess(bin string) (Parser, error) {
-	opts := goctags.Options{
-		Bin:  bin,
-		Info: log.New(os.Stderr, "CTAGS INF: ", log.LstdFlags),
-	}
-	if debug {
-		opts.Debug = log.New(os.Stderr, "CTAGS DBG: ", log.LstdFlags)
-	}
-	return goctags.New(opts)
+type parseReq struct {
+	Name    string
+	Content []byte
+}
+
+type parseResp struct {
+	Entries []*Entry
+	Err     error
 }
 
 type lockedParser struct {
-	p Parser
-	l sync.Mutex
+	mu   sync.Mutex
+	opts goctags.Options
+	p    Parser
+	send chan<- parseReq
+	recv <-chan parseResp
 }
 
+// parseTimeout is how long we wait for a response for parsing a single file
+// in ctags. 1 minute is a very conservative timeout which we should only hit
+// if ctags hangs.
+const parseTimeout = time.Minute
+
+// Parse wraps go-ctags Parse. It lazily starts the process and adds a timeout
+// around parse requests. Additionally it serializes access to the parsing
+// process. The timeout is important since we occasionally come across
+// documents which hang universal-ctags.
 func (lp *lockedParser) Parse(name string, content []byte) ([]*Entry, error) {
-	lp.l.Lock()
-	defer lp.l.Unlock()
-	return lp.p.Parse(name, content)
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+
+	if lp.p == nil {
+		p, err := goctags.New(lp.opts)
+		if err != nil {
+			return nil, err
+		}
+		send := make(chan parseReq)
+		// buf of 1 so we avoid blocking sends in the parser if we exit early.
+		recv := make(chan parseResp, 1)
+
+		go func() {
+			defer close(recv)
+			for req := range send {
+				entries, err := p.Parse(req.Name, req.Content)
+				recv <- parseResp{Entries: entries, Err: err}
+			}
+		}()
+
+		lp.p = p
+		lp.send = send
+		lp.recv = recv
+	}
+
+	lp.send <- parseReq{Name: name, Content: content}
+
+	deadline := time.NewTimer(parseTimeout)
+	defer deadline.Stop()
+
+	select {
+	case resp := <-lp.recv:
+		return resp.Entries, resp.Err
+	case <-deadline.C:
+		// Error out since ctags hanging is a sign something bad is happening.
+		lp.close()
+		return nil, fmt.Errorf("ctags timedout after %s parsing %s", parseTimeout, name)
+	}
 }
 
 func (lp *lockedParser) Close() {
-	lp.l.Lock()
-	defer lp.l.Unlock()
+	lp.mu.Lock()
+	defer lp.mu.Unlock()
+	lp.close()
+}
+
+// close assumes lp.mu is held.
+func (lp *lockedParser) close() {
+	if lp.p == nil {
+		return
+	}
+
 	lp.p.Close()
+	lp.p = nil
+	close(lp.send)
+	lp.send = nil
+	lp.recv = nil
 }
 
 // NewParser creates a parser that is implemented by the given
 // universal-ctags binary. The parser is safe for concurrent use.
 func NewParser(bin string) (Parser, error) {
 	if strings.Contains(bin, "universal-ctags") {
-		// todo: restart, parallelization.
-		proc, err := newProcess(bin)
-		if err != nil {
-			return nil, err
+		opts := goctags.Options{
+			Bin:  bin,
+			Info: log.New(os.Stderr, "CTAGS INF: ", log.LstdFlags),
 		}
-		return &lockedParser{p: proc}, nil
+		if debug {
+			opts.Debug = log.New(os.Stderr, "CTAGS DBG: ", log.LstdFlags)
+		}
+		return &lockedParser{
+			opts: opts,
+		}, nil
 	}
 
 	log.Fatal("not implemented")

--- a/ctags/json_test.go
+++ b/ctags/json_test.go
@@ -27,7 +27,7 @@ func TestJSON(t *testing.T) {
 		t.Skip(err)
 	}
 
-	p, err := newProcess("universal-ctags")
+	p, err := NewParser("universal-ctags")
 	if err != nil {
 		t.Fatal("newProcess", err)
 	}


### PR DESCRIPTION
I believe the most common reason for a repo to not index is making ctags hang. This commit implements a timeout which will detect and fail indexing if ctags takes to long to respond for a single file.

We hard fail so we can notice these failures and follow-up to see what is causing the issue. The main benefit of this change is failing an index job much sooner (1minute), rather than waiting for indexserver to kill it after 30 minutes.

The initial version of this commit would restart ctags, which is why I added the lazy initialization. However, this would lead us to ignoring bad repos and paying a cost of 1min per bad file in a repo. So I added the failing condition. I left lazy initialization in since we may want it in the future / I don't think it is that much more complicated. Happy to adjust based on feedback.
