### PR TITLE
shards: set SearchResult.Progress.Priority

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -659,7 +659,9 @@ search:
 
 			observeMetrics(r.SearchResult)
 
+			r.Priority = r.priority
 			r.MaxPendingPriority = pending.max()
+
 			sender.Send(r.SearchResult)
 		}
 	}


### PR DESCRIPTION
In a previous commit, we missed setting the actual `SearchResult.Progress.Priority` field.
This was a regression introduced while refactoring to address review feedback.