### PR TITLE
indexserver: move Name into IndexOptions struct

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -38,6 +38,9 @@ type IndexOptions struct {
 	// RepoID is the Sourcegraph Repository ID.
 	RepoID int32
 
+	// Name is the Repository Name.
+	Name string
+
 	// Priority indicates ranking in results, higher first.
 	Priority float64
 
@@ -57,9 +60,6 @@ type indexArgs struct {
 
 	// CloneURL is the remote git URL of the repository for cloning.
 	CloneURL string
-
-	// Name is the name of the repository.
-	Name string
 
 	// Incremental indicates to skip indexing if already indexed.
 	Incremental bool

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -49,21 +49,25 @@ func TestGetIndexOptions(t *testing.T) {
 
 	cases := map[string]*IndexOptions{
 		`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {
+			Name:       "test/repo",
 			Symbols:    true,
 			LargeFiles: []string{"foo", "bar"},
 		},
 
 		`{"Symbols": false, "LargeFiles": ["foo","bar"]}`: {
+			Name:       "test/repo",
 			LargeFiles: []string{"foo", "bar"},
 		},
 
-		`{}`: {},
+		`{}`: {Name: "test/repo"},
 
 		`{"Symbols": true}`: {
+			Name:    "test/repo",
 			Symbols: true,
 		},
 
 		`{"RepoID": 123}`: {
+			Name:   "test/repo",
 			RepoID: 123,
 		},
 
@@ -97,8 +101,8 @@ func TestIndex(t *testing.T) {
 		name: "minimal",
 		args: indexArgs{
 			CloneURL: "http://api.test/.internal/git/test/repo",
-			Name:     "test/repo",
 			IndexOptions: IndexOptions{
+				Name:     "test/repo",
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 			},
 		},
@@ -118,8 +122,8 @@ func TestIndex(t *testing.T) {
 		name: "minimal-id",
 		args: indexArgs{
 			CloneURL: "http://api.test/.internal/git/test/repo",
-			Name:     "test/repo",
 			IndexOptions: IndexOptions{
+				Name:     "test/repo",
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 				RepoID:   123,
 			},
@@ -140,13 +144,13 @@ func TestIndex(t *testing.T) {
 		name: "all",
 		args: indexArgs{
 			CloneURL:          "http://api.test/.internal/git/test/repo",
-			Name:              "test/repo",
 			Incremental:       true,
 			IndexDir:          "/data/index",
 			Parallelism:       4,
 			FileLimit:         123,
 			DownloadLimitMBPS: "1000",
 			IndexOptions: IndexOptions{
+				Name:       "test/repo",
 				LargeFiles: []string{"foo", "bar"},
 				Symbols:    true,
 				Branches: []zoekt.RepositoryBranch{

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -300,7 +300,7 @@ func (s *Server) Run(queue *Queue) {
 						tr.SetError()
 						continue
 					}
-					queue.AddOrUpdate(name, opt.IndexOptions)
+					queue.AddOrUpdate(opt.IndexOptions)
 				}
 			}
 
@@ -318,13 +318,13 @@ func (s *Server) Run(queue *Queue) {
 			continue
 		}
 
-		name, opts, ok := queue.Pop()
+		opts, ok := queue.Pop()
 		if !ok {
 			time.Sleep(time.Second)
 			continue
 		}
 		start := time.Now()
-		args := s.indexArgs(name, opts)
+		args := s.indexArgs(opts)
 
 		muIndexDir.Lock()
 		state, err := s.Index(args)
@@ -340,7 +340,7 @@ func (s *Server) Run(queue *Queue) {
 		case indexStateSuccessMeta:
 			log.Printf("updated meta %s in %v", args.String(), time.Since(start))
 		}
-		queue.SetIndexed(name, opts, state)
+		queue.SetIndexed(opts, state)
 	}
 }
 
@@ -443,10 +443,9 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	return indexStateSuccess, gitIndex(args, runCmd)
 }
 
-func (s *Server) indexArgs(name string, opts IndexOptions) *indexArgs {
+func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
 	return &indexArgs{
-		Name:         name,
-		CloneURL:     s.Sourcegraph.GetCloneURL(name),
+		CloneURL:     s.Sourcegraph.GetCloneURL(opts.Name),
 		IndexOptions: opts,
 
 		IndexDir:    s.IndexDir,
@@ -546,7 +545,7 @@ func (s *Server) enqueueForIndex(queue *Queue) func(rw http.ResponseWriter, r *h
 			http.Error(rw, "fetching index options", http.StatusInternalServerError)
 			return
 		}
-		queue.AddOrUpdate(name, opts[0].IndexOptions)
+		queue.AddOrUpdate(opts[0].IndexOptions)
 	}
 }
 
@@ -561,7 +560,7 @@ func (s *Server) forceIndex(name string) (string, error) {
 		return fmt.Sprintf("Indexing %s failed: %s", name, errS), errors.New(errS)
 	}
 
-	args := s.indexArgs(name, opts[0].IndexOptions)
+	args := s.indexArgs(opts[0].IndexOptions)
 	args.Incremental = false // force re-index
 	state, err := s.Index(args)
 	if err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -29,7 +29,9 @@ func TestServer_defaultArgs(t *testing.T) {
 		CPUCount: 6,
 	}
 	want := &indexArgs{
-		Name:              "testName",
+		IndexOptions: IndexOptions{
+			Name: "testName",
+		},
 		CloneURL:          "http://api.test/.internal/git/testName",
 		IndexDir:          "/testdata/index",
 		Parallelism:       6,
@@ -37,7 +39,7 @@ func TestServer_defaultArgs(t *testing.T) {
 		FileLimit:         1 << 20,
 		DownloadLimitMBPS: "1000",
 	}
-	got := s.indexArgs("testName", IndexOptions{})
+	got := s.indexArgs(IndexOptions{Name: "testName"})
 	if !cmp.Equal(got, want) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -12,24 +12,24 @@ func TestQueue(t *testing.T) {
 	queue := &Queue{}
 
 	for i := 0; i < 100; i++ {
-		queue.AddOrUpdate(fmt.Sprintf("item-%d", i), mkHEADIndexOptions(strconv.Itoa(i)))
+		queue.AddOrUpdate(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)))
 	}
 
 	// Odd numbers are already at the same commit
 	for i := 1; i < 100; i += 2 {
-		queue.SetIndexed(fmt.Sprintf("item-%d", i), mkHEADIndexOptions(strconv.Itoa(i)), indexStateSuccess)
+		queue.SetIndexed(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)), indexStateSuccess)
 	}
 
 	// Ensure we process all the even commits first, then odd.
 	want := 0
 	for {
-		name, opts, ok := queue.Pop()
+		opts, ok := queue.Pop()
 		if !ok {
 			break
 		}
 		got, _ := strconv.Atoi(opts.Branches[0].Version)
 		if got != want {
-			t.Fatalf("got %v %v, want %v", name, opts, want)
+			t.Fatalf("got %v, want %v", opts, want)
 		}
 		want += 2
 		if want == 100 {
@@ -37,7 +37,7 @@ func TestQueue(t *testing.T) {
 			want = 1
 		}
 		// update current, shouldn't put the job in the queue
-		queue.SetIndexed(name, opts, indexStateSuccess)
+		queue.SetIndexed(opts, indexStateSuccess)
 	}
 	if want != 101 {
 		t.Fatalf("only popped %d items", want)
@@ -50,20 +50,20 @@ func TestQueueFIFO(t *testing.T) {
 	queue := &Queue{}
 
 	for i := 0; i < 100; i++ {
-		queue.AddOrUpdate(fmt.Sprintf("item-%d", i), mkHEADIndexOptions(strconv.Itoa(i)))
+		queue.AddOrUpdate(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)))
 	}
 
 	want := 0
 	for {
-		name, opts, ok := queue.Pop()
+		opts, ok := queue.Pop()
 		if !ok {
 			break
 		}
 		got, _ := strconv.Atoi(opts.Branches[0].Version)
 		if got != want {
-			t.Fatalf("got %v %v, want %v", name, opts, want)
+			t.Fatalf("got %v, want %v", opts, want)
 		}
-		queue.SetIndexed(name, opts, indexStateSuccess)
+		queue.SetIndexed(opts, indexStateSuccess)
 		want++
 	}
 	if want != 100 {
@@ -74,22 +74,23 @@ func TestQueueFIFO(t *testing.T) {
 func TestQueue_MaybeRemoveMissing(t *testing.T) {
 	queue := &Queue{}
 
-	queue.AddOrUpdate("foo", mkHEADIndexOptions("foo"))
-	queue.AddOrUpdate("bar", mkHEADIndexOptions("bar"))
+	queue.AddOrUpdate(mkHEADIndexOptions("foo", "foo"))
+	queue.AddOrUpdate(mkHEADIndexOptions("bar", "bar"))
 	queue.MaybeRemoveMissing([]string{"bar"})
 
-	name, _, _ := queue.Pop()
-	if name != "bar" {
-		t.Fatalf("queue should only contain bar, pop returned %v", name)
+	opts, _ := queue.Pop()
+	if opts.Name != "bar" {
+		t.Fatalf("queue should only contain bar, pop returned %v", opts.Name)
 	}
-	_, _, ok := queue.Pop()
+	_, ok := queue.Pop()
 	if ok {
 		t.Fatal("queue should be empty")
 	}
 }
 
-func mkHEADIndexOptions(version string) IndexOptions {
+func mkHEADIndexOptions(name, version string) IndexOptions {
 	return IndexOptions{
+		Name:     name,
 		Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: version}},
 	}
 }

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -76,6 +76,10 @@ func (s *sourcegraphClient) GetIndexOptions(repos ...string) ([]indexOptionsItem
 		if err := dec.Decode(&opts[i]); err != nil {
 			return nil, fmt.Errorf("error decoding body: %w", err)
 		}
+		// Override Sourcegraph name. This can technically be out of sync with
+		// somewhat rare races. Once we have switched to ID backed communication
+		// with Sourcegraph we can fully rely on the name returned.
+		opts[i].Name = repos[i]
 	}
 
 	return opts, nil
@@ -145,6 +149,7 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 	opts := IndexOptions{
 		// magic at the end is to ensure we get a positive number when casting.
 		RepoID:  int32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1),
+		Name:    name,
 		Symbols: true,
 	}
 


### PR DESCRIPTION
Sourcegraph has started setting the Name in the response. This is in
preparation for us only communicating IDs. This commit has the nice
side-effect that we don't pass around name + options everywhere, but
just options.