### PR TITLE
dev: set fork, public, archived based on sentinel files

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -160,6 +160,15 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 		}}
 	}
 
+	if _, err := os.Stat(filepath.Join(dir, "SG_PRIVATE")); err == nil {
+		opts.Public = false
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SG_FORK")); err == nil {
+		opts.Fork = true
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SG_ARCHIVED")); err == nil {
+		opts.Archived = true
+	}
 	return opts, nil
 }
 


### PR DESCRIPTION
This lets us test changes to metadata while running Zoekt against a
fake instance of Sourcegraph.

Touching a file "SG_*" in the repo's root will set the corresonding
property in the response of getIndexOptions.