### PR TITLE
zoekt-sourcegraph-indexserver: add --debug-meta

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -580,6 +581,33 @@ func setupTmpDir(index string) error {
 	return nil
 }
 
+func printMetaData(fn string) error {
+	repo, indexMeta, err := zoekt.ReadMetadataPath(fn)
+	if err!= nil {
+		return err
+	}
+
+	printJson := func(v interface{}) error {
+		b, err := json.Marshal(v)
+		if err!= nil {
+			return  err
+		}
+		fmt.Printf("%+v\n", string(b))
+		return nil
+	}
+
+	err = printJson(indexMeta)
+	if err!=nil {
+		return err
+	}
+
+	err = printJson(repo)
+	if err!=nil {
+		return err
+	}
+	return nil
+}
+
 func printShardStats(fn string) error {
 	f, err := os.Open(fn)
 	if err != nil {
@@ -630,6 +658,7 @@ func main() {
 	debugList := flag.Bool("debug-list", false, "do not start the indexserver, rather list the repositories owned by this indexserver then quit.")
 	debugIndex := flag.String("debug-index", "", "do not start the indexserver, rather index the repositories then quit.")
 	debugShard := flag.String("debug-shard", "", "do not start the indexserver, rather print shard stats then quit.")
+	debugMeta := flag.String("debug-meta", "", "do not start the indexserver, rather print shard metadata then quit.")
 
 	_ = flag.Bool("exp-git-index", true, "DEPRECATED: not read anymore. We always use zoekt-git-index now.")
 
@@ -722,6 +751,14 @@ func main() {
 	if *debugShard != "" {
 		err = printShardStats(*debugShard)
 		if err != nil {
+			log.Fatal(err)
+		}
+		os.Exit(0)
+	}
+
+	if *debugMeta != "" {
+	err = printMetaData(*debugMeta)
+		if err!= nil {
 			log.Fatal(err)
 		}
 		os.Exit(0)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -583,26 +583,26 @@ func setupTmpDir(index string) error {
 
 func printMetaData(fn string) error {
 	repo, indexMeta, err := zoekt.ReadMetadataPath(fn)
-	if err!= nil {
+	if err != nil {
 		return err
 	}
 
 	printJson := func(v interface{}) error {
 		b, err := json.Marshal(v)
-		if err!= nil {
-			return  err
+		if err != nil {
+			return err
 		}
 		fmt.Printf("%+v\n", string(b))
 		return nil
 	}
 
 	err = printJson(indexMeta)
-	if err!=nil {
+	if err != nil {
 		return err
 	}
 
 	err = printJson(repo)
-	if err!=nil {
+	if err != nil {
 		return err
 	}
 	return nil
@@ -757,8 +757,8 @@ func main() {
 	}
 
 	if *debugMeta != "" {
-	err = printMetaData(*debugMeta)
-		if err!= nil {
+		err = printMetaData(*debugMeta)
+		if err != nil {
 			log.Fatal(err)
 		}
 		os.Exit(0)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -587,21 +587,12 @@ func printMetaData(fn string) error {
 		return err
 	}
 
-	printJson := func(v interface{}) error {
-		b, err := json.Marshal(v)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("%+v\n", string(b))
-		return nil
-	}
-
-	err = printJson(indexMeta)
+	err = json.NewEncoder(os.Stdout).Encode(indexMeta)
 	if err != nil {
 		return err
 	}
 
-	err = printJson(repo)
+	err = json.NewEncoder(os.Stdout).Encode(repo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds a new flag --debug-meta which prints a shard's indexMetaData
and repository meta data. We print JSON, so the ouput can easily be
piped to jq or something similar.