### PR TITLE
indexserver: make queue based on RepoID

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -36,7 +36,7 @@ type IndexOptions struct {
 	Branches []zoekt.RepositoryBranch
 
 	// RepoID is the Sourcegraph Repository ID.
-	RepoID int32
+	RepoID uint32
 
 	// Name is the Repository Name.
 	Name string

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -12,12 +12,12 @@ func TestQueue(t *testing.T) {
 	queue := &Queue{}
 
 	for i := 0; i < 100; i++ {
-		queue.AddOrUpdate(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)))
+		queue.AddOrUpdate(mkHEADIndexOptions(i, strconv.Itoa(i)))
 	}
 
 	// Odd numbers are already at the same commit
 	for i := 1; i < 100; i += 2 {
-		queue.SetIndexed(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)), indexStateSuccess)
+		queue.SetIndexed(mkHEADIndexOptions(i, strconv.Itoa(i)), indexStateSuccess)
 	}
 
 	// Ensure we process all the even commits first, then odd.
@@ -50,7 +50,7 @@ func TestQueueFIFO(t *testing.T) {
 	queue := &Queue{}
 
 	for i := 0; i < 100; i++ {
-		queue.AddOrUpdate(mkHEADIndexOptions(fmt.Sprintf("item-%d", i), strconv.Itoa(i)))
+		queue.AddOrUpdate(mkHEADIndexOptions(i, strconv.Itoa(i)))
 	}
 
 	want := 0
@@ -74,8 +74,8 @@ func TestQueueFIFO(t *testing.T) {
 func TestQueue_MaybeRemoveMissing(t *testing.T) {
 	queue := &Queue{}
 
-	queue.AddOrUpdate(mkHEADIndexOptions("foo", "foo"))
-	queue.AddOrUpdate(mkHEADIndexOptions("bar", "bar"))
+	queue.AddOrUpdate(IndexOptions{RepoID: 1, Name: "foo"})
+	queue.AddOrUpdate(IndexOptions{RepoID: 2, Name: "bar"})
 	queue.MaybeRemoveMissing([]string{"bar"})
 
 	opts, _ := queue.Pop()
@@ -88,9 +88,10 @@ func TestQueue_MaybeRemoveMissing(t *testing.T) {
 	}
 }
 
-func mkHEADIndexOptions(name, version string) IndexOptions {
+func mkHEADIndexOptions(id int, version string) IndexOptions {
 	return IndexOptions{
-		Name:     name,
+		RepoID:   uint32(id),
+		Name:     fmt.Sprintf("item-%d", id),
 		Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: version}},
 	}
 }

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -148,7 +148,7 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 
 	opts := IndexOptions{
 		// magic at the end is to ensure we get a positive number when casting.
-		RepoID:  int32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1),
+		RepoID:  uint32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1),
 		Name:    name,
 		Symbols: true,
 	}


### PR DESCRIPTION
Since we made the queue IndexOptions centered we can choose any unique
attribute as the key. The RepoID is not only smaller, but we will soon
need to add a way to "bump" a repo by id. This is where we add a repo
back to the queue with the old options.