### PR TITLE
all: use BranchesRepos instead of RepoSet in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ minimal to avoid difficult merge conflicts. Differences:
 - We have exposed the API via
   [keegancsmith/rpc](https://github.com/keegancsmith/rpc) (a fork of `net/rpc`
   which supports cancellation).
-- Query primitive `RepoSet` to efficiently specify a set of repositories to
+- Query primitive `BranchesRepos` to efficiently specify a set of repositories to
   search.
 - Allow empty shard directories on startup. Needed when starting a fresh
   instance which hasn't indexed anything yet.

--- a/query/query.go
+++ b/query/query.go
@@ -179,6 +179,14 @@ type BranchesRepos struct {
 	List []BranchRepos
 }
 
+// NewSingleBranchesRepos is a helper for creating a BranchesRepos which
+// searches a single branch.
+func NewSingleBranchesRepos(branch string, ids ...uint32) *BranchesRepos {
+	return &BranchesRepos{List: []BranchRepos{
+		{branch, roaring.BitmapOf(ids...)},
+	}}
+}
+
 func (q *BranchesRepos) String() string {
 	var sb strings.Builder
 
@@ -186,7 +194,7 @@ func (q *BranchesRepos) String() string {
 
 	for _, br := range q.List {
 		if size := br.Repos.GetCardinality(); size > 1 {
-			sb.WriteString(" " + br.Branch + ":" + strconv.FormatUint(size, 64))
+			sb.WriteString(" " + br.Branch + ":" + strconv.FormatUint(size, 10))
 		} else {
 			sb.WriteString(" " + br.Branch + "=" + br.Repos.String())
 		}

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestClientServer(t *testing.T) {
 	mock := &mockSearcher.MockSearcher{
-		WantSearch: query.NewAnd(mustParse("hello world|universe"), query.NewRepoSet("foo/bar", "baz/bam")),
+		WantSearch: query.NewAnd(mustParse("hello world|universe"), query.NewSingleBranchesRepos("HEAD", 1, 2)),
 		SearchResult: &zoekt.SearchResult{
 			Files: []zoekt.FileMatch{
 				{FileName: "bin.go"},
@@ -27,6 +27,7 @@ func TestClientServer(t *testing.T) {
 			Repos: []*zoekt.RepoListEntry{
 				{
 					Repository: zoekt.Repository{
+						ID:   2,
 						Name: "foo/bar",
 					},
 				},


### PR DESCRIPTION
Want to move away from supporting RepoSet and try unify on
BranchesRepos. There is one use case left of RepoSet in List that is
still needed, otherwise we are close to removing support for it.