### PR TITLE
indexserver: create empty repos with proper ID

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -130,7 +130,7 @@ func TestCleanup(t *testing.T) {
 				fs = append(fs, f)
 			}
 			for _, f := range fs {
-				createEmptyShard(t, f.RepoName, f.Path)
+				testCreateEmptyShard(t, f.RepoName, f.Path)
 				if err := os.Chtimes(f.Path, f.ModTime, f.ModTime); err != nil {
 					t.Fatal(err)
 				}
@@ -171,7 +171,7 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
-func createEmptyShard(t *testing.T, repo, path string) {
+func testCreateEmptyShard(t *testing.T, repo, path string) {
 	t.Helper()
 
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -130,7 +130,7 @@ func TestCleanup(t *testing.T) {
 				fs = append(fs, f)
 			}
 			for _, f := range fs {
-				testCreateEmptyShard(t, f.RepoName, f.Path)
+				createTestShard(t, f.RepoName, f.Path)
 				if err := os.Chtimes(f.Path, f.ModTime, f.ModTime); err != nil {
 					t.Fatal(err)
 				}
@@ -171,7 +171,7 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
-func testCreateEmptyShard(t *testing.T, repo, path string) {
+func createTestShard(t *testing.T, repo, path string) {
 	t.Helper()
 
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {


### PR DESCRIPTION
So far we called zoekt-archive-index to create empty repos. However,
zoekt-archive-index doesn't set the ID which causes us to constantly 
drop and recreate empty repositories.

With this change we don't call zoekt-archive-index anymore, but instead
created an empty shard directly from indexserver.