### PR TITLE
indexserver: vacuum tombstones

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -285,8 +285,8 @@ func shardsLog(indexDir, action string, shards []shard, repoName string) {
 	}
 }
 
-// vacuum removes tombstoned repos from compound shards. Ensure vacuum has
-// exclusive access to dir while it runs.
+// vacuum removes tombstoned repos from compound shards. Vacuum locks the index
+// directory for each compound shard it vacuums.
 func (s *Server) vacuum() {
 	d, err := os.Open(s.IndexDir)
 	if err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
+	"github.com/google/zoekt/build"
 )
 
 func TestCleanup(t *testing.T) {
@@ -229,4 +230,64 @@ func TestRemoveIncompleteShards(t *testing.T) {
 	if !reflect.DeepEqual(shards, left) {
 		t.Errorf("\ngot shards: %v\nwant: %v\n", left, shards)
 	}
+}
+
+func TestVacuum(t *testing.T) {
+	fn := createCompoundShard(t)
+
+	err := zoekt.SetTombstone(fn, "repo2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := removeTombstones(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 1 || got[0] != "repo2" {
+		t.Fatal(err)
+	}
+}
+
+// createCompoundShard returns a path to a compound shard containing repos
+// repo0..repo3
+func createCompoundShard(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	repoNames := []string{"repo0", "repo1", "repo2", "repo3"}
+	var repoFns []string
+
+	for _, name := range repoNames {
+		opts := build.Options{
+			IndexDir: dir,
+			RepositoryDescription: zoekt.Repository{
+				Name: name,
+				RawConfig: map[string]string{
+					"public": "1",
+				},
+			},
+		}
+		opts.SetDefaults()
+		b, err := build.NewBuilder(opts)
+		if err != nil {
+			t.Fatalf("NewBuilder: %v", err)
+		}
+		b.AddFile("F", []byte(strings.Repeat("abc", 100)))
+		if err := b.Finish(); err != nil {
+			t.Errorf("Finish: %v", err)
+		}
+
+		repoFns = append(repoFns, opts.FindAllShards()...)
+	}
+
+	// create a compound shard.
+	dir = t.TempDir()
+	fn, err := merge(dir, repoFns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fn
 }


### PR DESCRIPTION
This adds a background process that scans compound shards for tombstones
and removes them. This means compound shards will shrink over time,
eventually becoming targets for merging themselves.

The job is feature-flagged (RIP file in index dir), just like tombstones.