### PR TITLE
Replace Repo with RepoRegex implementation

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -275,7 +276,7 @@ func TestUpdate(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	repos, err := ss.List(ctx, &query.Repo{Pattern: "repo"}, nil)
+	repos, err := ss.List(ctx, &query.Repo{Regexp: regexp.MustCompile("repo")}, nil)
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -309,7 +310,7 @@ func TestUpdate(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	ctx = context.Background()
-	if repos, err = ss.List(ctx, &query.Repo{Pattern: "repo"}, nil); err != nil {
+	if repos, err = ss.List(ctx, &query.Repo{Regexp: regexp.MustCompile("repo")}, nil); err != nil {
 		t.Fatalf("List: %v", err)
 	} else if len(repos.Repos) != 2 {
 		t.Errorf("List(repo): got %v, want 2 repos", repos.Repos)
@@ -325,7 +326,7 @@ func TestUpdate(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	ctx = context.Background()
-	if repos, err = ss.List(ctx, &query.Repo{Pattern: "repo"}, nil); err != nil {
+	if repos, err = ss.List(ctx, &query.Repo{Regexp: regexp.MustCompile("repo")}, nil); err != nil {
 		t.Fatalf("List: %v", err)
 	} else if len(repos.Repos) != 1 {
 		var ss []string

--- a/eval.go
+++ b/eval.go
@@ -67,7 +67,16 @@ func (d *indexData) simplify(in query.Q) query.Q {
 		switch r := q.(type) {
 		case *query.Repo:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
-				return strings.Contains(repo.Name, r.Pattern)
+				switch expr := r.Expr.(type) {
+
+				case *query.Substring:
+					return strings.Contains(repo.Name, expr.Pattern)
+
+				case *query.Regexp:
+					return regexp.MustCompile(expr.Regexp.String()).MatchString(repo.Name)
+				}
+
+				return false
 			})
 		case *query.RepoRegexp:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {

--- a/eval.go
+++ b/eval.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strings"

--- a/eval.go
+++ b/eval.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strings"
@@ -67,16 +66,7 @@ func (d *indexData) simplify(in query.Q) query.Q {
 		switch r := q.(type) {
 		case *query.Repo:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
-				switch expr := r.Expr.(type) {
-
-				case *query.Substring:
-					return strings.Contains(repo.Name, expr.Pattern)
-
-				case *query.Regexp:
-					return regexp.MustCompile(expr.Regexp.String()).MatchString(repo.Name)
-				}
-
-				return false
+				return r.Regexp.MatchString(repo.Name)
 			})
 		case *query.RepoRegexp:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {

--- a/eval_test.go
+++ b/eval_test.go
@@ -172,9 +172,9 @@ func TestSimplifyRepoSet(t *testing.T) {
 
 func TestSimplifyRepo(t *testing.T) {
 	d := compoundReposShard(t, "foo", "fool")
-	all := &query.Repo{"foo"}
-	some := &query.Repo{"fool"}
-	none := &query.Repo{"bar"}
+	all := &query.Repo{Expr: &query.Substring{Pattern: "foo"}}
+	some := &query.Repo{Expr: &query.Substring{Pattern: "fool"}}
+	none := &query.Repo{Expr: &query.Substring{Pattern: "bar"}}
 
 	got := d.simplify(all)
 	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
@@ -234,7 +234,7 @@ func TestSimplifyRepoBranch(t *testing.T) {
 	d := compoundReposShard(t, "foo", "bar")
 
 	some := &query.RepoBranches{Set: map[string][]string{"bar": {"branch1"}}}
-	none := &query.Repo{"banana"}
+	none := &query.Repo{Expr: &query.Substring{Pattern: "banana"}}
 
 	got := d.simplify(some)
 	if d := cmp.Diff(some, got); d != "" {
@@ -255,7 +255,7 @@ func TestSimplifyBranchesRepos(t *testing.T) {
 			{Branch: "branch1", Repos: roaring.BitmapOf(hash("bar"))},
 		},
 	}
-	none := &query.Repo{"banana"}
+	none := &query.Repo{Expr: &query.Substring{Pattern: "banana"}}
 
 	got := d.simplify(some)
 	tr := cmp.Transformer("", func(b *roaring.Bitmap) []uint32 { return b.ToArray() })

--- a/eval_test.go
+++ b/eval_test.go
@@ -171,24 +171,40 @@ func TestSimplifyRepoSet(t *testing.T) {
 }
 
 func TestSimplifyRepo(t *testing.T) {
+	re := func(pat string) *query.Repo {
+		t.Helper()
+		re, err := regexp.Compile(pat)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &query.Repo{
+			Regexp: re,
+		}
+	}
 	d := compoundReposShard(t, "foo", "fool")
-	all := &query.Repo{Regexp: regexp.MustCompile("foo")}
-	some := &query.Repo{Regexp: regexp.MustCompile("fool")}
-	none := &query.Repo{Regexp: regexp.MustCompile("bar")}
+	cases := []struct {
+		name string
+		q    query.Q
+		want query.Q
+	}{{
+		name: "all",
+		q:    re("f.*"),
+		want: &query.Const{Value: true},
+	}, {
+		name: "some",
+		q:    re("foo."),
+		want: re("foo."),
+	}, {
+		name: "none",
+		q:    re("banana"),
+		want: &query.Const{Value: false},
+	}}
 
-	got := d.simplify(all)
-	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
-	}
-
-	got = d.simplify(some)
-	if d := cmp.Diff(some, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
-	}
-
-	got = d.simplify(none)
-	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
+	for _, tc := range cases {
+		got := d.simplify(tc.q)
+		if d := cmp.Diff(tc.want.String(), got.String()); d != "" {
+			t.Errorf("%s: -want, +got:\n%s", tc.name, d)
+		}
 	}
 }
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -172,9 +172,9 @@ func TestSimplifyRepoSet(t *testing.T) {
 
 func TestSimplifyRepo(t *testing.T) {
 	d := compoundReposShard(t, "foo", "fool")
-	all := &query.Repo{Expr: &query.Substring{Pattern: "foo"}}
-	some := &query.Repo{Expr: &query.Substring{Pattern: "fool"}}
-	none := &query.Repo{Expr: &query.Substring{Pattern: "bar"}}
+	all := &query.Repo{Regexp: regexp.MustCompile("foo")}
+	some := &query.Repo{Regexp: regexp.MustCompile("fool")}
+	none := &query.Repo{Regexp: regexp.MustCompile("bar")}
 
 	got := d.simplify(all)
 	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
@@ -234,7 +234,7 @@ func TestSimplifyRepoBranch(t *testing.T) {
 	d := compoundReposShard(t, "foo", "bar")
 
 	some := &query.RepoBranches{Set: map[string][]string{"bar": {"branch1"}}}
-	none := &query.Repo{Expr: &query.Substring{Pattern: "banana"}}
+	none := &query.Repo{Regexp: regexp.MustCompile("banana")}
 
 	got := d.simplify(some)
 	if d := cmp.Diff(some, got); d != "" {
@@ -255,7 +255,7 @@ func TestSimplifyBranchesRepos(t *testing.T) {
 			{Branch: "branch1", Repos: roaring.BitmapOf(hash("bar"))},
 		},
 	}
-	none := &query.Repo{Expr: &query.Substring{Pattern: "banana"}}
+	none := &query.Repo{Regexp: regexp.MustCompile("banana")}
 
 	got := d.simplify(some)
 	tr := cmp.Transformer("", func(b *roaring.Bitmap) []uint32 { return b.ToArray() })

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -373,7 +374,7 @@ func TestBranchWildcard(t *testing.T) {
 	}
 	defer searcher.Close()
 
-	if rlist, err := searcher.List(context.Background(), &query.Repo{Pattern: ""}, nil); err != nil {
+	if rlist, err := searcher.List(context.Background(), &query.Repo{Regexp: regexp.MustCompile("repo")}, nil); err != nil {
 		t.Fatalf("List(): %v", err)
 	} else if len(rlist.Repos) != 1 {
 		t.Errorf("got %v, want 1 result", rlist.Repos)
@@ -468,7 +469,7 @@ func TestFullAndShortRefNames(t *testing.T) {
 	}
 	defer searcher.Close()
 
-	if rlist, err := searcher.List(context.Background(), &query.Repo{Pattern: ""}, nil); err != nil {
+	if rlist, err := searcher.List(context.Background(), &query.Repo{Regexp: regexp.MustCompile("repo")}, nil); err != nil {
 		t.Fatalf("List(): %v", err)
 	} else if len(rlist.Repos) != 1 {
 		t.Errorf("got %v, want 1 result", rlist.Repos)
@@ -518,7 +519,7 @@ func TestLatestCommit(t *testing.T) {
 	}
 	defer searcher.Close()
 
-	rlist, err := searcher.List(context.Background(), &query.Repo{Pattern: ""}, nil)
+	rlist, err := searcher.List(context.Background(), &query.Repo{Regexp: regexp.MustCompile("repo")}, nil)
 	if err != nil {
 		t.Fatalf("List(): %v", err)
 	}

--- a/index_test.go
+++ b/index_test.go
@@ -152,7 +152,7 @@ func TestEmptyIndex(t *testing.T) {
 		t.Fatalf("Search: %v", err)
 	}
 
-	if _, err := searcher.List(context.Background(), &query.Repo{}, nil); err != nil {
+	if _, err := searcher.List(context.Background(), &query.Repo{Regexp: regexp.MustCompile("")}, nil); err != nil {
 		t.Fatalf("List: %v", err)
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -816,7 +816,7 @@ func TestRepoName(t *testing.T) {
 	sres := searchForTest(t, b,
 		query.NewAnd(
 			&query.Substring{Pattern: "needle"},
-			&query.Repo{Pattern: "foo"},
+			&query.Repo{Expr: &query.Substring{Pattern: "foo"}},
 		))
 
 	if len(sres.Files) != 0 {
@@ -830,7 +830,7 @@ func TestRepoName(t *testing.T) {
 	sres = searchForTest(t, b,
 		query.NewAnd(
 			&query.Substring{Pattern: "needle"},
-			&query.Repo{Pattern: "bla"},
+			&query.Repo{Expr: &query.Substring{Pattern: "bla"}},
 		))
 	if len(sres.Files) != 1 {
 		t.Fatalf("got %v, want 1 match", sres.Files)
@@ -1047,7 +1047,7 @@ func TestNegativeRepo(t *testing.T) {
 	sres := searchForTest(t, b,
 		query.NewAnd(
 			&query.Substring{Pattern: "needle"},
-			&query.Not{Child: &query.Repo{Pattern: "bla"}},
+			&query.Not{Child: &query.Repo{Expr: &query.Substring{Pattern: "bla"}}},
 		))
 
 	if len(sres.Files) != 0 {
@@ -1077,7 +1077,7 @@ func TestListRepos(t *testing.T) {
 			{Minimal: true},
 		} {
 			t.Run(fmt.Sprint(opts), func(t *testing.T) {
-				q := &query.Repo{Pattern: "epo"}
+				q := &query.Repo{Expr: &query.Substring{Pattern: "epo"}}
 
 				res, err := searcher.List(context.Background(), q, opts)
 				if err != nil {
@@ -1118,7 +1118,7 @@ func TestListRepos(t *testing.T) {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 
-				q = &query.Repo{Pattern: "bla"}
+				q = &query.Repo{Expr: &query.Substring{Pattern: "bla"}}
 				res, err = searcher.List(context.Background(), q, nil)
 				if err != nil {
 					t.Fatalf("List(%v): %v", q, err)
@@ -1145,7 +1145,7 @@ func TestListRepos(t *testing.T) {
 
 		searcher := searcherForTest(t, b)
 
-		q := &query.Repo{Pattern: "epo"}
+		q := &query.Repo{Expr: &query.Substring{Pattern: "epo"}}
 		res, err := searcher.List(context.Background(), q, &ListOptions{Minimal: true})
 		if err != nil {
 			t.Fatalf("List(%v): %v", q, err)
@@ -1173,7 +1173,7 @@ func TestListRepos(t *testing.T) {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
 
-		q = &query.Repo{Pattern: "bla"}
+		q = &query.Repo{Expr: &query.Substring{Pattern: "bla"}}
 		res, err = searcher.List(context.Background(), q, &ListOptions{Minimal: true})
 		if err != nil {
 			t.Fatalf("List(%v): %v", q, err)
@@ -1488,7 +1488,7 @@ func TestEstimateDocCount(t *testing.T) {
 	if sres := searchForTest(t, b,
 		query.NewAnd(
 			&query.Substring{Pattern: "needle"},
-			&query.Repo{Pattern: "reponame"},
+			&query.Repo{Expr: &query.Substring{Pattern: "reponame"}},
 		), SearchOptions{
 			EstimateDocCount: true,
 		}); sres.Stats.ShardFilesConsidered != 2 {
@@ -1497,7 +1497,7 @@ func TestEstimateDocCount(t *testing.T) {
 	if sres := searchForTest(t, b,
 		query.NewAnd(
 			&query.Substring{Pattern: "needle"},
-			&query.Repo{Pattern: "nomatch"},
+			&query.Repo{Expr: &query.Substring{Pattern: "nomatch"}},
 		), SearchOptions{
 			EstimateDocCount: true,
 		}); sres.Stats.ShardFilesConsidered != 0 {
@@ -1599,7 +1599,7 @@ func TestAndOrUnicode(t *testing.T) {
 		t.Errorf("parse: %v", err)
 	}
 	finalQ := query.NewAnd(q,
-		query.NewOr(query.NewAnd(&query.Repo{Pattern: "name"},
+		query.NewOr(query.NewAnd(&query.Repo{Expr: &query.Substring{Pattern: "name"}},
 			query.NewOr(&query.Branch{Pattern: "master"}))))
 
 	b := testIndexBuilder(t, &Repository{
@@ -1726,7 +1726,7 @@ func TestNoPositiveAtoms(t *testing.T) {
 
 	q := query.NewAnd(
 		&query.Not{Child: &query.Substring{Pattern: "xyz"}},
-		&query.Repo{Pattern: "reponame"})
+		&query.Repo{Expr: &query.Substring{Pattern: "reponame"}})
 	res := searchForTest(t, b, q)
 	if len(res.Files) != 2 {
 		t.Fatalf("got %v, want 2 results in f3", res.Files)

--- a/matchtree.go
+++ b/matchtree.go
@@ -973,24 +973,11 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 
 	case *query.Repo:
 		reposWant := make([]bool, len(d.repoMetaData))
-
-		switch expr := s.Expr.(type) {
-
-		case *query.Substring:
-			for repoIdx, r := range d.repoMetaData {
-				if strings.Contains(r.Name, expr.Pattern) {
-					reposWant[repoIdx] = true
-				}
-			}
-
-		case *query.Regexp:
-			for repoIdx, r := range d.repoMetaData {
-				if regexp.MustCompile(expr.Regexp.String()).MatchString(r.Name) {
-					reposWant[repoIdx] = true
-				}
+		for repoIdx, r := range d.repoMetaData {
+			if s.Regexp.MatchString(r.Name) {
+				reposWant[repoIdx] = true
 			}
 		}
-
 		return &docMatchTree{
 			reason:  "Repo",
 			numDocs: d.numDocs(),

--- a/matchtree.go
+++ b/matchtree.go
@@ -973,11 +973,24 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 
 	case *query.Repo:
 		reposWant := make([]bool, len(d.repoMetaData))
-		for repoIdx, r := range d.repoMetaData {
-			if strings.Contains(r.Name, s.Pattern) {
-				reposWant[repoIdx] = true
+
+		switch expr := s.Expr.(type) {
+
+		case *query.Substring:
+			for repoIdx, r := range d.repoMetaData {
+				if strings.Contains(r.Name, expr.Pattern) {
+					reposWant[repoIdx] = true
+				}
+			}
+
+		case *query.Regexp:
+			for repoIdx, r := range d.repoMetaData {
+				if regexp.MustCompile(expr.Regexp.String()).MatchString(r.Name) {
+					reposWant[repoIdx] = true
+				}
 			}
 		}
+
 		return &docMatchTree{
 			reason:  "Repo",
 			numDocs: d.numDocs(),

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -16,6 +16,7 @@ package zoekt
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
@@ -256,7 +257,7 @@ func TestRepo(t *testing.T) {
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 0, 1},
 	}
-	mt, err := d.newMatchTree(&query.Repo{Expr: &query.Substring{Pattern: "ar"}})
+	mt, err := d.newMatchTree(&query.Repo{Regexp: regexp.MustCompile("ar")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -256,7 +256,7 @@ func TestRepo(t *testing.T) {
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 0, 1},
 	}
-	mt, err := d.newMatchTree(&query.Repo{"ar"})
+	mt, err := d.newMatchTree(&query.Repo{Expr: &query.Substring{Pattern: "ar"}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/query/parse.go
+++ b/query/parse.go
@@ -118,11 +118,13 @@ func parseExpr(in []byte) (Q, int, error) {
 		}
 		expr = &caseQ{text}
 	case tokRepo:
-		if text == "" {
-			return nil, 0, fmt.Errorf("the repo: expr must have an argument")
+		r, err := regexp.Compile(text)
+
+		if err != nil {
+			return nil, 0, err
 		}
 
-		expr = &Repo{regexp.MustCompile(text)}
+		expr = &Repo{r}
 	case tokBranch:
 		expr = &Branch{Pattern: text}
 	case tokText, tokRegex:

--- a/query/parse.go
+++ b/query/parse.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 	"regexp/syntax"
 
 	"github.com/go-enry/go-enry/v2"
@@ -121,12 +122,7 @@ func parseExpr(in []byte) (Q, int, error) {
 			return nil, 0, fmt.Errorf("the repo: expr must have an argument")
 		}
 
-		q, err := regexpQuery(text, false, false)
-		if err != nil {
-			return nil, 0, err
-		}
-
-		expr = &Repo{q}
+		expr = &Repo{regexp.MustCompile(text)}
 	case tokBranch:
 		expr = &Branch{Pattern: text}
 	case tokText, tokRegex:

--- a/query/parse.go
+++ b/query/parse.go
@@ -117,7 +117,16 @@ func parseExpr(in []byte) (Q, int, error) {
 		}
 		expr = &caseQ{text}
 	case tokRepo:
-		expr = &Repo{Pattern: text}
+		if text == "" {
+			return nil, 0, fmt.Errorf("the repo: expr must have an argument")
+		}
+
+		q, err := regexpQuery(text, false, false)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		expr = &Repo{q}
 	case tokBranch:
 		expr = &Branch{Pattern: text}
 	case tokText, tokRegex:

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -17,6 +17,7 @@ package query
 import (
 	"log"
 	"reflect"
+	"regexp"
 	"regexp/syntax"
 	"testing"
 )
@@ -73,8 +74,8 @@ func TestParseQuery(t *testing.T) {
 		{"regex:abc[p-q]", &Regexp{Regexp: mustParseRE("abc[p-q]")}},
 		{"aBc[p-q]", &Regexp{Regexp: mustParseRE("aBc[p-q]"), CaseSensitive: true}},
 		{"aBc[p-q] case:auto", &Regexp{Regexp: mustParseRE("aBc[p-q]"), CaseSensitive: true}},
-		{"repo:go", &Repo{&Substring{Pattern: "go"}}},
-		{"repo:.*", &Repo{&Regexp{Regexp: mustParseRE(".*")}}},
+		{"repo:go", &Repo{regexp.MustCompile("go")}},
+		{"repo:.*", &Repo{Regexp: regexp.MustCompile(".*")}},
 
 		{"file:\"\"", &Const{true}},
 		{"abc.*def", &Regexp{Regexp: mustParseRE("abc.*def")}},

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -73,7 +73,8 @@ func TestParseQuery(t *testing.T) {
 		{"regex:abc[p-q]", &Regexp{Regexp: mustParseRE("abc[p-q]")}},
 		{"aBc[p-q]", &Regexp{Regexp: mustParseRE("aBc[p-q]"), CaseSensitive: true}},
 		{"aBc[p-q] case:auto", &Regexp{Regexp: mustParseRE("aBc[p-q]"), CaseSensitive: true}},
-		{"repo:go", &Repo{"go"}},
+		{"repo:go", &Repo{&Substring{Pattern: "go"}}},
+		{"repo:.*", &Repo{&Regexp{Regexp: mustParseRE(".*")}}},
 
 		{"file:\"\"", &Const{true}},
 		{"abc.*def", &Regexp{Regexp: mustParseRE("abc.*def")}},

--- a/query/query.go
+++ b/query/query.go
@@ -169,11 +169,11 @@ func (q *Const) String() string {
 }
 
 type Repo struct {
-	Pattern string
+	Expr Q
 }
 
 func (q *Repo) String() string {
-	return fmt.Sprintf("repo:%s", q.Pattern)
+	return fmt.Sprintf("repo:%s", q.Expr)
 }
 
 // RepoRegexp is a Sourcegraph addition which searches documents where the

--- a/query/query.go
+++ b/query/query.go
@@ -169,11 +169,11 @@ func (q *Const) String() string {
 }
 
 type Repo struct {
-	Expr Q
+	Regexp *regexp.Regexp
 }
 
 func (q *Repo) String() string {
-	return fmt.Sprintf("repo:%s", q.Expr)
+	return fmt.Sprintf("repo:%s", q.Regexp.String())
 }
 
 // RepoRegexp is a Sourcegraph addition which searches documents where the

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -84,7 +84,7 @@ func TestSimplify(t *testing.T) {
 }
 
 func TestMap(t *testing.T) {
-	in := NewAnd(&Substring{Pattern: "bla"}, &Not{&Repo{"foo"}})
+	in := NewAnd(&Substring{Pattern: "bla"}, &Not{&Repo{&Substring{Pattern: "foo"}}})
 	out := NewAnd(&Substring{Pattern: "bla"}, &Not{&Const{false}})
 
 	f := func(q Q) Q {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -17,6 +17,7 @@ package query
 import (
 	"log"
 	"reflect"
+	"regexp"
 	"testing"
 )
 
@@ -84,7 +85,7 @@ func TestSimplify(t *testing.T) {
 }
 
 func TestMap(t *testing.T) {
-	in := NewAnd(&Substring{Pattern: "bla"}, &Not{&Repo{&Substring{Pattern: "foo"}}})
+	in := NewAnd(&Substring{Pattern: "bla"}, &Not{&Repo{Regexp: regexp.MustCompile("foo")}})
 	out := NewAnd(&Substring{Pattern: "bla"}, &Not{&Const{false}})
 
 	f := func(q Q) Q {

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -455,7 +456,7 @@ func TestShardedSearcher_List(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			q := &query.Repo{Pattern: "epo"}
+			q := &query.Repo{Regexp: regexp.MustCompile("repo")}
 
 			res, err := ss.List(context.Background(), q, tc.opts)
 			if err != nil {

--- a/web/server.go
+++ b/web/server.go
@@ -552,7 +552,7 @@ func (s *Server) servePrintErr(w http.ResponseWriter, r *http.Request) error {
 	}
 	qs := []query.Q{
 		&query.Regexp{Regexp: re, FileName: true, CaseSensitive: true},
-		&query.Repo{Pattern: repoStr},
+		&query.Repo{Expr: &query.Substring{Pattern: repoStr}},
 	}
 
 	if branchStr := qvals.Get("b"); branchStr != "" {

--- a/web/server.go
+++ b/web/server.go
@@ -551,7 +551,7 @@ func (s *Server) servePrintErr(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	repoRe, err := regexp.Compile(repoStr)
+	repoRe, err := regexp.Compile("^"+regexp.QuoteMeta(repoStr)+"$")
 
 	if err != nil {
 		return err

--- a/web/server.go
+++ b/web/server.go
@@ -550,9 +550,16 @@ func (s *Server) servePrintErr(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
+
+	repoRe, err := regexp.Compile(repoStr)
+
+	if err != nil {
+		return err
+	}
+
 	qs := []query.Q{
 		&query.Regexp{Regexp: re, FileName: true, CaseSensitive: true},
-		&query.Repo{Expr: &query.Substring{Pattern: repoStr}},
+		&query.Repo{Regexp: repoRe},
 	}
 
 	if branchStr := qvals.Get("b"); branchStr != "" {


### PR DESCRIPTION
@keegancsmith here's a rough idea how to implement the query syntax for repo regex.

I know you added something similar with RepoRegex last month – haven't touched that.

Let me know what you think.