### PR TITLE
indexserver: move CloneURL into IndexOptions

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -41,6 +41,9 @@ type IndexOptions struct {
 	// Name is the Repository Name.
 	Name string
 
+	// CloneURL is the internal clone URL for Name.
+	CloneURL string
+
 	// Priority indicates ranking in results, higher first.
 	Priority float64
 
@@ -57,9 +60,6 @@ type IndexOptions struct {
 // indexArgs represents the arguments we pass to zoekt-git-index
 type indexArgs struct {
 	IndexOptions
-
-	// CloneURL is the remote git URL of the repository for cloning.
-	CloneURL string
 
 	// Incremental indicates to skip indexing if already indexed.
 	Incremental bool

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -96,9 +96,9 @@ func TestIndex(t *testing.T) {
 	}{{
 		name: "minimal",
 		args: indexArgs{
-			CloneURL: "http://api.test/.internal/git/test/repo",
 			IndexOptions: IndexOptions{
 				Name:     "test/repo",
+				CloneURL: "http://api.test/.internal/git/test/repo",
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 			},
 		},
@@ -117,9 +117,9 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "minimal-id",
 		args: indexArgs{
-			CloneURL: "http://api.test/.internal/git/test/repo",
 			IndexOptions: IndexOptions{
 				Name:     "test/repo",
+				CloneURL: "http://api.test/.internal/git/test/repo",
 				Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: "deadbeef"}},
 				RepoID:   123,
 			},
@@ -139,7 +139,6 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "all",
 		args: indexArgs{
-			CloneURL:          "http://api.test/.internal/git/test/repo",
 			Incremental:       true,
 			IndexDir:          "/data/index",
 			Parallelism:       4,
@@ -147,6 +146,7 @@ func TestIndex(t *testing.T) {
 			DownloadLimitMBPS: "1000",
 			IndexOptions: IndexOptions{
 				Name:       "test/repo",
+				CloneURL:   "http://api.test/.internal/git/test/repo",
 				LargeFiles: []string{"foo", "bar"},
 				Symbols:    true,
 				Branches: []zoekt.RepositoryBranch{

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -476,7 +476,6 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
 	return &indexArgs{
-		CloneURL:     s.Sourcegraph.GetCloneURL(opts.Name),
 		IndexOptions: opts,
 
 		IndexDir:    s.IndexDir,

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -32,7 +32,6 @@ func TestServer_defaultArgs(t *testing.T) {
 		IndexOptions: IndexOptions{
 			Name: "testName",
 		},
-		CloneURL:          "http://api.test/.internal/git/testName",
 		IndexDir:          "/testdata/index",
 		Parallelism:       6,
 		Incremental:       true,


### PR DESCRIPTION
This allows us to remove GetCloneURL from the Sourcegraph interface. In
future we could even set the CloneURL in the IndexOptions returned by
Sourcegraph.

This is motivated by some broader changes in the Sourcegraph interface
for config fingerprinting.