### PR TITLE
shards: avoid locking around Send

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -32,7 +32,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -430,13 +429,10 @@ func (s *loggedSearcher) StreamSearch(
 	sender zoekt.Sender,
 ) error {
 	var (
-		mu    sync.Mutex
 		stats zoekt.Stats
 	)
 	err := s.Streamer.StreamSearch(ctx, q, opts, stream.SenderFunc(func(event *zoekt.SearchResult) {
-		mu.Lock()
 		stats.Add(event.Stats)
-		mu.Unlock()
 		sender.Send(event)
 	}))
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -609,6 +609,9 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 		wg      sync.WaitGroup
 	)
 
+	// Since searching is mostly CPU bound, we limit the number
+	// of parallel shard searches which also reduces the peak working set
+
 	wg.Add(workers)
 	for i := 0; i < workers; i++ {
 		go func() {
@@ -647,7 +650,7 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 
 search:
 	for {
-		_ = proc.Yield(ctx)
+		_ = proc.Yield(ctx) // We let searchOneShard handle context errors.
 
 		select {
 		case work <- next:

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -593,7 +593,7 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 
 	defer cancel()
 
-	workers := runtime.NumCPU()
+	workers := runtime.GOMAXPROCS(0)
 	if workers > len(shards) {
 		workers = len(shards)
 	}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -15,6 +15,7 @@
 package shards
 
 import (
+	"container/heap"
 	"context"
 	"fmt"
 	"log"
@@ -28,7 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/google/zoekt"
@@ -580,98 +580,174 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 	shards, q = selectRepoSet(shards, q)
 	tr.LazyPrintf("after selectRepoSet shards:%d %s", len(shards), q)
 
-	var childCtx context.Context
+	if len(shards) == 0 {
+		return func() {}, nil
+	}
+
 	var cancel context.CancelFunc
 	if opts.MaxWallTime == 0 {
-		childCtx, cancel = context.WithCancel(ctx)
+		ctx, cancel = context.WithCancel(ctx)
 	} else {
-		childCtx, cancel = context.WithTimeout(ctx, opts.MaxWallTime)
+		ctx, cancel = context.WithTimeout(ctx, opts.MaxWallTime)
 	}
 
 	defer cancel()
 
-	mu := sync.Mutex{}
-	pendingPriorities := prioritySlice{}
+	workers := runtime.NumCPU()
+	if workers > len(shards) {
+		workers = len(shards)
+	}
 
-	g, ctx := errgroup.WithContext(childCtx)
+	type result struct {
+		*rankedShard
+		*zoekt.SearchResult
+		err error
+	}
 
-	// For each query, throttle the number of parallel
-	// actions. Since searching is mostly CPU bound, we limit the
-	// number of parallel searches. This reduces the peak working
-	// set, which hopefully stops https://cs.bazel.build from crashing
-	// when looking for the string "com".
-	//
-	// We do yield inside of the feeder. This means we could have num_workers +
-	// cap(feeder) searches run while yield blocks. However, doing it this way
-	// avoids needing to have synchronization in yield, so is done for
-	// simplicity.
-	feeder := make(chan *rankedShard, runtime.GOMAXPROCS(0))
-	g.Go(func() error {
-		defer close(feeder)
-		// Note: shards is sorted in order of descending priority.
-		for _, s := range shards {
-			// We let searchOneShard handle context errors.
-			_ = proc.Yield(ctx)
-			mu.Lock()
-			pendingPriorities.append(s.priority)
-			mu.Unlock()
-			feeder <- s
+	var (
+		results = make(chan *result)
+		search  = make(chan *rankedShard)
+		wg      sync.WaitGroup
+	)
+
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for s := range search {
+				sr, err := searchOneShard(ctx, s, q, opts)
+				r := &result{rankedShard: s, SearchResult: sr, err: err}
+				results <- r
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var (
+		pending = make(map[*rankedShard]struct{}, workers)
+		pq      = make(priorityQueue, 0, workers)
+		shard   = 0
+		next    = shards[shard]
+	)
+
+	stop := func() {
+		if search != nil {
+			close(search)
+			search = nil
+			next = nil
 		}
-		return nil
-	})
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
-		g.Go(func() error {
-			for s := range feeder {
-				err := searchOneShard(ctx, s, q, opts, stream.SenderFunc(func(sr *zoekt.SearchResult) {
-					metricSearchContentBytesLoadedTotal.Add(float64(sr.Stats.ContentBytesLoaded))
-					metricSearchIndexBytesLoadedTotal.Add(float64(sr.Stats.IndexBytesLoaded))
-					metricSearchCrashesTotal.Add(float64(sr.Stats.Crashes))
-					metricSearchFileCountTotal.Add(float64(sr.Stats.FileCount))
-					metricSearchShardFilesConsideredTotal.Add(float64(sr.Stats.ShardFilesConsidered))
-					metricSearchFilesConsideredTotal.Add(float64(sr.Stats.FilesConsidered))
-					metricSearchFilesLoadedTotal.Add(float64(sr.Stats.FilesLoaded))
-					metricSearchFilesSkippedTotal.Add(float64(sr.Stats.FilesSkipped))
-					metricSearchShardsSkippedTotal.Add(float64(sr.Stats.ShardsSkipped))
-					metricSearchMatchCountTotal.Add(float64(sr.Stats.MatchCount))
-					metricSearchNgramMatchesTotal.Add(float64(sr.Stats.NgramMatches))
+	}
 
-					// MaxPendingPriority *cannot* be this result's Priority, because
-					// the priority is removed before computing max() and calling sender.Send.
-					// (There may be duplicate priorities, though-- that's fine.) A PendingShard
-					// is one that has not entered this critical section and sent its results.
-					//
-					// Note that there are at least two layers above this implementing streamSearch
-					// or StreamSearch that also take a lock for the entirety of the Send() operation.
-					//
-					// This is to avoid a potential race between shards sending back results
-					// if the priority were removed before sending without a lock:
-					// 1) shard A (pri 1), B (pri 2), C (pri 3) dispatch, pendingPriorities = [1, 2, 3]
-					// 2) C completes and removes itself from the priority list, pP = [1, 2]
-					// 3) B completes, removes itself, computes max, *and sends results* as maxPendingPriority=1,
-					//    indicating that no future results will come from a lower-ordered shard, pP = [1]
-					// 4) A completes, removes itself, computes max, and sends results with maxPP=-Inf, indicating
-					//    that the stream is finished (?)
-					// 5) C finally wakes up, computes max, and sends results with maxPP=-Inf, but with priority=3.
-					mu.Lock()
-					pendingPriorities.remove(s.priority)
-					sr.Progress.MaxPendingPriority = pendingPriorities.max()
-					sr.Progress.Priority = s.priority
-					sender.Send(sr)
-					mu.Unlock()
-				}))
-				if err != nil {
-					mu.Lock()
-					pendingPriorities.remove(s.priority)
-					mu.Unlock()
-					return err
+search:
+	for {
+		_ = proc.Yield(ctx)
+
+		select {
+		case search <- next:
+			pending[next] = struct{}{}
+
+			if shard++; shard == len(shards) {
+				stop()
+			} else {
+				next = shards[shard]
+			}
+		case r, ok := <-results:
+			if !ok {
+				break search
+			}
+
+			if r.err != nil {
+				// Set final error and stop searching new shards, but consume any pending
+				// search results.
+				stop()
+				err = r.err
+				continue
+			}
+
+			observeMetrics(r.SearchResult)
+
+			// delete this rankedShard from the pending set before computing the new max pending priority
+			delete(pending, r.rankedShard)
+
+			r.Priority = r.rankedShard.priority
+			r.MaxPendingPriority = math.Inf(-1)
+			for s := range pending {
+				if s.priority > r.MaxPendingPriority {
+					r.MaxPendingPriority = s.priority
 				}
 			}
-			return nil
-		})
+
+			// Pop and send search results where it is guaranteed that no higher-priority result
+			// is possible, because there are no pending shards with a greater priority.
+			pq.add(r.SearchResult)
+			for pq.isTopAbove(r.MaxPendingPriority) {
+				sender.Send(heap.Pop(&pq).(*zoekt.SearchResult))
+			}
+		}
 	}
-	return func() {
-		runtime.KeepAlive(shards)
-	}, g.Wait()
+
+	// Flush any pending results.
+	for pq.Len() > 0 {
+		sender.Send(heap.Pop(&pq).(*zoekt.SearchResult))
+	}
+
+	return func() { runtime.KeepAlive(shards) }, err
+}
+
+func observeMetrics(sr *zoekt.SearchResult) {
+	metricSearchContentBytesLoadedTotal.Add(float64(sr.Stats.ContentBytesLoaded))
+	metricSearchIndexBytesLoadedTotal.Add(float64(sr.Stats.IndexBytesLoaded))
+	metricSearchCrashesTotal.Add(float64(sr.Stats.Crashes))
+	metricSearchFileCountTotal.Add(float64(sr.Stats.FileCount))
+	metricSearchShardFilesConsideredTotal.Add(float64(sr.Stats.ShardFilesConsidered))
+	metricSearchFilesConsideredTotal.Add(float64(sr.Stats.FilesConsidered))
+	metricSearchFilesLoadedTotal.Add(float64(sr.Stats.FilesLoaded))
+	metricSearchFilesSkippedTotal.Add(float64(sr.Stats.FilesSkipped))
+	metricSearchShardsSkippedTotal.Add(float64(sr.Stats.ShardsSkipped))
+	metricSearchMatchCountTotal.Add(float64(sr.Stats.MatchCount))
+	metricSearchNgramMatchesTotal.Add(float64(sr.Stats.NgramMatches))
+}
+
+// priorityQueue modified from https://golang.org/pkg/container/heap/
+// A priorityQueue implements heap.Interface and holds Items.
+// All Exported methods are part of the container.heap interface, and
+// unexported methods are local helpers.
+type priorityQueue []*zoekt.SearchResult
+
+func (pq *priorityQueue) add(sr *zoekt.SearchResult) {
+	heap.Push(pq, sr)
+}
+
+func (pq *priorityQueue) isTopAbove(limit float64) bool {
+	return len(*pq) > 0 && (*pq)[0].Progress.Priority >= limit
+}
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].Progress.Priority > pq[j].Progress.Priority
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	*pq = append(*pq, x.(*zoekt.SearchResult))
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*pq = old[0 : n-1]
+	return item
 }
 
 func copySlice(src *[]byte) {
@@ -690,25 +766,21 @@ func copyFiles(sr *zoekt.SearchResult) {
 	}
 }
 
-func searchOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) error {
+func searchOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoekt.SearchOptions) (sr *zoekt.SearchResult, err error) {
 	metricSearchShardRunning.Inc()
 	defer func() {
 		metricSearchShardRunning.Dec()
-		if r := recover(); r != nil {
-			log.Printf("crashed shard: %s: %s, %s", s.String(), r, debug.Stack())
+		if e := recover(); e != nil {
+			log.Printf("crashed shard: %s: %s, %s", s.String(), e, debug.Stack())
 
-			var r zoekt.SearchResult
-			r.Stats.Crashes = 1
-			sender.Send(&r)
+			if sr == nil {
+				sr = &zoekt.SearchResult{}
+			}
+			sr.Stats.Crashes = 1
 		}
 	}()
 
-	ms, err := s.Search(ctx, q, opts)
-	if err != nil {
-		return err
-	}
-	sender.Send(ms)
-	return nil
+	return s.Search(ctx, q, opts)
 }
 
 type shardListResult struct {
@@ -918,7 +990,7 @@ func (s *shardedSearcher) replace(shards map[string]zoekt.Searcher) {
 			//
 			// We can't just call Close now, because there may be ongoing searches
 			// which have old in the shards list. Previously we used an exclusive
-			// lock to gaurentee there were no concurrent searches. However, that
+			// lock to guarantee there were no concurrent searches. However, that
 			// led to blocking on the read path.
 			//
 			// We could introduce granular locking per rankedShard to know when

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -76,7 +76,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// mu protects aggStats and concurrent writes to the stream.
-	mu := sync.Mutex{}
 	aggStats := zoekt.Stats{}
 	send := func(zsr *zoekt.SearchResult) {
 		err := eventWriter.event(eventMatches, zsr)
@@ -87,9 +86,6 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = h.Searcher.StreamSearch(ctx, args.Q, args.Opts, SenderFunc(func(event *zoekt.SearchResult) {
-		mu.Lock()
-		defer mu.Unlock()
-
 		// We don't want to send events over the wire if they just contain stats and no
 		// file matches. Hence, in case we didn't find any results, we will just
 		// aggregate the stats.


### PR DESCRIPTION
This PR re-works `shardedSearcher.streamSearch` to avoid blocking CPUs while `Send`ing results across the network. We achieve this by centralizing the network I/O code in single loop that reads from a buffered channel.