### PR TITLE
indexserver: Sourcegraph interface is just List

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -74,13 +74,13 @@ func TestListRepoIDs(t *testing.T) {
 		Client:   retryablehttp.NewClient(),
 	}
 
-	gotRepos, err := s.ListRepoIDs(context.Background(), []uint32{1, 3})
+	gotRepos, err := s.List(context.Background(), []uint32{1, 3})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if want := []uint32{1, 2, 3}; !cmp.Equal(gotRepos, want) {
-		t.Errorf("repos mismatch (-want +got):\n%s", cmp.Diff(want, gotRepos))
+	if want := []uint32{1, 2, 3}; !cmp.Equal(gotRepos.IDs, want) {
+		t.Errorf("repos mismatch (-want +got):\n%s", cmp.Diff(want, gotRepos.IDs))
 	}
 	if want := `{"Hostname":"test-indexed-search-1","IndexedIDs":[1,3]}`; gotBody != want {
 		t.Errorf("body mismatch (-want +got):\n%s", cmp.Diff(want, gotBody))


### PR DESCRIPTION
This moves a lot of the business logic out of the main loop, and instead
provides an iterate interface for the main loop to use. We intend on
changing how we batch and call out to Sourcegraph. So this change
encapsulates what we actually care about from the Sourcegraph
interface. I also think it makes the code read much more cleanly.

Depends on https://github.com/sourcegraph/zoekt/pull/200