### PR TITLE
indexserver: default config batch size of 10000

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -53,7 +53,7 @@ type sourcegraphClient struct {
 	Hostname string
 
 	// BatchSize is how many repository configurations we request at once. If
-	// zero a value of 1000 is used.
+	// zero a value of 10000 is used.
 	BatchSize int
 
 	Client *retryablehttp.Client
@@ -72,7 +72,7 @@ func (s *sourcegraphClient) List(ctx context.Context, indexed []uint32) (*Source
 
 	batchSize := s.BatchSize
 	if batchSize == 0 {
-		batchSize = 1000
+		batchSize = 10_000
 	}
 
 	// We want to use a consistent fingerprint for each call. Next time list is


### PR DESCRIPTION
This is what we use on Sourcegraph.com, so is a better default. Should
work well on large installations, and shouldn't affect smaller
installations.