### PR TITLE
indexserver: move sourcegraph api functions into own struct

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -55,9 +55,8 @@ type IndexOptions struct {
 type indexArgs struct {
 	IndexOptions
 
-	// Root is the base URL for the Sourcegraph instance to index. Normally
-	// http://sourcegraph-frontend-internal or http://localhost:3090.
-	Root *url.URL
+	// CloneURL is the remote git URL of the repository for cloning.
+	CloneURL string
 
 	// Name is the name of the repository.
 	Name string
@@ -164,7 +163,7 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 	// We shallow fetch each commit specified in zoekt.Branches. This requires
 	// the server to have configured both uploadpack.allowAnySHA1InWant and
 	// uploadpack.allowFilter. (See gitservice.go in the Sourcegraph repository)
-	fetchArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--depth=1", getCloneURL(o.Root, o.Name)}
+	fetchArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--depth=1", o.CloneURL}
 	for _, b := range o.Branches {
 		fetchArgs = append(fetchArgs, b.Version)
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -4,17 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -131,48 +127,6 @@ func (o *indexArgs) String() string {
 	return s
 }
 
-// indexOptionsItem wraps IndexOptions to also include an error returned by
-// the API.
-type indexOptionsItem struct {
-	IndexOptions
-	Error string
-}
-
-func getIndexOptions(root *url.URL, repos ...string) ([]indexOptionsItem, error) {
-	u := root.ResolveReference(&url.URL{
-		Path: "/.internal/search/configuration",
-	})
-
-	resp, err := client.PostForm(u.String(), url.Values{"repo": repos})
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
-		_ = resp.Body.Close()
-		if err != nil {
-			return nil, err
-		}
-		return nil, &url.Error{
-			Op:  "Get",
-			URL: u.String(),
-			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
-		}
-	}
-
-	opts := make([]indexOptionsItem, len(repos))
-	dec := json.NewDecoder(resp.Body)
-	for i := range opts {
-		if err := dec.Decode(&opts[i]); err != nil {
-			return nil, fmt.Errorf("error decoding body: %w", err)
-		}
-	}
-
-	return opts, nil
-}
-
 func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 	if len(o.Branches) == 0 {
 		return errors.New("zoekt-git-index requires 1 or more branches")
@@ -210,8 +164,7 @@ func gitIndex(o *indexArgs, runCmd func(*exec.Cmd) error) error {
 	// We shallow fetch each commit specified in zoekt.Branches. This requires
 	// the server to have configured both uploadpack.allowAnySHA1InWant and
 	// uploadpack.allowFilter. (See gitservice.go in the Sourcegraph repository)
-	cloneURL := o.Root.ResolveReference(&url.URL{Path: path.Join("/.internal/git", o.Name)}).String()
-	fetchArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--depth=1", cloneURL}
+	fetchArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--depth=1", getCloneURL(o.Root, o.Name)}
 	for _, b := range o.Branches {
 		fetchArgs = append(fetchArgs, b.Version)
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 func TestGetIndexOptions(t *testing.T) {
@@ -39,6 +40,11 @@ func TestGetIndexOptions(t *testing.T) {
 	u, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	sg := &Sourcegraph{
+		Root:   u,
+		Client: retryablehttp.NewClient(),
 	}
 
 	cases := map[string]*IndexOptions{
@@ -67,7 +73,7 @@ func TestGetIndexOptions(t *testing.T) {
 	for r, want := range cases {
 		response = []byte(r)
 
-		got, err := getIndexOptions(u, "test/repo")
+		got, err := sg.GetIndexOptions("test/repo")
 		if err != nil && want != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -83,11 +83,6 @@ func TestGetIndexOptions(t *testing.T) {
 }
 
 func TestIndex(t *testing.T) {
-	root, err := url.Parse("http://api.test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		name string
 		args indexArgs
@@ -95,8 +90,8 @@ func TestIndex(t *testing.T) {
 	}{{
 		name: "minimal",
 		args: indexArgs{
-			Root: root,
-			Name: "test/repo",
+			CloneURL: "http://api.test/.internal/git/test/repo",
+			Name:     "test/repo",
 			IndexOptions: IndexOptions{
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 			},
@@ -116,8 +111,8 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "minimal-id",
 		args: indexArgs{
-			Root: root,
-			Name: "test/repo",
+			CloneURL: "http://api.test/.internal/git/test/repo",
+			Name:     "test/repo",
 			IndexOptions: IndexOptions{
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 				RepoID:   123,
@@ -138,7 +133,7 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "all",
 		args: indexArgs{
-			Root:              root,
+			CloneURL:          "http://api.test/.internal/git/test/repo",
 			Name:              "test/repo",
 			Incremental:       true,
 			IndexDir:          "/data/index",

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -15,18 +15,26 @@ import (
 )
 
 func TestServer_defaultArgs(t *testing.T) {
+	root, err := url.Parse("http://api.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	s := &Server{
+		Root:     root,
 		IndexDir: "/testdata/index",
 		CPUCount: 6,
 	}
 	want := &indexArgs{
+		Name:              "testName",
+		CloneURL:          "http://api.test/.internal/git/testName",
 		IndexDir:          "/testdata/index",
 		Parallelism:       6,
 		Incremental:       true,
 		FileLimit:         1 << 20,
 		DownloadLimitMBPS: "1000",
 	}
-	got := s.defaultArgs()
+	got := s.indexArgs("testName", IndexOptions{})
 	if !cmp.Equal(got, want) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+var client = retryablehttp.NewClient()
+
+func init() {
+	client.Logger = debug
+}
+
+// indexOptionsItem wraps IndexOptions to also include an error returned by
+// the API.
+type indexOptionsItem struct {
+	IndexOptions
+	Error string
+}
+
+func getIndexOptions(root *url.URL, repos ...string) ([]indexOptionsItem, error) {
+	u := root.ResolveReference(&url.URL{
+		Path: "/.internal/search/configuration",
+	})
+
+	resp, err := client.PostForm(u.String(), url.Values{"repo": repos})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, &url.Error{
+			Op:  "Get",
+			URL: u.String(),
+			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
+		}
+	}
+
+	opts := make([]indexOptionsItem, len(repos))
+	dec := json.NewDecoder(resp.Body)
+	for i := range opts {
+		if err := dec.Decode(&opts[i]); err != nil {
+			return nil, fmt.Errorf("error decoding body: %w", err)
+		}
+	}
+
+	return opts, nil
+}
+
+func getCloneURL(root *url.URL, name string) string {
+	return root.ResolveReference(&url.URL{Path: path.Join("/.internal/git", name)}).String()
+}
+
+func waitForFrontend(root *url.URL) {
+	warned := false
+	lastWarn := time.Now()
+	for {
+		err := ping(root)
+		if err == nil {
+			break
+		}
+
+		if time.Since(lastWarn) > 15*time.Second {
+			warned = true
+			lastWarn = time.Now()
+			log.Printf("frontend or gitserver API not available, will try again: %s", err)
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	if warned {
+		log.Println("frontend API is now reachable. Starting indexing...")
+	}
+}
+
+func listRepos(ctx context.Context, hostname string, root *url.URL, indexed []string) ([]string, error) {
+	body, err := json.Marshal(&struct {
+		Hostname string
+		Indexed  []string
+	}{
+		Hostname: hostname,
+		Indexed:  indexed,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	u := root.ResolveReference(&url.URL{Path: "/.internal/repos/index"})
+	resp, err := client.Post(u.String(), "application/json; charset=utf8", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list repositories: status %s", resp.Status)
+	}
+
+	var data struct {
+		RepoNames []string
+	}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	countsByHost := make(map[string]int)
+	for _, name := range data.RepoNames {
+		codeHost := codeHostFromName(name)
+		countsByHost[codeHost] += 1
+	}
+	for codeHost, count := range countsByHost {
+		metricNumAssigned.WithLabelValues(codeHost).Set(float64(count))
+	}
+	return data.RepoNames, nil
+}
+
+func ping(root *url.URL) error {
+	u := root.ResolveReference(&url.URL{Path: "/.internal/ping", RawQuery: "service=gitserver"})
+	resp, err := client.Get(u.String())
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ping: bad HTTP response status %d: %s", resp.StatusCode, string(body))
+	}
+	if !bytes.Equal(body, []byte("pong")) {
+		return fmt.Errorf("ping: did not receive pong: %s", string(body))
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is refactoring the interactions with the Sourcegraph API into its own struct. The intention is to add a mode to indexserver based on the local filesystem rather than just the Sourcegraph API. The benefit of that is it avoids needing to run the whole Sourcegraph environment to test manually test indexserver. This is so we can have a shorter feedback loop when making changes to indexserver -> move towards integration tests.

You can review this PR commit by commit.