### PR TITLE
indexserver: refactor removeAll

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -313,17 +313,14 @@ func (s *Server) vacuum() {
 		}
 
 		if info.Size() < s.minSizeBytes {
-			paths, err := zoekt.IndexFilePaths(path)
-			if err != nil {
-				debug.Printf("failed getting all file paths for %s", path)
-				continue
-			}
 			s.muIndexDir.Lock()
-			for _, p := range paths {
-				os.Remove(p)
-			}
+			err = removeShardAtPath(path)
 			s.muIndexDir.Unlock()
-			shardsLog(s.IndexDir, "delete", []shard{{Path: path}})
+			if err != nil {
+				debug.Println(err)
+			} else {
+				shardsLog(s.IndexDir, "delete", []shard{{Path: path}})
+			}
 			continue
 		}
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -238,14 +238,8 @@ func callMerge(shards []candidate) ([]byte, []byte, error) {
 	// delete the candidate shards to avoid duplicate results in case a compound
 	// shard was created after all.
 	for _, s := range shards {
-		paths, err := zoekt.IndexFilePaths(s.path)
-		if err != nil {
-			debug.Printf("failed to remove s %s: %v", s.path, err)
-		}
-		for _, p := range paths {
-			if err := os.Remove(p); err != nil {
-				debug.Printf("failed to remove shard file %s: %v", p, err)
-			}
+		if err := removeShardAtPath(s.path); err != nil {
+			debug.Println(err)
 		}
 	}
 	return outBuf.Bytes(), errBuf.Bytes(), err

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-github/v27 v27.0.6
 	github.com/google/slothfs v0.0.0-20190417171004-6b42407d9230
 	github.com/hashicorp/go-hclog v0.12.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/keegancsmith/rpc v1.1.0
 	github.com/keegancsmith/tmpfriend v0.0.0-20180423180255-86e88902a513

--- a/go.sum
+++ b/go.sum
@@ -272,11 +272,15 @@ github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.1 h1:99niEVkDqsEv3/jINwoOUgGE9L41LHXM4k3jTkV+DdA=
 github.com/hashicorp/go-hclog v0.12.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
This is a refactor to make it easier to delete a shard and its meta file.
The new function `removeShardAtPath` returns an error (instead of 
calling debug.Printf internally) which is useful when deciding whether 
we should log a success message or not.