### PR TITLE
shards: stream results per repo for compound shards

### DIFF
--- a/api.go
+++ b/api.go
@@ -47,6 +47,10 @@ type FileMatch struct {
 	// Sourcegraph.
 	RepositoryID uint32
 
+	// RepositoryPriority is a Sourcegraph extension. It is used by Sourcegraph to
+	// order results from different repositories relative to each other.
+	RepositoryPriority float64
+
 	// Only set if requested
 	Content []byte
 

--- a/eval.go
+++ b/eval.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"regexp/syntax"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/google/zoekt/query"
@@ -183,6 +184,15 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *SearchOptions) 
 	docCount := uint32(len(d.fileBranchMasks))
 	lastDoc := int(-1)
 
+	var curRepo uint16
+	var repoPriority float64
+	if len(d.repoMetaData) > 0 {
+		repoPriority, err = strconv.ParseFloat(d.repoMetaData[0].RawConfig["priority"], 64)
+		if err != nil {
+			repoPriority = 0
+		}
+	}
+
 nextFileMatch:
 	for {
 		canceled := false
@@ -220,6 +230,14 @@ nextFileMatch:
 
 		md := d.repoMetaData[d.repos[nextDoc]]
 
+		if d.repos[nextDoc] != curRepo {
+			curRepo = d.repos[nextDoc]
+			repoPriority, err = strconv.ParseFloat(md.RawConfig["priority"], 64)
+			if err != nil {
+				repoPriority = 0
+			}
+		}
+
 		for cost := costMin; cost <= costMax; cost++ {
 			v, ok := mt.matches(cp, cost, known)
 			if ok && !v {
@@ -233,11 +251,12 @@ nextFileMatch:
 		}
 
 		fileMatch := FileMatch{
-			Repository:   md.Name,
-			RepositoryID: md.ID,
-			FileName:     string(d.fileName(nextDoc)),
-			Checksum:     d.getChecksum(nextDoc),
-			Language:     d.languageMap[d.languages[nextDoc]],
+			Repository:         md.Name,
+			RepositoryID:       md.ID,
+			RepositoryPriority: repoPriority,
+			FileName:           string(d.fileName(nextDoc)),
+			Checksum:           d.getChecksum(nextDoc),
+			Language:           d.languageMap[d.languages[nextDoc]],
 		}
 
 		if s := d.subRepos[nextDoc]; s > 0 {

--- a/eval.go
+++ b/eval.go
@@ -332,7 +332,6 @@ nextFileMatch:
 		res.Stats.MatchCount += len(fileMatch.LineMatches)
 		res.Stats.FileCount++
 	}
-	SortFilesByScore(res.Files)
 
 	for _, md := range d.repoMetaData {
 		r := md

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -678,13 +678,15 @@ search:
 // sender.Send for each repository.
 func sendByRepository(result *zoekt.SearchResult, sender zoekt.Sender) {
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
+		zoekt.SortFilesByScore(result.Files)
 		sender.Send(result)
 		return
 	}
 
-	// stats must be aggregateable, hence we sent them separately.
 	send := func(repoName string, a, b int) {
+		zoekt.SortFilesByScore(result.Files[a:b])
 		sender.Send(&zoekt.SearchResult{
+			// No stats. Stats must be aggregateable, hence we sent them separately.
 			Progress: zoekt.Progress{
 				Priority:           result.Files[a].RepositoryPriority,
 				MaxPendingPriority: result.MaxPendingPriority,

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -677,6 +677,9 @@ search:
 // sendByRepository splits a zoekt.SearchResult by repository and calls
 // sender.Send for each batch. Ranking in Sourcegraph expects zoekt.SearchResult
 // to contain results with the same zoekt.SearchResult.Priority only.
+//
+// We split by repository instead of by priority because it is easier to set
+// RepoURLs and LineFragments in zoekt.SearchResult.
 func sendByRepository(result *zoekt.SearchResult, sender zoekt.Sender) {
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
 		zoekt.SortFilesByScore(result.Files)

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -670,16 +670,13 @@ search:
 			// For simple shards, send the results immediately.
 			if len(r.SearchResult.RepoURLs) <= 1 {
 				sender.Send(r.SearchResult)
-				break
+				continue
 			}
 
 			// For compound shards, stream results per repo.
 			stats, srs := splitByRepository(r.SearchResult)
 			tr.LazyPrintf("compound shard: results from %d repositories", len(srs))
 			for _, sr := range srs {
-				if len(sr.Files) == 0 {
-					panic("unreachable")
-				}
 				sr.Priority = sr.Files[0].RepositoryPriority
 
 				// TODO (stefan): make sure repos in compound shards are searched in order of their priority.

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -674,8 +674,9 @@ search:
 	return func() { runtime.KeepAlive(shards) }, err
 }
 
-// sendByRepository splits a zoekt.SearchResult by repository ID and calls
-// sender.Send for each repository.
+// sendByRepository splits a zoekt.SearchResult by repository and calls
+// sender.Send for each batch. Ranking in Sourcegraph expects zoekt.SearchResult
+// to contain results with the same zoekt.SearchResult.Priority only.
 func sendByRepository(result *zoekt.SearchResult, sender zoekt.Sender) {
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
 		zoekt.SortFilesByScore(result.Files)

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
+	"github.com/google/zoekt/stream"
 )
 
 type crashSearcher struct{}
@@ -806,4 +807,146 @@ func mkSearchResult(n int, repoID uint32) *zoekt.SearchResult {
 	}
 
 	return &zoekt.SearchResult{Files: fm, RepoURLs: map[string]string{fmt.Sprintf("repo%d", repoID): ""}}
+}
+
+func TestFileBasedSearch(t *testing.T) {
+	cases := []struct {
+		name              string
+		testShardedSearch func(t *testing.T, q query.Q, ib *zoekt.IndexBuilder) []zoekt.FileMatch
+	}{
+		{"Search", testShardedSearch},
+		{"StreamSearch", testShardedStreamSearch},
+	}
+
+	c1 := []byte("I love bananas without skin")
+	// -----------0123456789012345678901234567890123456789
+	c2 := []byte("In Dutch, ananas means pineapple")
+	// -----------0123456789012345678901234567890123456789
+	b := testIndexBuilder(t, nil,
+		zoekt.Document{Name: "f1", Content: c1},
+		zoekt.Document{Name: "f2", Content: c2},
+	)
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := tt.testShardedSearch(t, &query.Substring{
+				CaseSensitive: false,
+				Pattern:       "ananas",
+			}, b)
+
+			if len(matches) != 2 {
+				t.Fatalf("got %v, want 2 matches", matches)
+			}
+			if matches[0].FileName != "f2" || matches[1].FileName != "f1" {
+				t.Fatalf("got %v, want matches {f1,f2}", matches)
+			}
+			if matches[0].LineMatches[0].LineFragments[0].Offset != 10 || matches[1].LineMatches[0].LineFragments[0].Offset != 8 {
+				t.Fatalf("got %#v, want offsets 10,8", matches)
+			}
+		})
+	}
+}
+
+func TestWordBoundaryRanking(t *testing.T) {
+	cases := []struct {
+		name              string
+		testShardedSearch func(t *testing.T, q query.Q, ib *zoekt.IndexBuilder) []zoekt.FileMatch
+	}{
+		{"Search", testShardedSearch},
+		{"StreamSearch", testShardedStreamSearch},
+	}
+
+	b := testIndexBuilder(t, nil,
+		zoekt.Document{Name: "f1", Content: []byte("xbytex xbytex")},
+		zoekt.Document{Name: "f2", Content: []byte("xbytex\nbytex\nbyte bla")},
+		// -----------------------------------0123456 789012 34567890
+		zoekt.Document{Name: "f3", Content: []byte("xbytex ybytex")})
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			files := tt.testShardedSearch(t, &query.Substring{Pattern: "byte"}, b)
+
+			if len(files) != 3 {
+				t.Fatalf("got %#v, want 3 files", files)
+			}
+
+			file0 := files[0]
+			if file0.FileName != "f2" || len(file0.LineMatches) != 3 {
+				t.Fatalf("got file %s, num matches %d (%#v), want 3 matches in file f2", file0.FileName, len(file0.LineMatches), file0)
+			}
+
+			if file0.LineMatches[0].LineFragments[0].Offset != 13 {
+				t.Fatalf("got first match %#v, want full word match", files[0].LineMatches[0])
+			}
+			if file0.LineMatches[1].LineFragments[0].Offset != 7 {
+				t.Fatalf("got second match %#v, want partial word match", files[0].LineMatches[1])
+			}
+		})
+	}
+}
+
+func TestAtomCountScore(t *testing.T) {
+	cases := []struct {
+		name              string
+		testShardedSearch func(t *testing.T, q query.Q, ib *zoekt.IndexBuilder) []zoekt.FileMatch
+	}{
+		{"Search", testShardedSearch},
+		{"StreamSearch", testShardedStreamSearch},
+	}
+
+	b := testIndexBuilder(t,
+		&zoekt.Repository{
+			Branches: []zoekt.RepositoryBranch{
+				{"branches", "v1"},
+				{"needle", "v2"},
+			},
+		},
+		zoekt.Document{Name: "f1", Content: []byte("needle the bla"), Branches: []string{"branches"}},
+		zoekt.Document{Name: "needle-file-branch", Content: []byte("needle content"), Branches: []string{"needle"}},
+		zoekt.Document{Name: "needle-file", Content: []byte("needle content"), Branches: []string{"branches"}})
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			files := tt.testShardedSearch(t,
+				query.NewOr(
+					&query.Substring{Pattern: "needle"},
+					&query.Substring{Pattern: "needle", FileName: true},
+					&query.Branch{Pattern: "needle"},
+				), b)
+			var got []string
+			for _, f := range files {
+				got = append(got, f.FileName)
+			}
+			want := []string{"needle-file-branch", "needle-file", "f1"}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func testShardedStreamSearch(t *testing.T, q query.Q, ib *zoekt.IndexBuilder) []zoekt.FileMatch {
+	ss := newShardedSearcher(1)
+	searcher := searcherForTest(t, ib)
+	ss.replace(map[string]zoekt.Searcher{"r1": searcher})
+
+	var files []zoekt.FileMatch
+	sender := stream.SenderFunc(func(result *zoekt.SearchResult) {
+		files = append(files, result.Files...)
+	})
+
+	if err := ss.StreamSearch(context.Background(), q, &zoekt.SearchOptions{}, sender); err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+func testShardedSearch(t *testing.T, q query.Q, ib *zoekt.IndexBuilder) []zoekt.FileMatch {
+	ss := newShardedSearcher(1)
+	searcher := searcherForTest(t, ib)
+	ss.replace(map[string]zoekt.Searcher{"r1": searcher})
+
+	sres, _ := ss.Search(context.Background(), q, &zoekt.SearchOptions{})
+	return sres.Files
 }


### PR DESCRIPTION
With this change we stream results per repo for compound shards. The behavior of simple shards remains unchanged.

A nice property of this change is that from the perspective of Sourcegraph, results from Zoekt always look the same, irrespective of whether they come from compound shards or simple shards. Before, zoekt.SearchResults from compound shards could contain results from many repos.

This should fix an issue with ranking in Sourcegraph, where results coming from the same compound shard could be presented out of order.

Note: We move sorting from indexData one level up to shardedSearcher.

Commits can be reviewed separately.