### PR TITLE
indexserver: PAUSE file to stop indexserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmd/zoekt-server/zoekt-server
 cmd/zoekt-git-index/zoekt-git-index
 .envrc
 .idea
+.direnv


### PR DESCRIPTION
PAUSE if present in IndexDir will stop index jobs from running. This is
to make it possible to experiment with the content of the IndexDir
without the indexserver writing to it.

Co-authored-by: @stefanhengl 