### PR TITLE
indexserver: only try decode the returned repos

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -81,11 +81,28 @@ func TestGetIndexOptions(t *testing.T) {
 			continue
 		}
 
+		want.CloneURL = sg.getCloneURL(got[0].IndexOptions.Name)
+
 		if d := cmp.Diff(*want, got[0].IndexOptions); d != "" {
 			t.Log("response", r)
 			t.Errorf("mismatch (-want +got):\n%s", d)
 		}
 	}
+
+	// Special case our fingerprint API which doesn't return anything if the
+	// repo hasn't changed.
+	t.Run("unchanged", func(t *testing.T) {
+		response = []byte(``)
+
+		got, err := sg.GetIndexOptions(123)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(got) != 0 {
+			t.Fatalf("expected no options, got %v", got)
+		}
+	})
 }
 
 func TestIndex(t *testing.T) {

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -183,15 +183,19 @@ func (s *sourcegraphClient) getIndexOptions(fingerprint string, repos ...uint32)
 		}
 	}
 
-	opts := make([]indexOptionsItem, len(repos))
 	dec := json.NewDecoder(resp.Body)
-	for i := range opts {
-		if err := dec.Decode(&opts[i]); err != nil {
+	var opts []indexOptionsItem
+	for {
+		var opt indexOptionsItem
+		err := dec.Decode(&opt)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
 			return nil, "", fmt.Errorf("error decoding body: %w", err)
 		}
-		if opts[i].Name != "" {
-			opts[i].CloneURL = s.getCloneURL(opts[i].Name)
-		}
+		opt.CloneURL = s.getCloneURL(opt.Name)
+		opts = append(opts, opt)
 	}
 
 	return opts, resp.Header.Get("X-Sourcegraph-Config-Fingerprint"), nil


### PR DESCRIPTION
We try to decode all repos we passed in. However, with fingerprints we
only get back a subset. So we need to handle EOF.