### PR TITLE
merging: continue if merging fails for 1 compound

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -79,7 +79,8 @@ func doMerge(params string) error {
 				os.Remove(s.path)
 			}
 			if err != nil {
-				return fmt.Errorf("%s: %s", stdErr, err)
+				debug.Printf("error during merging compound %d, stdErr: %s, err: %s\n", ix, stdErr, err)
+				continue
 			}
 			// for len(comp.shards)<=1, callMerge is a NOP. Hence there is no need to log
 			// anything here.


### PR DESCRIPTION
Merging can take a long time and shards might disapear after we generated the candidates for a compound.
With this change we log the error and continue with the next compound, instead of aborting the process alltoghter.

Another approach we should maybe consider is to only calculate 1 compound shard ahead of time.