### PR TITLE
shards: send max pending priority while searching

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -634,7 +634,12 @@ search:
 
 		select {
 		case work <- next:
+			// We send the max pending priority as we search to keep frontend informed even
+			// if we don't find matches.
+			var r zoekt.SearchResult
 			pending.append(next.priority)
+			r.MaxPendingPriority = pending.max()
+			sender.Send(&r)
 
 			if shard++; shard == len(shards) {
 				stop()


### PR DESCRIPTION
On Cloud we see out of order search results on the first page. We
believe the reason might be that Zoekt doesn't report the pending
priority if it doesn't find any matches.

With this change we send the max pending priority as we search to keep
frontend informed even if we don't find matches.

Co-authored-by: Tomás Senart <tomas@sourcegraph.com>