### PR TITLE
builder: set same indexTime for all shards

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -414,6 +414,8 @@ func NewBuilder(opts Options) (*Builder, error) {
 		return nil, err
 	}
 
+	b.indexTime = time.Now()
+
 	return b, nil
 }
 

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -66,6 +66,20 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("want multiple shards, got %v", fs)
 	}
 
+	_, md0, err := zoekt.ReadMetadataPath(fs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range fs[1:] {
+		_, md, err := zoekt.ReadMetadataPath(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if md.IndexTime != md0.IndexTime {
+			t.Fatalf("wanted identical time stamps but got %v!=%v", md.IndexTime, md0.IndexTime)
+		}
+	}
+
 	ss, err := shards.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)


### PR DESCRIPTION
With this change, all shards belonging to the same repo will have the
same `indexTime` in their `repoMetaData`. This is useful for grouping
shards belonging to the same index job.