### PR TITLE
remove tracing in indexData.(Search|List)

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/google/zoekt/query"
-	"golang.org/x/net/trace"
 )
 
 const maxUInt16 = 0xffff
@@ -143,22 +142,7 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *SearchOptions) 
 	default:
 	}
 
-	tr := trace.New("indexData.Search", d.file.Name())
-	tr.LazyPrintf("opts: %+v", opts)
-	defer func() {
-		if sr != nil {
-			tr.LazyPrintf("num files: %d", len(sr.Files))
-			tr.LazyPrintf("stats: %+v", sr.Stats)
-		}
-		if err != nil {
-			tr.LazyPrintf("error: %v", err)
-			tr.SetError()
-		}
-		tr.Finish()
-	}()
-
 	q = d.simplify(q)
-	tr.LazyLog(q, true)
 	if c, ok := q.(*query.Const); ok && !c.Value {
 		return &res, nil
 	}
@@ -468,25 +452,9 @@ func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTr
 }
 
 func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl *RepoList, err error) {
-	tr := trace.New("indexData.List", d.file.Name())
-	tr.LazyPrintf("opts: %s", opts)
-	defer func() {
-		if rl != nil {
-			tr.LazyPrintf("repos size: %d", len(rl.Repos))
-			tr.LazyPrintf("crashes: %d", rl.Crashes)
-			tr.LazyPrintf("minimal size: %d", len(rl.Minimal))
-		}
-		if err != nil {
-			tr.LazyPrintf("error: %v", err)
-			tr.SetError()
-		}
-		tr.Finish()
-	}()
-
 	var include func(rle *RepoListEntry) (bool, error)
 
 	q = d.simplify(q)
-	tr.LazyLog(q, true)
 	if c, ok := q.(*query.Const); ok {
 		if !c.Value {
 			return &RepoList{}, nil


### PR DESCRIPTION
With lots of concurrent queries, internal locks in this library result
in contention spikes that affect end to end latency. We don't really
need per-shard tracing, so we remove this code rather than optimize it.

Tracing is left intact in horizontalSearcher.

- Profile: https://console.cloud.google.com/profiler;timespan=30m;end=2021-10-11T06:20:00.000Z/zoekt-webserver;type=CONTENTION;weight=99/delay?referrer=search&project=sourcegraph-dev
- K8S timeouts: https://sourcegraph.slack.com/archives/C0NF93T1C/p1633933113000900

Part of https://github.com/sourcegraph/sourcegraph/issues/25872