### PR TITLE
indexserver: merge in order of priority

### DIFF
--- a/api.go
+++ b/api.go
@@ -317,6 +317,12 @@ func (r *Repository) UnmarshalJSON(data []byte) error {
 		r.ID = uint32(id)
 	}
 
+	if v, ok := repo.RawConfig["priority"]; ok {
+		r.priority, err = strconv.ParseFloat(v, 64)
+		if err != nil {
+			r.priority = 0
+		}
+	}
 	return nil
 }
 

--- a/api.go
+++ b/api.go
@@ -272,6 +272,10 @@ type Repository struct {
 	// separator, generally '#' or ';'.
 	LineFragmentTemplate string
 
+	// Perf optimization: priority is set when we load the shard. It corresponds to
+	// the value of "priority" stored in RawConfig.
+	priority float64
+
 	// All zoekt.* configuration settings.
 	RawConfig map[string]string
 

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -115,6 +115,7 @@ func TestFlags(t *testing.T) {
 	ignored := []cmp.Option{
 		// depends on $PATH setting.
 		cmpopts.IgnoreFields(Options{}, "CTags"),
+		cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 	}
 
 	for _, c := range cases {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -130,6 +130,9 @@ type Server struct {
 	// Shards larger than MaxSizeBytes are excluded from merging.
 	MaxSizeBytes int64
 
+	// Compound shards smaller than minSizeBytes will be deleted by vacuum.
+	minSizeBytes int64
+
 	// CPUCount is the amount of parallelism to use when indexing a
 	// repository.
 	CPUCount int
@@ -697,6 +700,7 @@ func main() {
 	mergeInterval := flag.Duration("merge_interval", time.Hour, "run merge this often")
 	targetSize := flag.Int64("merge_target_size", getEnvWithDefaultInt64("SRC_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
 	maxSize := flag.Int64("merge_max_size", getEnvWithDefaultInt64("SRC_MAX_SIZE", 1800), "the maximum size in MiB a shard can have to be considered for merging")
+	minSize := flag.Int64("merge_min_size", getEnvWithDefaultInt64("SRC_MIN_SIZE", 1800), "the minimum size of a compound shard in MiB")
 	index := flag.String("index", defaultIndexDir, "set index directory to use")
 	listen := flag.String("listen", ":6072", "listen on this address.")
 	hostname := flag.String("hostname", hostnameBestEffort(), "the name we advertise to Sourcegraph when asking for the list of repositories to index. Can also be set via the NODE_NAME environment variable.")
@@ -794,6 +798,7 @@ func main() {
 		CPUCount:        cpuCount,
 		TargetSizeBytes: *targetSize * 1024 * 1024,
 		MaxSizeBytes:    *maxSize * 1024 * 1024,
+		minSizeBytes:    *minSize * 1024 * 1024,
 	}
 
 	if *debugList {

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -191,7 +191,7 @@ func (c *compound) add(cand candidate) {
 }
 
 // generateCompounds groups simple shards into compound shards without performing
-// the acutal merge. Shards that are not contained in any of the compound shards
+// the actual merge. Shards that are not contained in any of the compound shards
 // are returned in the second argument.
 func generateCompounds(shards []candidate, targetSizeBytes int64) ([]compound, []candidate) {
 	compounds := make([]compound, 0)

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -190,6 +190,9 @@ func (c *compound) add(cand candidate) {
 	c.size += cand.sizeBytes
 }
 
+// generateCompounds groups simple shards into compound shards without performing
+// the acutal merge. Shards that are not contained in any of the compound shards
+// are returned in the second argument.
 func generateCompounds(shards []candidate, targetSizeBytes int64) ([]compound, []candidate) {
 	compounds := make([]compound, 0)
 	cur := compound{}

--- a/index_test.go
+++ b/index_test.go
@@ -1156,6 +1156,7 @@ func TestListRepos(t *testing.T) {
 					cmpopts.IgnoreFields(RepoListEntry{}, "IndexMetadata"),
 					cmpopts.IgnoreFields(RepoStats{}, "IndexBytes"),
 					cmpopts.IgnoreFields(Repository{}, "SubRepoMap"),
+					cmpopts.IgnoreFields(Repository{}, "priority"),
 				}
 				if diff := cmp.Diff(want, res, ignored...); diff != "" {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)

--- a/merge.go
+++ b/merge.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 )
 
 // Merge files into a compound shard fn in the directory dstDir.
@@ -87,6 +88,10 @@ func merge(ds ...*indexData) (*IndexBuilder, error) {
 	if len(ds) == 0 {
 		return nil, fmt.Errorf("need 1 or more indexData to merge")
 	}
+
+	sort.Slice(ds, func(i, j int) bool {
+		return ds[i].repoMetaData[0].priority > ds[j].repoMetaData[0].priority
+	})
 
 	ib := newIndexBuilder()
 	ib.indexFormatVersion = NextIndexFormatVersion

--- a/read.go
+++ b/read.go
@@ -238,7 +238,6 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	d.metaData = *md
 	d.repoMetaData = make([]Repository, 0, len(repos))
 	for _, r := range repos {
-
 		d.repoMetaData = append(d.repoMetaData, *r)
 	}
 

--- a/read.go
+++ b/read.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 
 	"github.com/rs/xid"
 )
@@ -238,6 +239,11 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	d.metaData = *md
 	d.repoMetaData = make([]Repository, 0, len(repos))
 	for _, r := range repos {
+		// Performance optimization: parse repo priority on load.
+		r.priority, err = strconv.ParseFloat(r.RawConfig["priority"], 64)
+		if err != nil {
+			r.priority = 0
+		}
 		d.repoMetaData = append(d.repoMetaData, *r)
 	}
 

--- a/read.go
+++ b/read.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"os"
 	"sort"
-	"strconv"
 
 	"github.com/rs/xid"
 )
@@ -239,11 +238,7 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	d.metaData = *md
 	d.repoMetaData = make([]Repository, 0, len(repos))
 	for _, r := range repos {
-		// Performance optimization: parse repo priority on load.
-		r.priority, err = strconv.ParseFloat(r.RawConfig["priority"], 64)
-		if err != nil {
-			r.priority = 0
-		}
+
 		d.repoMetaData = append(d.repoMetaData, *r)
 	}
 

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -447,6 +447,7 @@ func TestShardedSearcher_List(t *testing.T) {
 				cmpopts.IgnoreFields(zoekt.RepoListEntry{}, "IndexMetadata"),
 				cmpopts.IgnoreFields(zoekt.RepoStats{}, "IndexBytes"),
 				cmpopts.IgnoreFields(zoekt.Repository{}, "SubRepoMap"),
+				cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 			}
 			if diff := cmp.Diff(tc.want, res, ignored...); diff != "" {
 				t.Fatalf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
With this change, repos in compound shards are ordered from highest priority to lowest.

I had to change more than I anticipated. The previous merge policy allowed a compound shard to be merged with simple shards once there was enough space in the compound shard (due to tombstones). However this makes sorting repositories during merging tricky. Instead we simply delete compound shards once they are too small and reindex.

I recommend to review by commit.