### PR TITLE
indexserver: compound shard support

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -574,6 +574,7 @@ func (b *Builder) Finish() error {
 
 	for p := range toDelete {
 		log.Printf("removing old shard file: %s", p)
+		b.shardLog("remove", p)
 		if err := os.Remove(p); err != nil {
 			b.buildError = err
 		}

--- a/build/builder.go
+++ b/build/builder.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -327,6 +328,23 @@ func (o *Options) IndexState() IndexState {
 
 	repos, index, err := zoekt.ReadMetadataPath(fn)
 	if os.IsNotExist(err) {
+		// TODO: remove once we support resolving repo name to shard name
+		// Ignore index requests for repos contained in compound shards.
+		compoundShards, err := filepath.Glob(path.Join(o.IndexDir, "compound-*.zoekt"))
+		if err != nil {
+			return IndexStateMissing
+		}
+		for _, fn := range compoundShards {
+			repos, index, err = zoekt.ReadMetadataPath(fn)
+			if err != nil {
+				return IndexStateMissing
+			}
+			for _, repo := range repos {
+				if repo.Name == o.RepositoryDescription.Name {
+					return IndexStateUnexpectedCompound
+				}
+			}
+		}
 		return IndexStateMissing
 	} else if err != nil {
 		return IndexStateCorrupt

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -140,17 +140,13 @@ func getShards(dir string) map[string][]shard {
 			continue
 		}
 
-		// TODO support compound shards once we support tombstones
-		if len(names) != 1 {
-			continue
+		for _, name := range names {
+			shards[name] = append(shards[name], shard{
+				Repo:    name,
+				Path:    path,
+				ModTime: fi.ModTime(),
+			})
 		}
-		name := names[0]
-
-		shards[name] = append(shards[name], shard{
-			Repo:    name,
-			Path:    path,
-			ModTime: fi.ModTime(),
-		})
 	}
 	return shards
 }

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/zoekt"
@@ -221,6 +222,14 @@ func moveAll(dstDir string, shards []shard) {
 		dstShard := shard
 		dstShard.Path = filepath.Join(dstDir, filepath.Base(shard.Path))
 		removeAll(dstShard)
+
+		// HACK we do not yet support tombstones in compound shard. So we avoid
+		// needing to deal with it by always deleting the whole compound shard.
+		if strings.HasPrefix(filepath.Base(shard.Path), "compound-") {
+			log.Printf("HACK removing compound shard since we don't support tombstoning: %s", shard.Path)
+			removeAll(shard)
+			continue
+		}
 
 		// Rename all paths, stop at first failure
 		for _, p := range paths {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -423,11 +423,6 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 		case build.IndexStateCorrupt:
 			log.Printf("falling back to full update: corrupt index: %s", args.String())
-
-			// TODO: Remove this case once we support tombstoning.
-		case build.IndexStateUnexpectedCompound:
-			log.Printf("compound shard: ignoring index request for %s", args.Name)
-			return indexStateNoop, nil
 		}
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -423,6 +423,11 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 		case build.IndexStateCorrupt:
 			log.Printf("falling back to full update: corrupt index: %s", args.String())
+
+			// TODO: Remove this case once we support tombstoning.
+		case build.IndexStateUnexpectedCompound:
+			log.Printf("compound shard: ignoring index request for %s", args.Name)
+			return indexStateNoop, nil
 		}
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/meta_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/build"
+)
+
+func TestMergeMeta(t *testing.T) {
+	dir := t.TempDir()
+
+	repoNames := []string{"repo0", "repo1", "repo2", "repo3"}
+	var repoFns []string
+
+	for _, name := range repoNames {
+		opts := build.Options{
+			IndexDir: dir,
+			RepositoryDescription: zoekt.Repository{
+				Name: name,
+				RawConfig: map[string]string{
+					"public": "1",
+				},
+			},
+		}
+		opts.SetDefaults()
+		b, err := build.NewBuilder(opts)
+		if err != nil {
+			t.Fatalf("NewBuilder: %v", err)
+		}
+		b.AddFile("F", []byte(strings.Repeat("abc", 100)))
+		if err := b.Finish(); err != nil {
+			t.Errorf("Finish: %v", err)
+		}
+		repoFns = append(repoFns, opts.FindAllShards()...)
+	}
+
+	// update meta on repo3 then test it changed
+	opts := &build.Options{
+		IndexDir: dir,
+		RepositoryDescription: zoekt.Repository{
+			Name: "repo3",
+			RawConfig: map[string]string{
+				"public": "0",
+			},
+		},
+	}
+	opts.SetDefaults()
+	if err := mergeMeta(opts); err != nil {
+		t.Fatal(err)
+	}
+	repos, _, _ := zoekt.ReadMetadataPath(repoFns[3])
+	if got, want := repos[0].RawConfig["public"], "0"; got != want {
+		t.Fatalf("failed to update metadata of repo3. Got public %q want %q", got, want)
+	}
+
+	// create a compound shard. Use a new indexdir to avoid the need to cleanup
+	// old shards.
+	dir = t.TempDir()
+	fn, err := merge(dir, repoFns)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readPublic := func() []string {
+		repos, _, _ := zoekt.ReadMetadataPath(fn)
+		var public []string
+		for _, r := range repos {
+			public = append(public, r.RawConfig["public"])
+		}
+		return public
+	}
+
+	if d := cmp.Diff([]string{"1", "1", "1", "0"}, readPublic()); d != "" {
+		t.Fatalf("wanted only repo3 to be marked private:\n%s", d)
+	}
+
+	// Update a repo1 in compound shard to be private
+	opts = &build.Options{
+		IndexDir: dir,
+		RepositoryDescription: zoekt.Repository{
+			Name: "repo1",
+			RawConfig: map[string]string{
+				"public": "0",
+			},
+		},
+	}
+	opts.SetDefaults()
+	if err := mergeMeta(opts); err != nil {
+		t.Fatal(err)
+	}
+	if d := cmp.Diff([]string{"1", "0", "1", "0"}, readPublic()); d != "" {
+		t.Fatalf("wanted only repo1 to be marked private:\n%s", d)
+	}
+}
+
+func merge(dstDir string, names []string) (string, error) {
+	var files []zoekt.IndexFile
+	for _, fn := range names {
+		f, err := os.Open(fn)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+
+		indexFile, err := zoekt.NewIndexFile(f)
+		if err != nil {
+			return "", err
+		}
+		defer indexFile.Close()
+
+		files = append(files, indexFile)
+	}
+
+	return zoekt.Merge(dstDir, files...)
+}


### PR DESCRIPTION
When updating an index for a repository we need to check against any existing index for a repository. This commit adds support for looking in compound shards for a repository when updating. Additionally it teaches indexserver's cleanup about compound shards.

This commit does not use tombstoning. Instead it deletes compound shards if any repository in it needs to be removed/updated. This means we then need to re-index everything in the compound shard. This is not our end state, but rather an intermediate step so that we can test compound shards without pausing the indexserver.
