### PR TITLE
indexserver: don't ask for url if not needed

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -676,7 +676,8 @@ func main() {
 	if *index == "" {
 		log.Fatal("must set -index")
 	}
-	if *root == "" {
+	needSourcegraph := !(*debugShard != "" || *debugMeta != "")
+	if *root == "" && needSourcegraph {
 		log.Fatal("must set -sourcegraph_url")
 	}
 	rootURL, err := url.Parse(*root)


### PR DESCRIPTION
--debug-meta and --debug-shard don't require a connection to
Sourcegraph. This change makes it less annoying to invoke the commands
from the index directory during local development.