### PR TITLE
shards: only `observeMetrics` when `r.err == nil`

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -646,8 +646,6 @@ search:
 				break search
 			}
 
-			observeMetrics(r.SearchResult)
-
 			// delete this result's priority from pending before computing the new max pending priority
 			pending.remove(r.priority)
 
@@ -658,6 +656,8 @@ search:
 				err = r.err
 				continue
 			}
+
+			observeMetrics(r.SearchResult)
 
 			r.MaxPendingPriority = pending.max()
 			sender.Send(r.SearchResult)


### PR DESCRIPTION
Otherwise `r.SearchResult == nil` and a panic happens.