### PR TITLE
web: add repo RAM usage to repolist output

### DIFF
--- a/web/api.go
+++ b/web/api.go
@@ -103,6 +103,8 @@ type Repository struct {
 
 	// Total amount of content bytes.
 	Size int64
+	// Total resident RAM usage in bytes.
+	MemorySize int64
 }
 
 // PrintInput is provided to the server.Print template.

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -126,7 +126,7 @@ func TestBasic(t *testing.T) {
 			"Found 1 repositories",
 			nowStr,
 			"repo-url\">name",
-			"1 files (36)",
+			"1 files (36B)",
 		},
 		"/search?q=magic": {
 			`value=magic`,

--- a/web/templates.go
+++ b/web/templates.go
@@ -287,28 +287,31 @@ document.onkeydown=function(e){
   <div class="container">
     {{template "navbar" .Last}}
     <div><b>
-    Found {{.Stats.Repos}} repositories ({{.Stats.Documents}} files, {{HumanUnit .Stats.ContentBytes}}b content)
+    Found {{.Stats.Repos}} repositories ({{.Stats.Documents}} files, {{HumanUnit .Stats.ContentBytes}}B content)
     </b></div>
     <table class="table table-hover table-condensed">
       <thead>
 	<tr>
-	  <th>Name <a href="/search?q={{.Last.Query}}&order=name">▼</a><a href="/search?q={{.Last.Query}}&order=revname">▲</a></th>
-	  <th>Last updated <a href="/search?q={{.Last.Query}}&order=revtime">▼</a><a href="/search?q={{.Last.Query}}&order=time">▲</a></th>
+	  {{- define "q"}}q={{.Last.Query}}{{if (gt .Last.Num 0)}}&num={{.Last.Num}}{{end}}{{end}}
+	  <th>Name <a href="/search?{{template "q" .}}&order=name">▼</a><a href="/search?{{template "q" .}}&order=revname">▲</a></th>
+	  <th>Last updated <a href="/search?{{template "q" .}}&order=revtime">▼</a><a href="/search?{{template "q" .}}&order=time">▲</a></th>
 	  <th>Branches</th>
-	  <th>Size <a href="/search?q={{.Last.Query}}&order=revsize">▼</a><a href="/search?q={{.Last.Query}}&order=size">▲</a></th>
+	  <th>Size <a href="/search?{{template "q" .}}&order=revsize">▼</a><a href="/search?{{template "q" .}}&order=size">▲</a></th>
+	  <th>RAM <a href="/search?{{template "q" .}}&order=revram">▼</a><a href="/search?{{template "q" .}}&order=ram">▲</a></th>
 	</tr>
       </thead>
       <tbody>
-	{{range .Repos}}
+	{{range .Repos -}}
 	<tr>
 	  <td>{{if .URL}}<a href="{{.URL}}">{{end}}{{.Name}}{{if .URL}}</a>{{end}}</td>
 	  <td><small>{{.IndexTime.Format "Jan 02, 2006 15:04"}}</small></td>
 	  <td style="vertical-align: middle;">
-	    {{range .Branches}}
+	    {{- range .Branches -}}
 	    {{if .URL}}<tt><a class="label label-default small" href="{{.URL}}">{{end}}{{.Name}}{{if .URL}}</a> </tt>{{end}}&nbsp;
-	    {{end}}
+	    {{- end -}}
 	  </td>
-	  <td><small>{{HumanUnit .Files}} files ({{HumanUnit .Size}})</small></td>
+	  <td><small>{{HumanUnit .Files}} files ({{HumanUnit .Size}}B)</small></td>
+	  <td><small>{{HumanUnit .MemorySize}}B</td>
 	</tr>
 	{{end}}
       </tbody>


### PR DESCRIPTION
This makes finding pathologically huge repos much easier. The repo list
already had a column for content size, and this change adds a column for
index size -- that is, approximately how many bytes of RAM are being
used by the repo.

To view, visit http://ZOEKTBACKEND/search?q=repo%3a&order=revram

Example output:
![image](https://user-images.githubusercontent.com/211868/132379924-5ea4e069-7ae0-490f-9b41-836a69b2baab.png)

Change-Id: Ie8c0e22faf398510c7699617aaa8885e7e80497b