### PR TITLE
all: switch SourcegraphID from uint32 to int32

### DIFF
--- a/api.go
+++ b/api.go
@@ -45,7 +45,7 @@ type FileMatch struct {
 
 	// RepositoryID is a Sourcegraph extension. This is the ID of Repository in
 	// Sourcegraph.
-	RepositoryID uint32
+	RepositoryID int32
 
 	// Only set if requested
 	Content []byte
@@ -240,7 +240,7 @@ type RepositoryBranch struct {
 // Repository holds repository metadata.
 type Repository struct {
 	// Sourcergaph's repository ID
-	ID uint32
+	ID int32
 
 	// The repository name
 	Name string
@@ -310,7 +310,7 @@ func (r *Repository) UnmarshalJSON(data []byte) error {
 
 	if v, ok := repo.RawConfig["repoid"]; ok {
 		id, _ := strconv.ParseUint(v, 10, 32)
-		r.ID = uint32(id)
+		r.ID = int32(id)
 	}
 
 	return nil
@@ -446,7 +446,7 @@ type RepoList struct {
 	Crashes int
 
 	// Minimal response to a List request. Returned when ListOptions.Minimal is true.
-	Minimal map[uint32]*MinimalRepoListEntry
+	Minimal map[int32]*MinimalRepoListEntry
 }
 
 type Searcher interface {

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -87,7 +87,7 @@ func (o *indexArgs) BuildOptions() *build.Options {
 		// IncrementalSkipIndexing and IndexState can correctly calculate if
 		// nothing needs to be done.
 		RepositoryDescription: zoekt.Repository{
-			ID:       uint32(o.IndexOptions.RepoID),
+			ID:       o.IndexOptions.RepoID,
 			Name:     o.Name,
 			Branches: o.Branches,
 			RawConfig: map[string]string{

--- a/eval.go
+++ b/eval.go
@@ -75,7 +75,7 @@ func (d *indexData) simplify(in query.Q) query.Q {
 		case *query.BranchesRepos:
 			for i := range d.repoMetaData {
 				for _, br := range r.List {
-					if br.Repos.Contains(d.repoMetaData[i].ID) {
+					if br.Repos.Contains(uint32(d.repoMetaData[i].ID)) {
 						return q
 					}
 				}
@@ -515,7 +515,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 
 	minimal := opts != nil && opts.Minimal
 	if minimal {
-		l.Minimal = make(map[uint32]*MinimalRepoListEntry, len(d.repoListEntry))
+		l.Minimal = make(map[int32]*MinimalRepoListEntry, len(d.repoListEntry))
 	} else {
 		l.Repos = make([]*RepoListEntry, 0, len(d.repoListEntry))
 	}

--- a/eval_test.go
+++ b/eval_test.go
@@ -252,7 +252,7 @@ func TestSimplifyBranchesRepos(t *testing.T) {
 
 	some := &query.BranchesRepos{
 		List: []query.BranchRepos{
-			{Branch: "branch1", Repos: roaring.BitmapOf(hash("bar"))},
+			{Branch: "branch1", Repos: roaring.BitmapOf(uint32(hash("bar")))},
 		},
 	}
 	none := &query.Repo{"banana"}
@@ -287,8 +287,12 @@ func TestSimplifyRepoBranchSimple(t *testing.T) {
 	}
 }
 
-func hash(name string) uint32 {
+func hash(name string) int32 {
 	h := fnv.New32()
-	h.Write([]byte(name))
-	return h.Sum32()
+	var x int32
+	for x <= 0 {
+		h.Write([]byte(name))
+		x = int32(h.Sum32())
+	}
+	return x
 }

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -224,7 +224,7 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 	}
 
 	id, _ := strconv.ParseUint(sec.Options.Get("repoid"), 10, 32)
-	desc.ID = uint32(id)
+	desc.ID = int32(id)
 
 	if desc.RawConfig == nil {
 		desc.RawConfig = map[string]string{}

--- a/index_test.go
+++ b/index_test.go
@@ -1195,7 +1195,7 @@ func TestListRepos(t *testing.T) {
 		}
 
 		want := &RepoList{
-			Minimal: map[uint32]*MinimalRepoListEntry{
+			Minimal: map[int32]*MinimalRepoListEntry{
 				repo.ID: {
 					HasSymbols: repo.HasSymbols,
 					Branches:   repo.Branches,

--- a/matchtree.go
+++ b/matchtree.go
@@ -915,7 +915,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 		for repoIdx := range d.repoMetaData {
 			var mask uint64
 			for _, br := range s.List {
-				if br.Repos.Contains(d.repoMetaData[repoIdx].ID) {
+				if br.Repos.Contains(uint32(d.repoMetaData[repoIdx].ID)) {
 					mask |= uint64(d.branchIDs[repoIdx][br.Branch])
 				}
 			}

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -309,8 +309,8 @@ func TestBranchesRepos(t *testing.T) {
 	}
 
 	mt, err := d.newMatchTree(&query.BranchesRepos{List: []query.BranchRepos{
-		{Branch: "b1", Repos: roaring.BitmapOf(hash("bar"))},
-		{Branch: "b2", Repos: roaring.BitmapOf(hash("bar"))},
+		{Branch: "b1", Repos: roaring.BitmapOf(uint32(hash("bar")))},
+		{Branch: "b2", Repos: roaring.BitmapOf(uint32(hash("bar")))},
 	}})
 	if err != nil {
 		t.Fatal(err)

--- a/query/query.go
+++ b/query/query.go
@@ -208,9 +208,13 @@ type BranchesRepos struct {
 
 // NewSingleBranchesRepos is a helper for creating a BranchesRepos which
 // searches a single branch.
-func NewSingleBranchesRepos(branch string, ids ...uint32) *BranchesRepos {
+func NewSingleBranchesRepos(branch string, ids ...int32) *BranchesRepos {
+	uids := make([]uint32, len(ids))
+	for i, x := range ids {
+		uids[i] = uint32(x)
+	}
 	return &BranchesRepos{List: []BranchRepos{
-		{branch, roaring.BitmapOf(ids...)},
+		{branch, roaring.BitmapOf(uids...)},
 	}}
 }
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -309,7 +309,7 @@ func selectRepoSet(shards []rankedShard, q query.Q) ([]rankedShard, query.Q) {
 
 			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
 				for _, br := range setQuery.List {
-					if br.Repos.Contains(repo.ID) {
+					if br.Repos.Contains(uint32(repo.ID)) {
 						return true
 					}
 				}
@@ -725,7 +725,7 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 	}
 
 	agg := zoekt.RepoList{
-		Minimal: map[uint32]*zoekt.MinimalRepoListEntry{},
+		Minimal: map[int32]*zoekt.MinimalRepoListEntry{},
 	}
 
 	uniq := map[string]*zoekt.RepoListEntry{}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -202,7 +202,7 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 
 	for _, name := range repoSetNames {
 		repoBranchesSet.Set[name] = []string{"HEAD"}
-		branchesRepos.List[0].Repos.Add(hash(name))
+		branchesRepos.List[0].Repos.Add(uint32(hash(name)))
 	}
 
 	set := query.NewRepoSet(repoSetNames...)
@@ -235,10 +235,14 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 	}
 }
 
-func hash(name string) uint32 {
+func hash(name string) int32 {
 	h := fnv.New32()
-	h.Write([]byte(name))
-	return h.Sum32()
+	var x int32
+	for x <= 0 {
+		h.Write([]byte(name))
+		x = int32(h.Sum32())
+	}
+	return x
 }
 
 type memSeeker struct {
@@ -373,7 +377,7 @@ func TestShardedSearcher_List(t *testing.T) {
 						Stats:      zoekt.RepoStats{Shards: 2},
 					},
 				},
-				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+				Minimal: map[int32]*zoekt.MinimalRepoListEntry{
 					repos[0].ID: {
 						HasSymbols: repos[0].HasSymbols,
 						Branches:   repos[0].Branches,
@@ -440,7 +444,7 @@ func searcherForTest(t testing.TB, b *zoekt.IndexBuilder) zoekt.Searcher {
 func reposForTest(n int) (result []*zoekt.Repository) {
 	for i := 0; i < n; i++ {
 		result = append(result, &zoekt.Repository{
-			ID:   uint32(i + 1),
+			ID:   int32(i + 1),
 			Name: fmt.Sprintf("test-repository-%d", i),
 		})
 	}
@@ -470,7 +474,7 @@ func BenchmarkShardedSearch(b *testing.B) {
 
 	filesPerRepo := 300
 	repos := reposForTest(3000)
-	var repoSetIDs []uint32
+	var repoSetIDs []int32
 
 	for i, r := range repos {
 		searcher := testSearcherForRepo(b, r, filesPerRepo)


### PR DESCRIPTION
In Sourcegraph the type RepoID is int32. This updates our code to be
consistent with Sourcegraph. This is a non-backwards compatible change
since it will change the gob encoding. As such it needs to be rolled out
with the sourcegraph frontend.

This also brings up another aspect. Should we change Sourcegraph's
RepoID type to actually be uint32. I believe that is what it really is
in the DB. That is likely a better change than this.