### PR TITLE
indexserver: update merge policy

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -41,62 +41,65 @@ func TestHasMultipleShards(t *testing.T) {
 func TestGenerateCompoundShards(t *testing.T) {
 	shards := []candidate{
 		{
-			path:      "r1",
+			path:      "r2",
 			sizeBytes: 2,
 		},
 		{
-			path:      "r2",
+			path:      "r3",
 			sizeBytes: 3,
 		},
 		{
-			path:      "r3",
-			sizeBytes: 9,
+			path:      "r8",
+			sizeBytes: 8,
 		},
 		{
-			path:      "r4",
-			sizeBytes: 10,
+			path:      "r9",
+			sizeBytes: 9,
 		},
 		{
 			path:      "r5",
 			sizeBytes: 5,
 		},
 		{
-			path:      "r6",
+			path:      "r1",
 			sizeBytes: 1,
 		},
 	}
 
 	// Expected compounds
-	// compound 0: r4 (total size 10)
-	// compound 1: r3 + r6 (total size  10)
-	// compound 2: r5 + r2 + r1 (total size 10)
+	// compound 0: r1 + r5 + r3 (total size 9)
+	// compound 1: r9 (total size  9)
+	// compound 3: r8 + r2 (total size  10)
 
 	compounds := generateCompounds(shards, 10)
 
-	if len(compounds) != 3 {
-		t.Fatalf("expected 3 compound shards, but got %d", len(compounds))
+	wantCompounds := 3
+	if len(compounds) != wantCompounds {
+		t.Fatalf("expected %d compound shards, but got %d", wantCompounds, len(compounds))
 	}
 
+	wantTotalShards := 6
 	totalShards := 0
 	for _, c := range compounds {
 		totalShards += len(c.shards)
 	}
-	if totalShards != 6 {
-		t.Fatalf("shards mismatch: wanted %d, got %d", 6, totalShards)
+	if totalShards != wantTotalShards {
+		t.Fatalf("shards mismatch: wanted %d, got %d", wantTotalShards, totalShards)
 	}
 
-	want := []candidate{{"r4", 10}}
+	want := []candidate{{"r1", 1}, {"r5", 5}, {"r3", 3}}
 	if diff := cmp.Diff(want, compounds[0].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
 		t.Fatalf("-want,+got\n%s", diff)
 	}
 
-	want = []candidate{{"r3", 9}, {"r6", 1}}
+	want = []candidate{{"r9", 9}}
 	if diff := cmp.Diff(want, compounds[1].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
 		t.Fatalf("-want,+got\n%s", diff)
 	}
 
-	want = []candidate{{"r5", 5}, {"r2", 3}, {"r1", 2}}
+	want = []candidate{{"r8", 8}, {"r2", 2}}
 	if diff := cmp.Diff(want, compounds[2].shards, cmp.Options{cmp.AllowUnexported(candidate{})}); diff != "" {
 		t.Fatalf("-want,+got\n%s", diff)
 	}
+
 }


### PR DESCRIPTION
This updates the merge policy like follows:
- Don't merge shards by size
- Exclude large compound shards from merging

**Don't merge shards by size**
Sorting by size led to a very uneven distribution of shards to compound
shards. A more uniform distribution should lead to a more predictable
performance during search.

**Exclude large compound shards from merging**
We introduce a threshold to exclude large compound shards from merging.
It takes around 2 minutes to create a compound shard of 2 GiB. This is
true even if we just add 1 repo to an existing compound shard. The
reason is that we don't support incremental merging, but instead create
a compound shard from scratch for each merge operation. Hence we want to
avoid merging a compound shard with other smaller candidate shards if
the compound shard already has a decent size. 

Without the threshold every compound shard with a tombstone will likely
be part of the next merge run. 

The concrete value of the threshold is not important as long as it is
smaller than the targetSize and large enough to see sufficient benefits
from merging.

I have tested the merge locally and in production.