### PR TITLE
add support for RepoRegexp

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -68,6 +68,10 @@ func (d *indexData) simplify(in query.Q) query.Q {
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return strings.Contains(repo.Name, r.Pattern)
 			})
+		case *query.RepoRegexp:
+			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
+				return r.Regexp.MatchString(repo.Name)
+			})
 		case *query.BranchesRepos:
 			for i := range d.repoMetaData {
 				for _, br := range r.List {

--- a/matchtree.go
+++ b/matchtree.go
@@ -967,6 +967,22 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 				return reposWant[d.repos[docID]]
 			},
 		}, nil
+
+	case *query.RepoRegexp:
+		reposWant := make([]bool, len(d.repoMetaData))
+		for repoIdx, r := range d.repoMetaData {
+			if s.Regexp.MatchString(r.Name) {
+				reposWant[repoIdx] = true
+			}
+		}
+		return &docMatchTree{
+			reason:  "RepoRegexp",
+			numDocs: d.numDocs(),
+			predicate: func(docID uint32) bool {
+				return reposWant[d.repos[docID]]
+			},
+		}, nil
+
 	case query.RawConfig:
 		return &docMatchTree{
 			reason:  s.String(),

--- a/query/query.go
+++ b/query/query.go
@@ -189,22 +189,13 @@ func (q *RepoRegexp) String() string {
 // GobEncode implements gob.Encoder.
 func (q *RepoRegexp) GobEncode() ([]byte, error) {
 	// gob can't encode syntax.Regexp
-	var buf bytes.Buffer
-	buf.WriteByte(1) // version
-	buf.WriteString(q.Regexp.String())
-	return buf.Bytes(), nil
+	return []byte(q.Regexp.String()), nil
 }
 
 // GobDecode implements gob.Decoder.
 func (q *RepoRegexp) GobDecode(data []byte) error {
-	if len(data) == 0 {
-		return fmt.Errorf("malformed RepoRegexp gob: empty")
-	}
-	if data[0] != 1 {
-		return fmt.Errorf("malformed RepoRegexp gob: expected version 1 got %d", data[0])
-	}
 	var err error
-	q.Regexp, err = regexp.Compile(string(data[1:]))
+	q.Regexp, err = regexp.Compile(string(data))
 	return err
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strconv"
@@ -173,6 +174,38 @@ type Repo struct {
 
 func (q *Repo) String() string {
 	return fmt.Sprintf("repo:%s", q.Pattern)
+}
+
+// RepoRegexp is a Sourcegraph addition which searches documents where the
+// repository name matches Regexp.
+type RepoRegexp struct {
+	Regexp *regexp.Regexp
+}
+
+func (q *RepoRegexp) String() string {
+	return fmt.Sprintf("reporegex:%q", q.Regexp.String())
+}
+
+// GobEncode implements gob.Encoder.
+func (q *RepoRegexp) GobEncode() ([]byte, error) {
+	// gob can't encode syntax.Regexp
+	var buf bytes.Buffer
+	buf.WriteByte(1) // version
+	buf.WriteString(q.Regexp.String())
+	return buf.Bytes(), nil
+}
+
+// GobDecode implements gob.Decoder.
+func (q *RepoRegexp) GobDecode(data []byte) error {
+	if len(data) == 0 {
+		return fmt.Errorf("malformed RepoRegexp gob: empty")
+	}
+	if data[0] != 1 {
+		return fmt.Errorf("malformed RepoRegexp gob: expected version 1 got %d", data[0])
+	}
+	var err error
+	q.Regexp, err = regexp.Compile(string(data[1:]))
+	return err
 }
 
 // BranchesRepos is a slice of BranchRepos to match. It is a Sourcegraph

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -126,6 +126,8 @@ var once sync.Once
 func RegisterGob() {
 	once.Do(func() {
 		gob.Register(&query.And{})
+		gob.Register(&query.BranchRepos{})
+		gob.Register(&query.BranchesRepos{})
 		gob.Register(&query.Branch{})
 		gob.Register(&query.Const{})
 		gob.Register(&query.GobCache{})
@@ -133,9 +135,8 @@ func RegisterGob() {
 		gob.Register(&query.Not{})
 		gob.Register(&query.Or{})
 		gob.Register(&query.Regexp{})
-		gob.Register(&query.BranchRepos{})
-		gob.Register(&query.BranchesRepos{})
 		gob.Register(&query.RepoBranches{})
+		gob.Register(&query.RepoRegexp{})
 		gob.Register(&query.RepoSet{})
 		gob.Register(&query.Repo{})
 		gob.Register(&query.Substring{})


### PR DESCRIPTION
This will be used by Sourcegraph to avoid talking to the database and
instead fully relying on Zoekt.