### PR TITLE
indexserver: remove ListRepoNames and GetIndexOptionsName

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -29,7 +29,7 @@ func TestGetIndexOptions(t *testing.T) {
 			http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
 			return
 		}
-		if got, want := r.Form, (url.Values{"repo": []string{"test/repo"}}); !reflect.DeepEqual(got, want) {
+		if got, want := r.Form, (url.Values{"repoID": []string{"123"}}); !reflect.DeepEqual(got, want) {
 			http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
 			return
 		}
@@ -49,25 +49,21 @@ func TestGetIndexOptions(t *testing.T) {
 
 	cases := map[string]*IndexOptions{
 		`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {
-			Name:       "test/repo",
 			Symbols:    true,
 			LargeFiles: []string{"foo", "bar"},
 		},
 
 		`{"Symbols": false, "LargeFiles": ["foo","bar"]}`: {
-			Name:       "test/repo",
 			LargeFiles: []string{"foo", "bar"},
 		},
 
-		`{}`: {Name: "test/repo"},
+		`{}`: {},
 
 		`{"Symbols": true}`: {
-			Name:    "test/repo",
 			Symbols: true,
 		},
 
 		`{"RepoID": 123}`: {
-			Name:   "test/repo",
 			RepoID: 123,
 		},
 
@@ -77,7 +73,7 @@ func TestGetIndexOptions(t *testing.T) {
 	for r, want := range cases {
 		response = []byte(r)
 
-		got, err := sg.GetIndexOptionsName("test/repo")
+		got, err := sg.GetIndexOptions(123)
 		if err != nil && want != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -89,11 +89,6 @@ var (
 		Name: "index_indexing_total",
 		Help: "Counts indexings (indexing activity, should be used with rate())",
 	})
-
-	metricsEnqueueRepoForIndex = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "enqueue_repo_for_index_total",
-		Help: "Counts the number of time /enqueueforindex is called",
-	})
 )
 
 type indexState string
@@ -528,35 +523,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	repoTmpl.Execute(w, data)
 }
 
-// serveEnqueueForIndex is expected to be called by other services in order to
-// trigger an index.  We expect repo-updater to call this endpoint when a new
-// repo has been added to an instance that we wish to index and don't want to
-// wait for polling to happen.
-func (s *Server) serveEnqueueForIndex(rw http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(rw, "not found", http.StatusNotFound)
-		return
-	}
-	metricsEnqueueRepoForIndex.Inc()
-	err := r.ParseForm()
-	if err != nil {
-		http.Error(rw, "error parsing form", http.StatusBadRequest)
-		return
-	}
-	name := r.Form.Get("repo")
-	if name == "" {
-		http.Error(rw, "missing repo", http.StatusBadRequest)
-		return
-	}
-	debug.Printf("enqueueRepoForIndex called with repo: %q", name)
-	opts, err := s.Sourcegraph.GetIndexOptionsName(name)
-	if err != nil || opts[0].Error != "" {
-		http.Error(rw, "fetching index options", http.StatusInternalServerError)
-		return
-	}
-	s.queue.AddOrUpdate(opts[0].IndexOptions)
-}
-
 // forceIndex will run the index job for repo name now. It will return always
 // return a string explaining what it did, even if it failed.
 func (s *Server) forceIndex(name string) (string, error) {
@@ -828,7 +794,6 @@ func main() {
 			mux := http.NewServeMux()
 			debugserver.AddHandlers(mux, true)
 			mux.Handle("/", s)
-			mux.HandleFunc("/enqueueforindex", s.serveEnqueueForIndex)
 			debug.Printf("serving HTTP on %s", *listen)
 			log.Fatal(http.ListenAndServe(*listen, mux))
 		}()

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -57,7 +57,7 @@ func TestListRepoIDs(t *testing.T) {
 		}
 		gotBody = string(b)
 
-		_, err = w.Write([]byte(`{"RepoNames": ["foo", "bar", "baz"]}`))
+		_, err = w.Write([]byte(`{"RepoIDs": [1, 2, 3]}`))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,15 +75,15 @@ func TestListRepoIDs(t *testing.T) {
 		Client:   retryablehttp.NewClient(),
 	}
 
-	gotRepos, err := s.ListRepoNames(context.Background(), []string{"foo", "bam"})
+	gotRepos, err := s.ListRepoIDs(context.Background(), []uint32{1, 3})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if want := []string{"foo", "bar", "baz"}; !cmp.Equal(gotRepos, want) {
+	if want := []uint32{1, 2, 3}; !cmp.Equal(gotRepos, want) {
 		t.Errorf("repos mismatch (-want +got):\n%s", cmp.Diff(want, gotRepos))
 	}
-	if want := `{"Hostname":"test-indexed-search-1","Indexed":["foo","bam"]}`; gotBody != want {
+	if want := `{"Hostname":"test-indexed-search-1","IndexedIDs":[1,3]}`; gotBody != want {
 		t.Errorf("body mismatch (-want +got):\n%s", cmp.Diff(want, gotBody))
 	}
 	if want := "/.internal/repos/index"; gotURL.Path != want {


### PR DESCRIPTION
These are only used by the debug page and the unused enqueueforindex endpoint.

In the case of the debug page we update to support IDs. In the case of enqueueforindex we remove it since it is unused.
