### PR TITLE
indexserver: remove codehost label from metrics

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -85,24 +85,3 @@ func TestListRepos(t *testing.T) {
 		t.Errorf("request path mismatch (-want +got):\n%s", cmp.Diff(want, gotURL.Path))
 	}
 }
-
-func TestCodeHostFromName(t *testing.T) {
-	cases := map[string]string{
-		// no codehost
-		"foo":     "unknown",
-		"foo/bar": "unknown",
-		"/foo":    "unknown",
-		"/":       "unknown",
-		"":        "unknown",
-
-		"foo.com":     "foo.com",
-		"foo.com/bar": "foo.com",
-	}
-
-	for repoName, want := range cases {
-		got := codeHostFromName(repoName)
-		if got != want {
-			t.Errorf("codeHostFromName(%q): got %q want %q", repoName, got, want)
-		}
-	}
-}

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -116,14 +116,8 @@ func (s *sourcegraphClient) ListRepos(ctx context.Context, indexed []string) ([]
 		return nil, err
 	}
 
-	countsByHost := make(map[string]int)
-	for _, name := range data.RepoNames {
-		codeHost := codeHostFromName(name)
-		countsByHost[codeHost] += 1
-	}
-	for codeHost, count := range countsByHost {
-		metricNumAssigned.WithLabelValues(codeHost).Set(float64(count))
-	}
+	metricNumAssigned.Set(float64(len(data.RepoNames)))
+
 	return data.RepoNames, nil
 }
 


### PR DESCRIPTION
This doesn't seem like a useful value to track anymore. I think
historically we were interested in it while rolling out gitlab
support.