### PR TITLE
indexserver: use repo IDs instead of names

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -578,9 +578,8 @@ func (b *Builder) Finish() error {
 			if !strings.HasSuffix(p, ".zoekt") {
 				continue
 			}
-			repoName := b.opts.RepositoryDescription.Name
-			b.shardLog("tomb", p, repoName)
-			err := zoekt.SetTombstone(p, repoName)
+			b.shardLog("tomb", p, b.opts.RepositoryDescription.Name)
+			err := zoekt.SetTombstone(p, b.opts.RepositoryDescription.ID)
 			b.buildError = err
 			continue
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -255,7 +255,7 @@ func TestVacuum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(got) != 1 || got[0] != "repo2" {
+	if len(got) != 1 || got[0].Name != "repo2" {
 		t.Fatal(err)
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -115,7 +115,7 @@ func marshalBool(b bool) string {
 }
 
 func (o *indexArgs) String() string {
-	s := o.Name
+	s := fmt.Sprintf("%d %s", o.RepoID, o.Name)
 	for i, b := range o.Branches {
 		if i == 0 {
 			s = fmt.Sprintf("%s@%s=%s", s, b.Name, b.Version)

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -115,7 +115,7 @@ func (q *Queue) SetIndexed(opts IndexOptions, state indexState) {
 	q.mu.Unlock()
 }
 
-// MaybeRemoveMissing will remove all queue items not in names. It will
+// MaybeRemoveMissing will remove all queue items not in ids. It will
 // heuristically not run to conserve resources and return -1. Otherwise it
 // will return the number of names removed from the queue.
 //
@@ -124,9 +124,9 @@ func (q *Queue) SetIndexed(opts IndexOptions, state indexState) {
 // removals. Removal requires memory allocation and coarse locking. To avoid
 // that we use a heuristic which can falsely decide it doesn't need to
 // remove. However, we will converge onto removing items.
-func (q *Queue) MaybeRemoveMissing(names []string) int {
+func (q *Queue) MaybeRemoveMissing(ids []uint32) int {
 	q.mu.Lock()
-	sameSize := len(q.items) == len(names)
+	sameSize := len(q.items) == len(ids)
 	q.mu.Unlock()
 
 	// heuristically skip expensive work
@@ -134,9 +134,9 @@ func (q *Queue) MaybeRemoveMissing(names []string) int {
 		return -1
 	}
 
-	set := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		set[name] = struct{}{}
+	set := make(map[uint32]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
 	}
 
 	q.mu.Lock()
@@ -144,7 +144,7 @@ func (q *Queue) MaybeRemoveMissing(names []string) int {
 
 	count := 0
 	for _, item := range q.items {
-		if _, ok := set[item.opts.Name]; ok {
+		if _, ok := set[item.opts.RepoID]; ok {
 			continue
 		}
 

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -76,7 +76,7 @@ func TestQueue_MaybeRemoveMissing(t *testing.T) {
 
 	queue.AddOrUpdate(IndexOptions{RepoID: 1, Name: "foo"})
 	queue.AddOrUpdate(IndexOptions{RepoID: 2, Name: "bar"})
-	queue.MaybeRemoveMissing([]string{"bar"})
+	queue.MaybeRemoveMissing([]uint32{2})
 
 	opts, _ := queue.Pop()
 	if opts.Name != "bar" {

--- a/tombstones.go
+++ b/tombstones.go
@@ -17,7 +17,7 @@ func TombstonesEnabled(dir string) bool {
 var mockRepos []*Repository
 
 // SetTombstone idempotently sets a tombstone for repoName in .meta.
-func SetTombstone(shardPath string, repoName string) error {
+func SetTombstone(shardPath string, repoID uint32) error {
 	var repos []*Repository
 	var err error
 
@@ -31,7 +31,7 @@ func SetTombstone(shardPath string, repoName string) error {
 	}
 
 	for _, repo := range repos {
-		if repo.Name == repoName {
+		if repo.ID == repoID {
 			repo.Tombstone = true
 		}
 	}

--- a/tombstones_test.go
+++ b/tombstones_test.go
@@ -21,7 +21,7 @@ func TestSetTombstone(t *testing.T) {
 	dir := t.TempDir()
 	ghostShard := filepath.Join(dir, "test.zoekt")
 
-	SetTombstone(ghostShard, "r2")
+	SetTombstone(ghostShard, 2)
 
 	blob := readMeta(ghostShard)
 	gotRepos := []*Repository{}
@@ -39,7 +39,7 @@ func TestSetTombstone(t *testing.T) {
 		t.Fatal("r3 should have been alive")
 	}
 
-	SetTombstone(ghostShard, "r1")
+	SetTombstone(ghostShard, 1)
 
 	blob = readMeta(ghostShard)
 	gotRepos = nil
@@ -60,8 +60,8 @@ func TestSetTombstone(t *testing.T) {
 
 func mkRepos(repoNames ...string) []*Repository {
 	ret := make([]*Repository, 0, len(repoNames))
-	for _, n := range repoNames {
-		ret = append(ret, &Repository{Name: n})
+	for i, n := range repoNames {
+		ret = append(ret, &Repository{ID: uint32(i + 1), Name: n})
 	}
 	return ret
 }


### PR DESCRIPTION
This moves the bulk of our interactions with Sourcegraph to be based on repository IDs instead of names. To do this required also updating our cleanup routines to be ID based.

Cleanup is based on the list of assigned repositories. We could keep the name based cleanup if we did it after we had resolved options. However, resolving options can fail so I opted to update the cleanup code to be ID based. This is where the bulk of the changes occurred. We set tombstones as part of cleanup, so that also switched to being ID based.