### PR TITLE
shards: close Searcher after exclusive lock

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -581,7 +581,6 @@ func searchOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoek
 	}()
 
 	ms, err := s.Search(ctx, q, opts)
-
 	if err != nil {
 		return err
 	}
@@ -774,15 +773,8 @@ func (s *shardedSearcher) replace(key string, shard zoekt.Searcher) {
 	}
 
 	proc := s.sched.Exclusive()
-	defer proc.Release()
 
 	old := s.shards[key]
-	if old.Searcher != nil {
-		start := time.Now()
-		old.Close()
-		metricShardCloseDurationSeconds.Observe(time.Since(start).Seconds())
-	}
-
 	if shard == nil {
 		delete(s.shards, key)
 	} else {
@@ -790,6 +782,14 @@ func (s *shardedSearcher) replace(key string, shard zoekt.Searcher) {
 	}
 	s.rankedVersion++
 	s.ranked = nil
+
+	proc.Release()
+
+	if old.Searcher != nil {
+		start := time.Now()
+		old.Close()
+		metricShardCloseDurationSeconds.Observe(time.Since(start).Seconds())
+	}
 
 	metricShardsLoaded.Set(float64(len(s.shards)))
 }


### PR DESCRIPTION
This should help reduce the exclusive lock time, but @rmmh is doing a larger change that avoid holding a full read lock during searches.