### PR TITLE
build: don't count content of skipped files

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -451,6 +451,11 @@ func (b *Builder) Add(doc zoekt.Document) error {
 	}
 
 	b.todo = append(b.todo, &doc)
+
+	if doc.SkipReason != "" {
+		return nil
+	}
+
 	b.size += len(doc.Name) + len(doc.Content)
 	if b.size > b.opts.ShardMax {
 		return b.flush()

--- a/build/builder.go
+++ b/build/builder.go
@@ -452,11 +452,12 @@ func (b *Builder) Add(doc zoekt.Document) error {
 
 	b.todo = append(b.todo, &doc)
 
-	if doc.SkipReason != "" {
-		return nil
+	if doc.SkipReason == "" {
+		b.size += len(doc.Name) + len(doc.Content)
+	} else {
+		b.size += len(doc.Name) + len(doc.SkipReason)
 	}
 
-	b.size += len(doc.Name) + len(doc.Content)
 	if b.size > b.opts.ShardMax {
 		return b.flush()
 	}

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -194,3 +194,28 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(m.Run())
 }
+
+func TestDontCountSkippedFiles(t *testing.T) {
+	b, err := NewBuilder(Options{RepositoryDescription: zoekt.Repository{
+		Name: "foo",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binary := "abc def \x00 abc"
+
+	err = b.Add(zoekt.Document{
+		Name:    "f1",
+		Content: []byte(binary),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b.todo) != 1 || b.todo[0].SkipReason == "" {
+		t.Fatalf("document should have been skipped")
+	}
+	if b.size != 0 {
+		t.Fatalf("skipped documents should not count towards shard size thresold")
+	}
+}

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -195,7 +195,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestDontCountSkippedFiles(t *testing.T) {
+func TestDontCountContentOfSkippedFiles(t *testing.T) {
 	b, err := NewBuilder(Options{RepositoryDescription: zoekt.Repository{
 		Name: "foo",
 	}})
@@ -203,11 +203,11 @@ func TestDontCountSkippedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	binary := "abc def \x00 abc"
-
+	// content with at least 100 bytes
+	binary := append([]byte("abc def \x00"), make([]byte, 100)...)
 	err = b.Add(zoekt.Document{
 		Name:    "f1",
-		Content: []byte(binary),
+		Content: binary,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -215,7 +215,7 @@ func TestDontCountSkippedFiles(t *testing.T) {
 	if len(b.todo) != 1 || b.todo[0].SkipReason == "" {
 		t.Fatalf("document should have been skipped")
 	}
-	if b.size != 0 {
-		t.Fatalf("skipped documents should not count towards shard size thresold")
+	if b.size >= 100 {
+		t.Fatalf("content of skipped documents should not count towards shard size thresold")
 	}
 }


### PR DESCRIPTION
For repositories with a lot of binary files we sometimes ended up with
several tiny shards, although the content would have easily fit into a
single shard.