### PR TITLE
indexserver: port merging policy to Go

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -127,12 +127,6 @@ type shard struct {
 	Repo    string
 	Path    string
 	ModTime time.Time
-
-	// The size as reported by os.Stat.
-	SizeBytes int64
-
-	// The rank of repo as recorded in its RawConfig.
-	Rank float64
 }
 
 func getShards(dir string) map[string][]shard {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -127,6 +127,12 @@ type shard struct {
 	Repo    string
 	Path    string
 	ModTime time.Time
+
+	// The size as reported by os.Stat.
+	SizeBytes int64
+
+	// The rank of repo as recorded in its RawConfig.
+	Rank float64
 }
 
 func getShards(dir string) map[string][]shard {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -817,30 +816,7 @@ func main() {
 	}
 
 	if *debugMerge != "" {
-		params := strings.Split(*debugMerge, ",")
-		dir := params[0]
-
-		maxSize, err := strconv.Atoi(params[1])
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		targetSize, err := strconv.Atoi(params[2])
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		days, err := strconv.Atoi(params[3])
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		simulate, err := strconv.ParseBool(params[4])
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		err = doMerge(dir, targetSize, maxSize, days, simulate)
+		err = doMerge(*debugMerge)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -741,7 +741,7 @@ func main() {
 		}
 	}
 
-	isDebugCmd := *debugList || *debugIndex != "" || *debugShard != "" || *debugMeta != ""
+	isDebugCmd := *debugList || *debugIndex != "" || *debugShard != "" || *debugMeta != "" || *debugMerge != ""
 
 	if err := setupTmpDir(*index, !isDebugCmd); err != nil {
 		log.Fatalf("failed to setup TMPDIR under %s: %v", *index, err)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -696,7 +696,7 @@ func main() {
 	debugIndex := flag.String("debug-index", "", "do not start the indexserver, rather index the repositories then quit.")
 	debugShard := flag.String("debug-shard", "", "do not start the indexserver, rather print shard stats then quit.")
 	debugMeta := flag.String("debug-meta", "", "do not start the indexserver, rather print shard metadata then quit.")
-	debugMerge := flag.String("debug-merge", "", "index dir,max shard size in MiB,compound target size in MiB,min age in days.")
+	debugMerge := flag.String("debug-merge", "", "index dir,compound target size in MiB,simulate(true,false)")
 
 	_ = flag.Bool("exp-git-index", true, "DEPRECATED: not read anymore. We always use zoekt-git-index now.")
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -14,10 +15,29 @@ import (
 	"github.com/google/zoekt"
 )
 
-// doMerge drives the merge process, I imagine this function goes away once we
-// automate merging.
+// parseParams is helper function to parse a comma separated string of parameters
+// of the form "string,int,bool". This should be used just for debugging and
+// testing only.
+func parseParams(params string) (indexDir string, targetSizeBytes int64, simulate bool, err error) {
+	ps := strings.Split(params, ",")
+	indexDir = ps[0]
+
+	targetSize, err := strconv.Atoi(ps[1])
+	if err != nil {
+		return
+	}
+	targetSizeBytes = int64(targetSize * 1024 * 1024)
+
+	simulate, err = strconv.ParseBool(ps[3])
+	if err != nil {
+		return
+	}
+	return
+}
+
+// doMerge drives the merge process.
 func doMerge(params string) error {
-	dir, maxSize, targetSize, days, simulate, err := parseParams(params)
+	dir, targetSizeBytes, simulate, err := parseParams(params)
 	if err != nil {
 		return err
 	}
@@ -26,27 +46,14 @@ func doMerge(params string) error {
 		debug.Println("simulating")
 	}
 
-	shards := loadShards(dir)
+	shards, excluded := loadCandidates(dir)
+	debug.Printf("found %d candidate shards, %d excluded\n", len(shards), excluded)
 	if len(shards) == 0 {
-		return fmt.Errorf("no shards found")
-	}
-	debug.Printf("found %d shards\n", len(shards))
-
-	backupDir := filepath.Join(dir, ".scratch/bak")
-	err = os.MkdirAll(backupDir, 0o755)
-	if err != nil {
-		debug.Printf("error creating backup dir %s: %s", backupDir, err)
-		return err
+		return nil
 	}
 
-	opts := compoundOpts{
-		targetSizeBytes: int64(targetSize) * 1024 * 1024,
-		maxSizeBytes:    int64(maxSize) * 1024 * 1024,
-		cutoffDate:      time.Now().AddDate(0, 0, -days),
-	}
-	compounds, excluded := generateCompounds(shards, opts)
-
-	debug.Printf("generated %d compounds and %d excluded repositories\n", len(compounds), len(excluded))
+	compounds := generateCompounds(shards, targetSizeBytes)
+	debug.Printf("generated %d compounds\n", len(compounds))
 	if len(compounds) == 0 {
 		return nil
 	}
@@ -57,10 +64,12 @@ func doMerge(params string) error {
 		debug.Printf("compound %d: merging %d shards with total size %.2f MiB\n", ix, len(comp.shards), float64(comp.size)/(1024*1024))
 		if !simulate {
 			err := callMerge(comp.shards)
+			for _, s := range comp.shards {
+				os.Remove(s.path)
+			}
 			if err != nil {
 				return err
 			}
-			moveAll(backupDir, comp.shards)
 		}
 		totalShards += len(comp.shards)
 		totalSizeBytes += comp.size
@@ -70,17 +79,26 @@ func doMerge(params string) error {
 	return nil
 }
 
-// loadShards returns all simple shards in dir without .meta files.
-func loadShards(dir string) []shard {
+type candidate struct {
+	path string
+
+	// The size as reported by os.Stat.
+	sizeBytes int64
+}
+
+// loadCandidates returns all shards eligable for merging.
+func loadCandidates(dir string) ([]candidate, int) {
+	excluded := 0
+
 	d, err := os.Open(dir)
 	if err != nil {
-		debug.Printf("failed to loadShards: %s", dir)
-		return []shard{}
+		debug.Printf("failed to load candidates: %s", dir)
+		return []candidate{}, excluded
 	}
 	defer d.Close()
 	names, _ := d.Readdirnames(-1)
 
-	shards := make([]shard, 0, len(names))
+	candidates := make([]candidate, 0, len(names))
 	for _, n := range names {
 		path := filepath.Join(dir, n)
 
@@ -90,103 +108,103 @@ func loadShards(dir string) []shard {
 			continue
 		}
 
-		if fi.IsDir() || filepath.Ext(path) != ".zoekt" || strings.HasPrefix(filepath.Base(path), "compound-") {
+		if fi.IsDir() || filepath.Ext(path) != ".zoekt" {
 			continue
 		}
 
-		repos, _, err := zoekt.ReadMetadataPath(path)
-		if err != nil {
-			debug.Printf("failed to load metadata for %s\n", filepath.Base(path))
-			continue
-		}
-		if len(repos) != 1 {
-			debug.Printf("expected %s to be a simple shard, but encountered %d repos", n, len(repos))
+		if isExcluded(path) {
+			excluded++
 			continue
 		}
 
-		rank, err := strconv.ParseFloat(repos[0].RawConfig["rank"], 64)
-		if err != nil {
-			debug.Printf("error parsing rank %s for shard: %s: %s, setting rank to 0", repos[0].RawConfig["rank"], n, err)
-			rank = 0
-		}
-
-		shards = append(shards, shard{
-			Repo:      n,
-			Path:      path,
-			ModTime:   fi.ModTime(),
-			SizeBytes: fi.Size(),
-			Rank:      rank,
+		candidates = append(candidates, candidate{
+			path:      path,
+			sizeBytes: fi.Size(),
 		})
 	}
-	return shards
+	return candidates, excluded
+}
+
+var reShard = regexp.MustCompile("\\.[0-9]{5}\\.zoekt$")
+
+func hasMultipleShards(path string) bool {
+	if !reShard.MatchString(path) {
+		return false
+	}
+	secondShard := reShard.ReplaceAllString(path, ".00001.zoekt")
+	_, err := os.Stat(secondShard)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func isExcluded(path string) bool {
+	repos, _, err := zoekt.ReadMetadataPath(path)
+	if err != nil {
+		debug.Printf("failed to load metadata for %s\n", filepath.Base(path))
+		return true
+	}
+
+	if len(repos) > 1 {
+		return false
+	}
+
+	if repos[0].LatestCommitDate.After(time.Now().AddDate(0, 0, -7)) {
+		return true
+	}
+
+	if rank, err := strconv.Atoi(repos[0].RawConfig["rank"]); err == nil && rank > 100 {
+		return true
+	}
+
+	if hasMultipleShards(path) {
+		return true
+	}
+
+	return false
 }
 
 type compound struct {
-	shards []shard
+	shards []candidate
 	size   int64
 }
 
-type compoundOpts struct {
-	targetSizeBytes int64
-	maxSizeBytes    int64
-	cutoffDate      time.Time
+func (c *compound) add(cand candidate) {
+	c.shards = append(c.shards, cand)
+	c.size += cand.sizeBytes
 }
 
-// generateCompounds encodes the merge policy:
-//   - merge shards that are older than opt.cutoffDate
-//   - merge shards that are smaller than opt.maxSizeBytes
-//   - merge shards with similar rank
-//   - compound shards should be larger than opt.targetSizeBytes
-func generateCompounds(shards []shard, opt compoundOpts) ([]compound, []shard) {
-	cur := 0
-	for ix, s := range shards {
-		if s.ModTime.After(opt.cutoffDate) || s.SizeBytes > opt.maxSizeBytes {
-			shards[cur], shards[ix] = shards[ix], shards[cur]
-			cur++
-			continue
-		}
-	}
-	if cur == len(shards) {
-		return []compound{}, shards
-	}
-
-	excluded := shards[:cur]
-	shards = shards[cur:]
-
+func generateCompounds(shards []candidate, targetSizeBytes int64) []compound {
 	sort.Slice(shards, func(i, j int) bool {
-		return shards[i].Rank < shards[j].Rank
+		return shards[i].sizeBytes < shards[j].sizeBytes
 	})
 
-	// We prioritze merging shards with similar priority. This approach does not
-	// minimize the distance to the target compound size, but it gets close enough.
 	compounds := make([]compound, 0)
-	currentCompound := compound{}
-	for _, s := range shards {
-		if currentCompound.size > opt.targetSizeBytes {
-			compounds = append(compounds, currentCompound)
-			currentCompound = compound{}
-		}
-		currentCompound.shards = append(currentCompound.shards, s)
-		currentCompound.size += s.SizeBytes
-	}
-	if currentCompound.size > opt.targetSizeBytes {
-		compounds = append(compounds, currentCompound)
-	} else {
-		// The shards in currentCompound did not reach the desired target size. We don't
-		// want to create tiny compound shards, hence we append to excluded. The next
-		// time we run merge we might have enough shards to cross the threshold.
-		excluded = append(excluded, currentCompound.shards...)
-	}
+	for len(shards) > 0 {
+		cur := compound{}
 
-	return compounds, excluded
+		cur.add(shards[len(shards)-1])
+		shards = shards[:len(shards)-1]
+		for i := len(shards) - 1; i >= 0; i-- {
+			if cur.size+shards[i].sizeBytes > targetSizeBytes {
+				continue
+			}
+			cur.add(shards[i])
+			shards = append(shards[:i], shards[i+1:]...)
+		}
+
+		// No need to merge a single shard.
+		if len(cur.shards) == 1 {
+			continue
+		}
+
+		compounds = append(compounds, cur)
+	}
+	return compounds
 }
 
-func callMerge(shards []shard) error {
-	sb := strings.Builder{}
-	for _, s := range shards {
-		sb.WriteString(fmt.Sprintf("%s\n", s.Path))
-	}
-
+func callMerge(shards []candidate) error {
 	cmd := exec.Command("zoekt-merge-index", "-")
 	wc, err := cmd.StdinPipe()
 	if err != nil {
@@ -198,40 +216,10 @@ func callMerge(shards []shard) error {
 		return err
 	}
 
-	_, err = io.WriteString(wc, sb.String())
-	if err != nil {
-		return err
+	for _, s := range shards {
+		io.WriteString(wc, fmt.Sprintf("%s\n", s.path))
 	}
 	wc.Close()
 
 	return cmd.Wait()
-}
-
-// parseParams is helper function to parse a comma separated string of parameters
-// of the form "path,1,2000,1,true". This should be used just for debugging and
-// testing.
-func parseParams(params string) (indexDir string, maxSize int, targetSize int, days int, simulate bool, err error) {
-	ps := strings.Split(params, ",")
-	indexDir = ps[0]
-
-	maxSize, err = strconv.Atoi(ps[1])
-	if err != nil {
-		return
-	}
-
-	targetSize, err = strconv.Atoi(ps[2])
-	if err != nil {
-		return
-	}
-
-	days, err = strconv.Atoi(ps[3])
-	if err != nil {
-		return
-	}
-
-	simulate, err = strconv.ParseBool(ps[4])
-	if err != nil {
-		return
-	}
-	return
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -154,7 +154,7 @@ func isExcluded(path string) bool {
 		return true
 	}
 
-	if rank, err := strconv.Atoi(repos[0].RawConfig["rank"]); err == nil && rank > 100 {
+	if priority, err := strconv.ParseFloat(repos[0].RawConfig["priority"], 64); err == nil && priority > 100 {
 		return true
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -140,6 +140,10 @@ func hasMultipleShards(path string) bool {
 }
 
 func isExcluded(path string) bool {
+	if hasMultipleShards(path) {
+		return true
+	}
+
 	repos, _, err := zoekt.ReadMetadataPath(path)
 	if err != nil {
 		debug.Printf("failed to load metadata for %s\n", filepath.Base(path))
@@ -155,10 +159,6 @@ func isExcluded(path string) bool {
 	}
 
 	if priority, err := strconv.ParseFloat(repos[0].RawConfig["priority"], 64); err == nil && priority > 100 {
-		return true
-	}
-
-	if hasMultipleShards(path) {
 		return true
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -14,7 +14,12 @@ import (
 	"github.com/google/zoekt"
 )
 
-func doMerge(dir string, targetSize int, maxSize int, days int, simulate bool) error {
+func doMerge(params string) error {
+	dir, maxSize, targetSize, days, simulate, err := parseParams(params)
+	if err != nil {
+		return err
+	}
+
 	if simulate {
 		debug.Println("simulating")
 	}
@@ -26,7 +31,7 @@ func doMerge(dir string, targetSize int, maxSize int, days int, simulate bool) e
 	debug.Printf("found %d shards\n", len(shards))
 
 	backupDir := filepath.Join(dir, ".scratch/bak")
-	err := os.MkdirAll(backupDir, 0o755)
+	err = os.MkdirAll(backupDir, 0o755)
 	if err != nil {
 		debug.Printf("error creating backup dir %s: %s", backupDir, err)
 		return err
@@ -197,4 +202,30 @@ func callMerge(shards []shard) error {
 	wc.Close()
 
 	return cmd.Wait()
+}
+
+func parseParams(params string) (indexDir string, maxSize int, targetSize int, days int, simulate bool, err error) {
+	ps := strings.Split(params, ",")
+	indexDir = ps[0]
+
+	maxSize, err = strconv.Atoi(ps[1])
+	if err != nil {
+		return
+	}
+
+	targetSize, err = strconv.Atoi(ps[2])
+	if err != nil {
+		return
+	}
+
+	days, err = strconv.Atoi(ps[3])
+	if err != nil {
+		return
+	}
+
+	simulate, err = strconv.ParseBool(ps[4])
+	if err != nil {
+		return
+	}
+	return
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -14,6 +14,8 @@ import (
 	"github.com/google/zoekt"
 )
 
+// doMerge drives the merge process, I imagine this function goes away once we
+// automate merging.
 func doMerge(params string) error {
 	dir, maxSize, targetSize, days, simulate, err := parseParams(params)
 	if err != nil {
@@ -68,6 +70,7 @@ func doMerge(params string) error {
 	return nil
 }
 
+// loadShards returns all simple shards in dir without .meta files.
 func loadShards(dir string) []shard {
 	d, err := os.Open(dir)
 	if err != nil {
@@ -129,7 +132,7 @@ type compoundOpts struct {
 	cutoffDate      time.Time
 }
 
-// generateCompounds encodes the following merge policy:
+// generateCompounds encodes the merge policy:
 //   - merge shards that are older than opt.cutoffDate
 //   - merge shards that are smaller than opt.maxSizeBytes
 //   - merge shards with similar rank
@@ -204,6 +207,9 @@ func callMerge(shards []shard) error {
 	return cmd.Wait()
 }
 
+// parseParams is helper function to parse a comma separated string of parameters
+// of the form "path,1,2000,1,true". This should be used just for debugging and
+// testing.
 func parseParams(params string) (indexDir string, maxSize int, targetSize int, days int, simulate bool, err error) {
 	ps := strings.Split(params, ",")
 	indexDir = ps[0]

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -47,13 +47,13 @@ func doMerge(params string) error {
 	}
 
 	shards, excluded := loadCandidates(dir)
-	debug.Printf("found %d candidate shards, %d repos were excluded\n", len(shards), excluded)
+	debug.Printf("merging: found %d candidate shards, %d repos were excluded\n", len(shards), excluded)
 	if len(shards) == 0 {
 		return nil
 	}
 
 	compounds := generateCompounds(shards, targetSizeBytes)
-	debug.Printf("generated %d compounds\n", len(compounds))
+	debug.Printf("merging: generated %d compounds\n", len(compounds))
 	if len(compounds) == 0 {
 		return nil
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -193,18 +193,16 @@ func generateCompounds(shards []candidate, targetSizeBytes int64) []compound {
 			cur.add(shards[i])
 			shards = append(shards[:i], shards[i+1:]...)
 		}
-
-		// No need to merge a single shard.
-		if len(cur.shards) == 1 {
-			continue
-		}
-
 		compounds = append(compounds, cur)
 	}
 	return compounds
 }
 
 func callMerge(shards []candidate) error {
+	if len(shards) <= 1 {
+		return nil
+	}
+
 	cmd := exec.Command("zoekt-merge-index", "-")
 	wc, err := cmd.StdinPipe()
 	if err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -81,10 +81,14 @@ func doMerge(params string) error {
 			if err != nil {
 				return fmt.Errorf("%s: %s", stdErr, err)
 			}
-			newCompoundName := reCompound.Find(stdErr)
-			now := time.Now()
-			for _, s := range comp.shards {
-				_, _ = fmt.Fprintf(wc, "%d\t%s\t%s\t%s\n", now.UTC().Unix(), "merge", filepath.Base(s.path), string(newCompoundName))
+			// for len(comp.shards)<=1, callMerge is a NOP. Hence there is no need to log
+			// anything here.
+			if len(comp.shards) > 1 {
+				newCompoundName := reCompound.Find(stdErr)
+				now := time.Now()
+				for _, s := range comp.shards {
+					_, _ = fmt.Fprintf(wc, "%d\t%s\t%s\t%s\n", now.UTC().Unix(), "merge", filepath.Base(s.path), string(newCompoundName))
+				}
 			}
 		}
 		totalShards += len(comp.shards)
@@ -218,6 +222,8 @@ func generateCompounds(shards []candidate, targetSizeBytes int64) []compound {
 	return compounds
 }
 
+// callMerge calls zoekt-merge-index and caputures its output. callMerge is a NOP
+// if len(shards) <= 1.
 func callMerge(shards []candidate) ([]byte, []byte, error) {
 	if len(shards) <= 1 {
 		return nil, nil, nil

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGenerateCompoundShards(t *testing.T) {
+	old := time.Date(2021, 01, 01, 0, 0, 0, 0, time.UTC)
+	recent := old.AddDate(0, 0, 30)
+
+	var maxSize int64 = 1 * 1024 * 1024
+
+	shards := []shard{
+		{
+			Repo:      "r1",
+			ModTime:   old,
+			SizeBytes: maxSize - 1,
+			Rank:      1,
+		},
+		{
+			Repo:      "r2",
+			ModTime:   old,
+			SizeBytes: maxSize - 1,
+			Rank:      3,
+		},
+		{
+			Repo:      "r3",
+			ModTime:   old,
+			SizeBytes: maxSize - 1,
+			Rank:      2,
+		},
+		{
+			Repo:      "r4",
+			ModTime:   old,
+			SizeBytes: maxSize - 1,
+			Rank:      4,
+		},
+		// Too new
+		{
+			Repo:      "r5",
+			ModTime:   recent,
+			SizeBytes: 1,
+			Rank:      5,
+		},
+		// Too big
+		{
+			Repo:      "r6",
+			ModTime:   old,
+			SizeBytes: 2 * maxSize,
+			Rank:      1,
+		},
+	}
+
+	compounds, excluded := generateCompounds(shards, compoundOpts{
+		targetSizeBytes: maxSize,
+		maxSizeBytes:    maxSize,
+		cutoffDate:      old.AddDate(0, 0, 1),
+	})
+
+	if len(compounds) != 2 {
+		t.Fatalf("expected 2 compound shards, but got %d", len(compounds))
+	}
+
+	totalShards := 0
+	for _, c := range compounds {
+		totalShards += len(c.shards)
+	}
+	totalShards += len(excluded)
+	if totalShards != len(shards) {
+		t.Fatalf("shards mismatch: wanted %d, got %d", len(shards), totalShards)
+	}
+
+	var excludedRepos []string
+	for _, er := range excluded {
+		excludedRepos = append(excludedRepos, er.Repo)
+	}
+	sort.Strings(excludedRepos)
+
+	if diff := cmp.Diff([]string{"r5", "r6"}, excludedRepos); diff != "" {
+		t.Fatalf("-want, +got: %s", diff)
+	}
+}
+
+func TestGenerateCompoundShards_EmptyShards(t *testing.T) {
+	compounds, excluded := generateCompounds([]shard{}, compoundOpts{
+		targetSizeBytes: 1,
+		maxSizeBytes:    1,
+		cutoffDate:      time.Now(),
+	})
+
+	if !(len(compounds) == 0 && len(excluded) == 0) {
+		t.Fatalf("Expect \"compounds\" and \"excluded\" to be empty")
+	}
+}
+
+func TestGenerateCompoundShards_AllShards(t *testing.T) {
+	compounds, excluded := generateCompounds([]shard{{
+		Repo:      "r1",
+		ModTime:   time.Now().AddDate(0, 0, -1),
+		SizeBytes: 2,
+	}}, compoundOpts{
+		targetSizeBytes: 1,
+		maxSizeBytes:    3,
+		cutoffDate:      time.Now(),
+	})
+
+	if len(compounds) != 1 {
+		t.Fatalf("want %d, got %d", 1, len(compounds))
+	}
+	if len(excluded) != 0 {
+		t.Fatalf("want %d, got %d", 0, len(excluded))
+	}
+}
+
+func TestGenerateCompoundShards_NoShards(t *testing.T) {
+	compounds, excluded := generateCompounds([]shard{{
+		Repo:      "r1",
+		ModTime:   time.Now().AddDate(0, 0, 1),
+		SizeBytes: 2,
+	}}, compoundOpts{
+		targetSizeBytes: 1,
+		maxSizeBytes:    1,
+		cutoffDate:      time.Now(),
+	})
+
+	if len(compounds) != 0 {
+		t.Fatalf("want %d, got %d", 0, len(compounds))
+	}
+	if len(excluded) != 1 {
+		t.Fatalf("want %d, got %d", 1, len(excluded))
+	}
+}

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -67,32 +67,36 @@ func TestGenerateCompoundShards(t *testing.T) {
 	}
 
 	// Expected compounds
+	// compound 0: r4 (total size 10)
 	// compound 1: r3 + r6 (total size  10)
 	// compound 2: r5 + r2 + r1 (total size 10)
-	//
-	// r4 -> already max size
 
 	compounds := generateCompounds(shards, 10)
 
-	if len(compounds) != 2 {
-		t.Fatalf("expected 2 compound shards, but got %d", len(compounds))
+	if len(compounds) != 3 {
+		t.Fatalf("expected 3 compound shards, but got %d", len(compounds))
 	}
 
 	totalShards := 0
 	for _, c := range compounds {
 		totalShards += len(c.shards)
 	}
-	if totalShards != 5 {
-		t.Fatalf("shards mismatch: wanted %d, got %d", 5, totalShards)
+	if totalShards != 6 {
+		t.Fatalf("shards mismatch: wanted %d, got %d", 6, totalShards)
 	}
 
-	want := []candidate{{"r3", 9}, {"r6", 1}}
+	want := []candidate{{"r4", 10}}
 	if diff := cmp.Diff(want, compounds[0].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
 		t.Fatalf("-want,+got\n%s", diff)
 	}
 
-	want = []candidate{{"r5", 5}, {"r2", 3}, {"r1", 2}}
+	want = []candidate{{"r3", 9}, {"r6", 1}}
 	if diff := cmp.Diff(want, compounds[1].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
+		t.Fatalf("-want,+got\n%s", diff)
+	}
+
+	want = []candidate{{"r5", 5}, {"r2", 3}, {"r1", 2}}
+	if diff := cmp.Diff(want, compounds[2].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
 		t.Fatalf("-want,+got\n%s", diff)
 	}
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -1,65 +1,78 @@
 package main
 
 import (
-	"sort"
+	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestHasMultipleShards(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		file                  string
+		wantHasMultipleShards bool
+	}{
+		{"large.00000.zoekt", true},
+		{"large.00001.zoekt", true},
+		{"small.00000.zoekt", false},
+		{"compound-foo.00000.zoekt", false},
+		{"else", false},
+	}
+
+	for _, c := range cases {
+		_, err := os.Create(filepath.Join(dir, c.file))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.file, func(t *testing.T) {
+			if got := hasMultipleShards(filepath.Join(dir, tt.file)); got != tt.wantHasMultipleShards {
+				t.Fatalf("want %t, got %t", tt.wantHasMultipleShards, got)
+			}
+		})
+	}
+}
+
 func TestGenerateCompoundShards(t *testing.T) {
-	old := time.Date(2021, 01, 01, 0, 0, 0, 0, time.UTC)
-	recent := old.AddDate(0, 0, 30)
-
-	var maxSize int64 = 1 * 1024 * 1024
-
-	shards := []shard{
+	shards := []candidate{
 		{
-			Repo:      "r1",
-			ModTime:   old,
-			SizeBytes: maxSize - 1,
-			Rank:      1,
+			path:      "r1",
+			sizeBytes: 2,
 		},
 		{
-			Repo:      "r2",
-			ModTime:   old,
-			SizeBytes: maxSize - 1,
-			Rank:      3,
+			path:      "r2",
+			sizeBytes: 3,
 		},
 		{
-			Repo:      "r3",
-			ModTime:   old,
-			SizeBytes: maxSize - 1,
-			Rank:      2,
+			path:      "r3",
+			sizeBytes: 9,
 		},
 		{
-			Repo:      "r4",
-			ModTime:   old,
-			SizeBytes: maxSize - 1,
-			Rank:      4,
+			path:      "r4",
+			sizeBytes: 10,
 		},
-		// Too new
 		{
-			Repo:      "r5",
-			ModTime:   recent,
-			SizeBytes: 1,
-			Rank:      5,
+			path:      "r5",
+			sizeBytes: 5,
 		},
-		// Too big
 		{
-			Repo:      "r6",
-			ModTime:   old,
-			SizeBytes: 2 * maxSize,
-			Rank:      1,
+			path:      "r6",
+			sizeBytes: 1,
 		},
 	}
 
-	compounds, excluded := generateCompounds(shards, compoundOpts{
-		targetSizeBytes: maxSize,
-		maxSizeBytes:    maxSize,
-		cutoffDate:      old.AddDate(0, 0, 1),
-	})
+	// Expected compounds
+	// compound 1: r3 + r6 (total size  10)
+	// compound 2: r5 + r2 + r1 (total size 10)
+	//
+	// r4 -> already max size
+
+	compounds := generateCompounds(shards, 10)
 
 	if len(compounds) != 2 {
 		t.Fatalf("expected 2 compound shards, but got %d", len(compounds))
@@ -69,68 +82,17 @@ func TestGenerateCompoundShards(t *testing.T) {
 	for _, c := range compounds {
 		totalShards += len(c.shards)
 	}
-	totalShards += len(excluded)
-	if totalShards != len(shards) {
-		t.Fatalf("shards mismatch: wanted %d, got %d", len(shards), totalShards)
+	if totalShards != 5 {
+		t.Fatalf("shards mismatch: wanted %d, got %d", 5, totalShards)
 	}
 
-	var excludedRepos []string
-	for _, er := range excluded {
-		excludedRepos = append(excludedRepos, er.Repo)
+	want := []candidate{{"r3", 9}, {"r6", 1}}
+	if diff := cmp.Diff(want, compounds[0].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
+		t.Fatalf("-want,+got\n%s", diff)
 	}
-	sort.Strings(excludedRepos)
 
-	if diff := cmp.Diff([]string{"r5", "r6"}, excludedRepos); diff != "" {
-		t.Fatalf("-want, +got: %s", diff)
-	}
-}
-
-func TestGenerateCompoundShards_EmptyShards(t *testing.T) {
-	compounds, excluded := generateCompounds([]shard{}, compoundOpts{
-		targetSizeBytes: 1,
-		maxSizeBytes:    1,
-		cutoffDate:      time.Now(),
-	})
-
-	if !(len(compounds) == 0 && len(excluded) == 0) {
-		t.Fatalf("Expect \"compounds\" and \"excluded\" to be empty")
-	}
-}
-
-func TestGenerateCompoundShards_AllShards(t *testing.T) {
-	compounds, excluded := generateCompounds([]shard{{
-		Repo:      "r1",
-		ModTime:   time.Now().AddDate(0, 0, -1),
-		SizeBytes: 2,
-	}}, compoundOpts{
-		targetSizeBytes: 1,
-		maxSizeBytes:    3,
-		cutoffDate:      time.Now(),
-	})
-
-	if len(compounds) != 1 {
-		t.Fatalf("want %d, got %d", 1, len(compounds))
-	}
-	if len(excluded) != 0 {
-		t.Fatalf("want %d, got %d", 0, len(excluded))
-	}
-}
-
-func TestGenerateCompoundShards_NoShards(t *testing.T) {
-	compounds, excluded := generateCompounds([]shard{{
-		Repo:      "r1",
-		ModTime:   time.Now().AddDate(0, 0, 1),
-		SizeBytes: 2,
-	}}, compoundOpts{
-		targetSizeBytes: 1,
-		maxSizeBytes:    1,
-		cutoffDate:      time.Now(),
-	})
-
-	if len(compounds) != 0 {
-		t.Fatalf("want %d, got %d", 0, len(compounds))
-	}
-	if len(excluded) != 1 {
-		t.Fatalf("want %d, got %d", 1, len(excluded))
+	want = []candidate{{"r5", 5}, {"r2", 3}, {"r1", 2}}
+	if diff := cmp.Diff(want, compounds[1].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
+		t.Fatalf("-want,+got\n%s", diff)
 	}
 }


### PR DESCRIPTION
This ports the merging policy in /cmd/zoekt-merge-index from Python to
Go. I added the ported policy to zoekt-sourcegraph-indexserver because
this is were merging will finally run in a background process.

To make testing easier, I added a command to indexserver that lets us
trigger a merge job manually, just like we do with the python script.
The way I treat parameters is a bit hacky but this way don't have to add
a ton of parameters to the flagset and remove them later on.

After testing the merge policy manually, the next step is to run merging
every x hours on a subset of our instances in production and monitor the
behavior.

**Summary of the merging policy:**
All shards are eligable for merging except:
- repos with recent commits (last 7 days)
- popular repos (ranking greater than 100)
- large repos (repo that are distributed accross many shards)

Explicity, compound shards are eligable for merging, too. Compound shards
shrink over time, because we vacuum the tombstones, and the smaller
they get the higher the probabiliy that are subject to a merge.

The merge policy tries to build compund shard that match the desired 
target size.