### PR TITLE
shards: buffer search channel

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -582,8 +582,10 @@ func (ss *shardedSearcher) streamSearch(ctx context.Context, proc *process, q qu
 	}
 
 	var (
-		results = make(chan *result, workers) // buffer to free up workers while sending back results
-		search  = make(chan *rankedShard)
+		// buffered channels to continue searching when sending back results
+		// takes a while / blocks. The maximum pending result set is workers * 2.
+		results = make(chan *result, workers)
+		search  = make(chan *rankedShard, workers)
 		wg      sync.WaitGroup
 	)
 


### PR DESCRIPTION
Without this buffer, we wouldn't send any new work to the search channel
when we'd be blocked on Send, even if the worker go-routines were free
to take new work.