### PR TITLE
trace: flatten opentracing spans

### DIFF
--- a/trace/trace.go
+++ b/trace/trace.go
@@ -31,18 +31,30 @@ func New(ctx context.Context, family, title string) (*Trace, context.Context) {
 
 // New returns a new Trace with the specified family and title.
 func (t Tracer) New(ctx context.Context, family, title string) (*Trace, context.Context) {
-	span, ctx := StartSpanFromContextWithTracer(
-		ctx,
-		t.Tracer,
-		family,
-		opentracing.Tag{Key: "title", Value: title},
-	)
+	// In Zoekt child OpenTracing Spans don't really make much sense since all
+	// our spans are either middleware which just wrap an actual search, or the
+	// actual search. So we only create a new span if there is no parent.
+	parent := TraceFromContext(ctx)
+	var span opentracing.Span
+	if parent != nil {
+		span = parent.span
+		span.LogFields(log.String("child.family", family), log.String("child.title", title))
+	} else {
+		span, ctx = StartSpanFromContextWithTracer(
+			ctx,
+			t.Tracer,
+			family,
+			opentracing.Tag{Key: "title", Value: title},
+		)
+	}
+
 	tr := nettrace.New(family, title)
 	trace := &Trace{span: span, trace: tr, family: family}
-	if parent := TraceFromContext(ctx); parent != nil {
+	if parent != nil {
 		tr.LazyPrintf("parent: %s", parent.family)
 		trace.family = parent.family + " > " + family
 	}
+
 	return trace, ContextWithTrace(ctx, trace)
 }
 


### PR DESCRIPTION
It is quite frustrating to read traces involving zoekt since they are
always 4 levels deep with all spans but the leaf containing not much
useful information. This just ends up taking up a lot of vertical
space. Instead we can just collapse spans in Zoekt.

Before

![image](https://user-images.githubusercontent.com/187831/137919100-f01334cb-0d0d-4340-a245-d2b078d7343b.png)
