### PR TITLE
wip: mvp support compound shards in production

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -140,17 +140,13 @@ func getShards(dir string) map[string][]shard {
 			continue
 		}
 
-		// TODO support compound shards once we support tombstones
-		if len(names) != 1 {
-			continue
+		for _, name := range names {
+			shards[name] = append(shards[name], shard{
+				Repo:    name,
+				Path:    path,
+				ModTime: fi.ModTime(),
+			})
 		}
-		name := names[0]
-
-		shards[name] = append(shards[name], shard{
-			Repo:    name,
-			Path:    path,
-			ModTime: fi.ModTime(),
-		})
 	}
 	return shards
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -402,6 +402,11 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 		case build.IndexStateCorrupt:
 			log.Printf("falling back to full update: corrupt index: %s", args.String())
+
+			// TODO: Remove this case once we support tombstoning.
+		case build.IndexStateUnexpectedCompound:
+			log.Printf("compound shard: ignoring index request for %s", args.Name)
+			return indexStateNoop, nil
 		}
 	}
 


### PR DESCRIPTION
This is a hacky intermediary step towards testing compound shards in
production. `getShards` will now return compound shard as
individual shards pointing to the same file/shard.

As a consequence, indexserver is now aware of the repos contained in a
compound shard and won't reindex an existing repo.

On the downside, cleanup will delete the entire compound shard if one
the repos has to be discarded. Just for the sake of testing, I propose
that we temporarily disable cleanup on one of the Zoekt instances (not
part of this PR).