### PR TITLE
indexserver: remove WaitForFrontend

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -242,7 +242,6 @@ func codeHostFromName(repoName string) string {
 // Run the sync loop. This blocks forever.
 func (s *Server) Run(queue *Queue) {
 	removeIncompleteShards(s.IndexDir)
-	s.Sourcegraph.WaitForFrontend()
 
 	// Start a goroutine which updates the queue with commits to index.
 	go func() {


### PR DESCRIPTION
We have a retryable http client, so we can instead rely on that.