### PR TITLE
indexserver: add ListRepos and GetIndexOptions by ID

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -77,7 +77,7 @@ func TestGetIndexOptions(t *testing.T) {
 	for r, want := range cases {
 		response = []byte(r)
 
-		got, err := sg.GetIndexOptions("test/repo")
+		got, err := sg.GetIndexOptionsName("test/repo")
 		if err != nil && want != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -254,7 +254,7 @@ func (s *Server) Run() {
 				continue
 			}
 
-			repos, err := s.Sourcegraph.ListReposName(context.Background(), listIndexed(s.IndexDir))
+			repos, err := s.Sourcegraph.ListRepoNames(context.Background(), listIndexed(s.IndexDir))
 			if err != nil {
 				log.Println(err)
 				continue
@@ -774,7 +774,7 @@ func main() {
 	}
 
 	if *debugList {
-		repos, err := s.Sourcegraph.ListReposName(context.Background(), listIndexed(s.IndexDir))
+		repos, err := s.Sourcegraph.ListRepoNames(context.Background(), listIndexed(s.IndexDir))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -254,7 +254,7 @@ func (s *Server) Run() {
 				continue
 			}
 
-			repos, err := s.Sourcegraph.ListRepos(context.Background(), listIndexed(s.IndexDir))
+			repos, err := s.Sourcegraph.ListReposName(context.Background(), listIndexed(s.IndexDir))
 			if err != nil {
 				log.Println(err)
 				continue
@@ -283,7 +283,7 @@ func (s *Server) Run() {
 			// We ask the frontend to get index options in batches.
 			for repos := range batched(repos, s.BatchSize) {
 				start := time.Now()
-				opts, err := s.Sourcegraph.GetIndexOptions(repos...)
+				opts, err := s.Sourcegraph.GetIndexOptionsName(repos...)
 				if err != nil {
 					metricResolveRevisionDuration.WithLabelValues("false").Observe(time.Since(start).Seconds())
 					tr.LazyPrintf("failed fetching options batch: %v", err)
@@ -547,7 +547,7 @@ func (s *Server) serveEnqueueForIndex(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	debug.Printf("enqueueRepoForIndex called with repo: %q", name)
-	opts, err := s.Sourcegraph.GetIndexOptions(name)
+	opts, err := s.Sourcegraph.GetIndexOptionsName(name)
 	if err != nil || opts[0].Error != "" {
 		http.Error(rw, "fetching index options", http.StatusInternalServerError)
 		return
@@ -558,7 +558,7 @@ func (s *Server) serveEnqueueForIndex(rw http.ResponseWriter, r *http.Request) {
 // forceIndex will run the index job for repo name now. It will return always
 // return a string explaining what it did, even if it failed.
 func (s *Server) forceIndex(name string) (string, error) {
-	opts, err := s.Sourcegraph.GetIndexOptions(name)
+	opts, err := s.Sourcegraph.GetIndexOptionsName(name)
 	if err != nil {
 		return fmt.Sprintf("Indexing %s failed: %v", name, err), err
 	}
@@ -774,7 +774,7 @@ func main() {
 	}
 
 	if *debugList {
-		repos, err := s.Sourcegraph.ListRepos(context.Background(), listIndexed(s.IndexDir))
+		repos, err := s.Sourcegraph.ListReposName(context.Background(), listIndexed(s.IndexDir))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -75,7 +75,7 @@ func TestListRepos(t *testing.T) {
 		Client:   retryablehttp.NewClient(),
 	}
 
-	gotRepos, err := s.ListRepos(context.Background(), []string{"foo", "bam"})
+	gotRepos, err := s.ListReposName(context.Background(), []string{"foo", "bam"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -45,7 +45,7 @@ func TestServer_defaultArgs(t *testing.T) {
 	}
 }
 
-func TestListRepos(t *testing.T) {
+func TestListRepoIDs(t *testing.T) {
 	var gotBody string
 	var gotURL *url.URL
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -75,7 +75,7 @@ func TestListRepos(t *testing.T) {
 		Client:   retryablehttp.NewClient(),
 	}
 
-	gotRepos, err := s.ListReposName(context.Background(), []string{"foo", "bam"})
+	gotRepos, err := s.ListRepoNames(context.Background(), []string{"foo", "bam"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -29,7 +29,7 @@ type Sourcegraph interface {
 	// Deprecated. Included to minimize diff sizes.
 	GetIndexOptionsName(repos ...string) ([]indexOptionsItem, error)
 	// Deprecated. Included to minimize diff sizes.
-	ListReposName(ctx context.Context, indexed []string) ([]string, error)
+	ListRepoNames(ctx context.Context, indexed []string) ([]string, error)
 }
 
 // sourcegraphClient contains methods which interact with the sourcegraph API.
@@ -134,7 +134,7 @@ func (s *sourcegraphClient) GetCloneURL(name string) string {
 	return s.Root.ResolveReference(&url.URL{Path: path.Join("/.internal/git", name)}).String()
 }
 
-func (s *sourcegraphClient) ListReposName(ctx context.Context, indexed []string) ([]string, error) {
+func (s *sourcegraphClient) ListRepoNames(ctx context.Context, indexed []string) ([]string, error) {
 	body, err := json.Marshal(&struct {
 		Hostname string
 		Indexed  []string
@@ -302,7 +302,7 @@ func (sf sourcegraphFake) ListRepos(ctx context.Context, indexed []uint32) ([]ui
 	return repos, err
 }
 
-func (sf sourcegraphFake) ListReposName(ctx context.Context, indexed []string) ([]string, error) {
+func (sf sourcegraphFake) ListRepoNames(ctx context.Context, indexed []string) ([]string, error) {
 	var repos []string
 	err := sf.visitRepos(func(name string) {
 		repos = append(repos, name)

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -15,15 +15,21 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	"github.com/google/zoekt"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
 type Sourcegraph interface {
-	GetIndexOptions(repos ...string) ([]indexOptionsItem, error)
+	GetIndexOptions(repos ...uint32) ([]indexOptionsItem, error)
 	GetCloneURL(name string) string
-	ListRepos(ctx context.Context, indexed []string) ([]string, error)
+	ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error)
+
+	// Deprecated. Included to minimize diff sizes.
+	GetIndexOptionsName(repos ...string) ([]indexOptionsItem, error)
+	// Deprecated. Included to minimize diff sizes.
+	ListReposName(ctx context.Context, indexed []string) ([]string, error)
 }
 
 // sourcegraphClient contains methods which interact with the sourcegraph API.
@@ -46,7 +52,7 @@ type indexOptionsItem struct {
 	Error string
 }
 
-func (s *sourcegraphClient) GetIndexOptions(repos ...string) ([]indexOptionsItem, error) {
+func (s *sourcegraphClient) GetIndexOptionsName(repos ...string) ([]indexOptionsItem, error) {
 	u := s.Root.ResolveReference(&url.URL{
 		Path: "/.internal/search/configuration",
 	})
@@ -85,11 +91,50 @@ func (s *sourcegraphClient) GetIndexOptions(repos ...string) ([]indexOptionsItem
 	return opts, nil
 }
 
+func (s *sourcegraphClient) GetIndexOptions(repos ...uint32) ([]indexOptionsItem, error) {
+	u := s.Root.ResolveReference(&url.URL{
+		Path: "/.internal/search/configuration",
+	})
+
+	repoIDs := make([]string, len(repos))
+	for i, id := range repos {
+		repoIDs[i] = strconv.Itoa(int(id))
+	}
+	resp, err := s.Client.PostForm(u.String(), url.Values{"repoID": repoIDs})
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, &url.Error{
+			Op:  "Get",
+			URL: u.String(),
+			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
+		}
+	}
+
+	opts := make([]indexOptionsItem, len(repos))
+	dec := json.NewDecoder(resp.Body)
+	for i := range opts {
+		if err := dec.Decode(&opts[i]); err != nil {
+			return nil, fmt.Errorf("error decoding body: %w", err)
+		}
+	}
+
+	return opts, nil
+}
+
 func (s *sourcegraphClient) GetCloneURL(name string) string {
 	return s.Root.ResolveReference(&url.URL{Path: path.Join("/.internal/git", name)}).String()
 }
 
-func (s *sourcegraphClient) ListRepos(ctx context.Context, indexed []string) ([]string, error) {
+func (s *sourcegraphClient) ListReposName(ctx context.Context, indexed []string) ([]string, error) {
 	body, err := json.Marshal(&struct {
 		Hostname string
 		Indexed  []string
@@ -125,12 +170,48 @@ func (s *sourcegraphClient) ListRepos(ctx context.Context, indexed []string) ([]
 	return data.RepoNames, nil
 }
 
+func (s *sourcegraphClient) ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error) {
+	body, err := json.Marshal(&struct {
+		Hostname   string
+		IndexedIDs []uint32
+	}{
+		Hostname:   s.Hostname,
+		IndexedIDs: indexed,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	u := s.Root.ResolveReference(&url.URL{Path: "/.internal/repos/index"})
+	resp, err := s.Client.Post(u.String(), "application/json; charset=utf8", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list repositories: status %s", resp.Status)
+	}
+
+	var data struct {
+		RepoIDs []uint32
+	}
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	metricNumAssigned.Set(float64(len(data.RepoIDs)))
+
+	return data.RepoIDs, nil
+}
+
 type sourcegraphFake struct {
 	RootDir string
 	Log     *log.Logger
 }
 
-func (sf sourcegraphFake) GetIndexOptions(repos ...string) ([]indexOptionsItem, error) {
+func (sf sourcegraphFake) GetIndexOptionsName(repos ...string) ([]indexOptionsItem, error) {
 	var items []indexOptionsItem
 	for _, name := range repos {
 		opts, err := sf.getIndexOptions(name)
@@ -143,12 +224,44 @@ func (sf sourcegraphFake) GetIndexOptions(repos ...string) ([]indexOptionsItem, 
 	return items, nil
 }
 
+func (sf sourcegraphFake) GetIndexOptions(repos ...uint32) ([]indexOptionsItem, error) {
+	reposIdx := map[uint32]int{}
+	for i, id := range repos {
+		reposIdx[id] = i
+	}
+
+	items := make([]indexOptionsItem, len(repos))
+	err := sf.visitRepos(func(name string) {
+		idx, ok := reposIdx[sf.id(name)]
+		if !ok {
+			return
+		}
+		opts, err := sf.getIndexOptions(name)
+		if err != nil {
+			items[idx] = indexOptionsItem{Error: err.Error()}
+		} else {
+			items[idx] = indexOptionsItem{IndexOptions: opts}
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range items {
+		if items[i].Error == "" && items[i].RepoID == 0 {
+			items[i].Error = "not found"
+		}
+	}
+
+	return items, nil
+}
+
 func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 	dir := filepath.Join(sf.RootDir, filepath.FromSlash(name))
 
 	opts := IndexOptions{
-		// magic at the end is to ensure we get a positive number when casting.
-		RepoID:  uint32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1),
+		RepoID:  sf.id(name),
 		Name:    name,
 		Symbols: true,
 	}
@@ -180,9 +293,25 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 func (sf sourcegraphFake) GetCloneURL(name string) string {
 	return filepath.Join(sf.RootDir, filepath.FromSlash(name))
 }
-func (sf sourcegraphFake) ListRepos(ctx context.Context, indexed []string) ([]string, error) {
+
+func (sf sourcegraphFake) ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error) {
+	var repos []uint32
+	err := sf.visitRepos(func(name string) {
+		repos = append(repos, sf.id(name))
+	})
+	return repos, err
+}
+
+func (sf sourcegraphFake) ListReposName(ctx context.Context, indexed []string) ([]string, error) {
 	var repos []string
-	err := filepath.Walk(sf.RootDir, func(path string, fi os.FileInfo, fileErr error) error {
+	err := sf.visitRepos(func(name string) {
+		repos = append(repos, name)
+	})
+	return repos, err
+}
+
+func (sf sourcegraphFake) visitRepos(visit func(name string)) error {
+	return filepath.Walk(sf.RootDir, func(path string, fi os.FileInfo, fileErr error) error {
 		if fileErr != nil {
 			sf.Log.Printf("WARN: ignoring error searching %s: %v", path, fileErr)
 			return nil
@@ -204,9 +333,13 @@ func (sf sourcegraphFake) ListRepos(ctx context.Context, indexed []string) ([]st
 		}
 
 		name := filepath.ToSlash(subpath)
-		repos = append(repos, name)
+		visit(name)
 
 		return filepath.SkipDir
 	})
-	return repos, err
+}
+
+func (sf sourcegraphFake) id(name string) uint32 {
+	// magic at the end is to ensure we get a positive number when casting.
+	return uint32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1)
 }

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -24,7 +24,7 @@ import (
 type Sourcegraph interface {
 	GetIndexOptions(repos ...uint32) ([]indexOptionsItem, error)
 	GetCloneURL(name string) string
-	ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error)
+	ListRepoIDs(ctx context.Context, indexed []uint32) ([]uint32, error)
 
 	// Deprecated. Included to minimize diff sizes.
 	GetIndexOptionsName(repos ...string) ([]indexOptionsItem, error)
@@ -170,7 +170,7 @@ func (s *sourcegraphClient) ListRepoNames(ctx context.Context, indexed []string)
 	return data.RepoNames, nil
 }
 
-func (s *sourcegraphClient) ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error) {
+func (s *sourcegraphClient) ListRepoIDs(ctx context.Context, indexed []uint32) ([]uint32, error) {
 	body, err := json.Marshal(&struct {
 		Hostname   string
 		IndexedIDs []uint32
@@ -294,7 +294,7 @@ func (sf sourcegraphFake) GetCloneURL(name string) string {
 	return filepath.Join(sf.RootDir, filepath.FromSlash(name))
 }
 
-func (sf sourcegraphFake) ListRepos(ctx context.Context, indexed []uint32) ([]uint32, error) {
+func (sf sourcegraphFake) ListRepoIDs(ctx context.Context, indexed []uint32) ([]uint32, error) {
 	var repos []uint32
 	err := sf.visitRepos(func(name string) {
 		repos = append(repos, sf.id(name))

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -232,7 +232,7 @@ func (sf sourcegraphFake) GetIndexOptions(repos ...uint32) ([]indexOptionsItem, 
 
 	items := make([]indexOptionsItem, len(repos))
 	err := sf.visitRepos(func(name string) {
-		idx, ok := reposIdx[sf.id(name)]
+		idx, ok := reposIdx[fakeID(name)]
 		if !ok {
 			return
 		}
@@ -261,7 +261,7 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 	dir := filepath.Join(sf.RootDir, filepath.FromSlash(name))
 
 	opts := IndexOptions{
-		RepoID:  sf.id(name),
+		RepoID:  fakeID(name),
 		Name:    name,
 		Symbols: true,
 	}
@@ -297,7 +297,7 @@ func (sf sourcegraphFake) GetCloneURL(name string) string {
 func (sf sourcegraphFake) ListRepoIDs(ctx context.Context, indexed []uint32) ([]uint32, error) {
 	var repos []uint32
 	err := sf.visitRepos(func(name string) {
-		repos = append(repos, sf.id(name))
+		repos = append(repos, fakeID(name))
 	})
 	return repos, err
 }
@@ -339,7 +339,8 @@ func (sf sourcegraphFake) visitRepos(visit func(name string)) error {
 	})
 }
 
-func (sf sourcegraphFake) id(name string) uint32 {
+// fakeID returns a deterministic ID based on name. Used for fakes and tests.
+func fakeID(name string) uint32 {
 	// magic at the end is to ensure we get a positive number when casting.
 	return uint32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1)
 }


### PR DESCRIPTION
We keep the name based versions since it makes it more convenient to
piece meal migrate parts of indexserver over. Once everything is
migrated over we can delete the deprecated functions.