### PR TITLE
ci: add step to push one-off custom images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,45 @@ jobs:
         add_git_labels: "true"
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+  custom-docker:
+    if: ${{ contains(github.ref, 'custom-docker') }}
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      # This is the same tag we used for zoekt in the infrastructure repo.
+      - name: version
+        id: version
+        run: .github/workflows/docker-version.sh
+
+      - name: build-zoekt
+        uses: docker/build-push-action@v1
+        with:
+          repository: zoekt
+          tags: "latest"
+          add_git_labels: "true"
+          push: "false"
+          build_args: VERSION=${{ steps.version.outputs.value }}
+
+      - name: build-push-webserver
+        uses: docker/build-push-action@v1
+        with:
+          repository: sourcegraph/zoekt-webserver
+          tags: ${{ steps.version.outputs.value }}
+          dockerfile: Dockerfile.webserver
+          add_git_labels: "true"
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: build-push-indexserver
+        uses: docker/build-push-action@v1
+        with:
+          repository: sourcegraph/zoekt-indexserver
+          tags: ${{ steps.version.outputs.value }}
+          dockerfile: Dockerfile.indexserver
+          add_git_labels: "true"
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-  custom-docker:
-    if: ${{ contains(github.ref, 'custom-docker') }}
+  docker-images-patch:
+    if: ${{ contains(github.ref, 'docker-images-patch') }}
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
branches that contain the substring "docker-images-patch" will
build and push images without the tag "latest".