### PR TITLE
indexserver: ensure indexed for unchanged repositories

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -289,10 +289,11 @@ func (s *Server) Run() {
 
 			repos.IterateIndexOptions(s.queue.AddOrUpdate)
 
-			// TODO(keegan) with config fingerprint we don't call AddOrUpdate on
-			// everything, just those repos which have changed. We need to bump
-			// everything in repos.IDs back into the queue incase something happened
-			// to the repo on disk.
+			// IterateIndexOptions will only iterate over repositories that have
+			// changed since we last called list. However, we want to add all IDs
+			// back onto the queue just to check that what is on disk is still
+			// correct. This will use the last IndexOptions we stored in the queue.
+			s.queue.Bump(repos.IDs)
 
 			<-cleanupDone
 		}


### PR DESCRIPTION
This fixes the potential issue introduced by fingerprinting. The issue
was that previously we would check the search configuration for all
repositories a replica is supposed to index. However, with config
fingerprinting we only checked those repositories that had changed in
Sourcegraph. Previously even if a repo hadn't changed the indexserver
would ensure that the shard would exist on disk. For example if a
previous index job failed, or the shard went missing due to an admin or
corruption.

Depends on https://github.com/sourcegraph/zoekt/pull/202