### PR TITLE
shards: reduce blocking in locking strategy

### DIFF
--- a/shards/eval_test.go
+++ b/shards/eval_test.go
@@ -15,7 +15,7 @@ func TestSearchTypeRepo(t *testing.T) {
 	addShard := func(docs ...zoekt.Document) {
 		b := testIndexBuilder(t, &zoekt.Repository{ID: 1, Name: "reponame"}, docs...)
 		shard := searcherForTest(t, b)
-		ss.replace(fmt.Sprintf("key-%d", nextShardNum), shard)
+		ss.replace(map[string]zoekt.Searcher{fmt.Sprintf("key-%d", nextShardNum): shard})
 		nextShardNum++
 	}
 	addShard(

--- a/shards/sched_test.go
+++ b/shards/sched_test.go
@@ -168,27 +168,10 @@ func TestMultiScheduler(t *testing.T) {
 		t.Fatal("expected second acquire after cap to fail")
 	}
 
-	// We check that exclusive works by trying to acquire one and ensuring it
-	// only works once we have released all other existing procs
-	exclusiveC := make(chan *process)
-	go func() {
-		exclusiveC <- sched.Exclusive()
-	}()
-
-	select {
-	case <-exclusiveC:
-		t.Fatal("should not acquire exclusive since other procs are running")
-	case <-time.After(10 * time.Millisecond):
-	}
-
 	for _, p := range procs {
 		p.Release()
 	}
 	procs = nil
-
-	// Now we should get exclusive
-	proc := <-exclusiveC
-	proc.Release()
 }
 
 func quickCtx(t *testing.T) context.Context {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -138,7 +138,7 @@ var (
 	})
 	metricShardsBatchReplaceDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "zoekt_shards_batch_replace_duration_seconds",
-		Help:    "The time it takes to close a Searcher.",
+		Help:    "The time it takes to replace a batch of Searchers.",
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
 	})
 	metricListAllRepos = promauto.NewGauge(prometheus.GaugeOpts{

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -624,7 +624,7 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 					metricSearchMatchCountTotal.Add(float64(sr.Stats.MatchCount))
 					metricSearchNgramMatchesTotal.Add(float64(sr.Stats.NgramMatches))
 
-					// copyFiles must happen before finalizer for *rankedShard Closes the underlying mmaped file
+					// copyFiles must happen before the finalizer for *rankedShard Closes the underlying mmaped file
 					// so we ensure it always happens before *rankedShard is no longer referenced and can be garbage
 					// collected
 					copyFiles(sr)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -298,13 +298,13 @@ func (ss *shardedSearcher) String() string {
 // Close closes references to open files. It may be called only once.
 func (ss *shardedSearcher) Close() {
 	ss.mu.Lock()
-	shards := ss.shards
-	ss.shards = make(map[string]*rankedShard)
+	shards := make(map[string]zoekt.Searcher, len(ss.shards))
+	for k := range ss.shards {
+		shards[k] = nil
+	}
 	ss.mu.Unlock()
 
-	for _, s := range shards {
-		s.Close()
-	}
+	ss.replace(shards)
 }
 
 func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -847,7 +847,8 @@ func reportListAllMetrics(repos []*zoekt.RepoListEntry) {
 // getShards returns the currently loaded shards. The shards are sorted by decreasing
 // rank and should not be mutated.
 func (s *shardedSearcher) getShards() []*rankedShard {
-	return s.ranked.Load().([]*rankedShard)
+	ranked, _ := s.ranked.Load().([]*rankedShard)
+	return ranked
 }
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -131,11 +131,6 @@ var (
 		Name: "zoekt_list_shard_running",
 		Help: "The number of concurrent list requests in a shard running",
 	})
-	metricShardCloseDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "zoekt_shard_close_duration_seconds",
-		Help:    "The time it takes to close a Searcher.",
-		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
-	})
 	metricShardsBatchReplaceDurationSeconds = promauto.NewHistogram(prometheus.HistogramOpts{
 		Name:    "zoekt_shards_batch_replace_duration_seconds",
 		Help:    "The time it takes to replace a batch of Searchers.",
@@ -910,9 +905,7 @@ func (s *shardedSearcher) replace(shards map[string]zoekt.Searcher) {
 
 		if old != nil && old.Searcher != nil {
 			runtime.SetFinalizer(old, func(r *rankedShard) {
-				start := time.Now()
 				r.Close()
-				metricShardCloseDurationSeconds.Observe(time.Since(start).Seconds())
 			})
 		}
 	}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -21,13 +21,11 @@ import (
 	"hash/fnv"
 	"log"
 	"math"
-	"math/rand"
 	"os"
 	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
@@ -712,25 +710,4 @@ func TestPrioritySlice(t *testing.T) {
 			t.Errorf("%d: got %f, want %f", step, max, oper.expectedMax)
 		}
 	}
-}
-
-func BenchmarkRLock(b *testing.B) {
-	type locker struct{ sync.RWMutex }
-	rlocks := make([]*locker, 100000)
-	for i := 0; i < cap(rlocks); i++ {
-		rlocks[i] = new(locker)
-	}
-
-	rand.Shuffle(len(rlocks), func(i, j int) {
-		rlocks[i], rlocks[j] = rlocks[j], rlocks[i]
-	})
-
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for j := range rlocks {
-				rlocks[j].RLock()
-			}
-		}
-	})
 }

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -59,7 +59,7 @@ func TestCrashResilience(t *testing.T) {
 	log.SetOutput(out)
 	defer log.SetOutput(os.Stderr)
 	ss := newShardedSearcher(2)
-	ss.ranked = rankedShards{{Searcher: &crashSearcher{}}}
+	ss.ranked.Store([]*rankedShard{{Searcher: &crashSearcher{}}})
 
 	q := &query.Substring{Pattern: "hoi"}
 	opts := &zoekt.SearchOptions{}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -133,10 +133,9 @@ func TestOrderByShard(t *testing.T) {
 
 	n := 10 * runtime.GOMAXPROCS(0)
 	for i := 0; i < n; i++ {
-		ss.replace(fmt.Sprintf("shard%d", i),
-			&rankSearcher{
-				rank: uint16(i),
-			})
+		ss.replace(map[string]zoekt.Searcher{
+			fmt.Sprintf("shard%d", i): &rankSearcher{rank: uint16(i)},
+		})
 	}
 
 	if res, err := ss.Search(context.Background(), &query.Substring{Pattern: "bla"}, &zoekt.SearchOptions{}); err != nil {
@@ -182,7 +181,9 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 		}
 		b := testIndexBuilder(t, r, docs...)
 		shard := searcherForTest(t, b)
-		ss.replace(fmt.Sprintf("key-%d", nextShardNum), shard)
+		ss.replace(map[string]zoekt.Searcher{
+			fmt.Sprintf("key-%d", nextShardNum): shard,
+		})
 		nextShardNum++
 	}
 
@@ -228,9 +229,11 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 			repoSetNames = append(repoSetNames, repoName)
 		}
 
-		ss.replace(shardName, &rankSearcher{
-			repo: &zoekt.Repository{ID: hash(repoName), Name: repoName},
-			rank: uint16(n - i),
+		ss.replace(map[string]zoekt.Searcher{
+			shardName: &rankSearcher{
+				repo: &zoekt.Repository{ID: hash(repoName), Name: repoName},
+				rank: uint16(n - i),
+			},
 		})
 	}
 
@@ -321,7 +324,7 @@ func TestUnloadIndex(t *testing.T) {
 	}
 
 	ss := newShardedSearcher(2)
-	ss.replace("key", searcher)
+	ss.replace(map[string]zoekt.Searcher{"key": searcher})
 
 	var opts zoekt.SearchOptions
 	q := &query.Substring{Pattern: "needle"}
@@ -368,10 +371,12 @@ func TestShardedSearcher_List(t *testing.T) {
 
 	// Test duplicate removal when ListOptions.Minimal is true and false
 	ss := newShardedSearcher(4)
-	ss.replace("1", searcherForTest(t, testIndexBuilder(t, repos[0])))
-	ss.replace("2", searcherForTest(t, testIndexBuilder(t, repos[0])))
-	ss.replace("3", searcherForTest(t, testIndexBuilder(t, repos[1])))
-	ss.replace("4", searcherForTest(t, testIndexBuilder(t, repos[1])))
+	ss.replace(map[string]zoekt.Searcher{
+		"1": searcherForTest(t, testIndexBuilder(t, repos[0])),
+		"2": searcherForTest(t, testIndexBuilder(t, repos[0])),
+		"3": searcherForTest(t, testIndexBuilder(t, repos[1])),
+		"4": searcherForTest(t, testIndexBuilder(t, repos[1])),
+	})
 
 	for _, tc := range []struct {
 		name string
@@ -519,13 +524,15 @@ func BenchmarkShardedSearch(b *testing.B) {
 	repos := reposForTest(3000)
 	var repoSetIDs []uint32
 
+	shards := make(map[string]zoekt.Searcher, len(repos))
 	for i, r := range repos {
-		searcher := testSearcherForRepo(b, r, filesPerRepo)
-		ss.replace(r.Name, searcher)
+		shards[r.Name] = testSearcherForRepo(b, r, filesPerRepo)
 		if i%2 == 0 {
 			repoSetIDs = append(repoSetIDs, r.ID)
 		}
 	}
+
+	ss.replace(shards)
 
 	ctx := context.Background()
 	opts := &zoekt.SearchOptions{}
@@ -588,7 +595,7 @@ func TestRawQuerySearch(t *testing.T) {
 		r.RawConfig = rawConfig
 		b := testIndexBuilder(t, r, docs...)
 		shard := searcherForTest(t, b)
-		ss.replace(fmt.Sprintf("key-%d", nextShardNum), shard)
+		ss.replace(map[string]zoekt.Searcher{fmt.Sprintf("key-%d", nextShardNum): shard})
 		nextShardNum++
 	}
 	addShard("public", map[string]string{"public": "1"}, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -192,13 +192,6 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 	addShard("weekend-project-2", 0.25, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
 	addShard("super-star", 0.9, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})
 
-	q := &query.Substring{Pattern: "foo"}
-
-	sr, err := ss.Search(context.Background(), q, &zoekt.SearchOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	want := []string{
 		"super-star",
 		"moderately-popular",
@@ -207,8 +200,10 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 	}
 
 	var have []string
-	for _, fm := range sr.Files {
-		have = append(have, fm.Repository)
+	for _, s := range ss.getShards() {
+		for _, r := range s.repos {
+			have = append(have, r.Name)
+		}
 	}
 
 	if !reflect.DeepEqual(want, have) {

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -724,7 +724,6 @@ func BenchmarkRLock(b *testing.B) {
 	})
 
 	b.ResetTimer()
-	b.SetParallelism(1)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			for j := range rlocks {

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -57,9 +57,7 @@ func TestCrashResilience(t *testing.T) {
 	log.SetOutput(out)
 	defer log.SetOutput(os.Stderr)
 	ss := newShardedSearcher(2)
-	ss.shards = map[string]rankedShard{
-		"x": {Searcher: &crashSearcher{}},
-	}
+	ss.ranked = rankedShards{{Searcher: &crashSearcher{}}}
 
 	q := &query.Substring{Pattern: "hoi"}
 	opts := &zoekt.SearchOptions{}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -184,9 +184,10 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 		nextShardNum++
 	}
 
-	addShard("super-star", 0.9, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})
 	addShard("weekend-project", 0.25, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
 	addShard("moderately-popular", 0.5, zoekt.Document{Name: "f3", Content: []byte("foo bar")})
+	addShard("weekend-project-2", 0.25, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
+	addShard("super-star", 0.9, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})
 
 	q := &query.Substring{Pattern: "foo"}
 
@@ -196,9 +197,10 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 	}
 
 	want := []string{
-		"weekend-project",
-		"moderately-popular",
 		"super-star",
+		"moderately-popular",
+		"weekend-project",
+		"weekend-project-2",
 	}
 
 	var have []string

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -21,11 +21,13 @@ import (
 	"hash/fnv"
 	"log"
 	"math"
+	"math/rand"
 	"os"
 	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -708,4 +710,26 @@ func TestPrioritySlice(t *testing.T) {
 			t.Errorf("%d: got %f, want %f", step, max, oper.expectedMax)
 		}
 	}
+}
+
+func BenchmarkRLock(b *testing.B) {
+	type locker struct{ sync.RWMutex }
+	rlocks := make([]*locker, 100000)
+	for i := 0; i < cap(rlocks); i++ {
+		rlocks[i] = new(locker)
+	}
+
+	rand.Shuffle(len(rlocks), func(i, j int) {
+		rlocks[i], rlocks[j] = rlocks[j], rlocks[i]
+	})
+
+	b.ResetTimer()
+	b.SetParallelism(1)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for j := range rlocks {
+				rlocks[j].RLock()
+			}
+		}
+	})
 }

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -30,7 +30,7 @@ import (
 )
 
 type shardLoader interface {
-	// Load a new file. Should be safe for concurrent calls.
+	// Load a new file.
 	load(filenames ...string)
 	drop(filenames ...string)
 }

--- a/shards/watcher_test.go
+++ b/shards/watcher_test.go
@@ -30,12 +30,16 @@ type loggingLoader struct {
 	drops chan string
 }
 
-func (l *loggingLoader) load(k string) {
-	l.loads <- k
+func (l *loggingLoader) load(keys ...string) {
+	for _, key := range keys {
+		l.loads <- key
+	}
 }
 
-func (l *loggingLoader) drop(k string) {
-	l.drops <- k
+func (l *loggingLoader) drop(keys ...string) {
+	for _, key := range keys {
+		l.drops <- key
+	}
 }
 
 func advanceFS() {


### PR DESCRIPTION
This commit is an attempt to reduce the blocking that occurs when `multiScheduler.Acquire` [calls pile up](https://github.com/sourcegraph/sourcegraph/issues/25872#issuecomment-943311299) after a `multiScheduler.Exclusive` call happens, waiting for already running searches to finish AND the work protected by the Exclusive process.

To that end, we:

1. Remove the `Exclusive` lock functionality from `multiScheduler` which now concerns itself only with controlling concurrent searches and their fairness (interactive + batch).
2. Make `shardedSearcher.replace` work with batches to amortize the initial loading sorting cost instead of sorting it on the search path.
3. Leverage `runtime.SetFinalizer` to call `Close` on a `*rankedSearcher` that was dropped when it is no longer referenced anywhere by any on-going searches.

Part of https://github.com/sourcegraph/sourcegraph/issues/25872
