### PR TITLE
matchtree: regex uses substring iterator for start of search

### DIFF
--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -121,6 +121,10 @@ func TestBasic(t *testing.T) {
 			"href=\"file-url#line",
 			"carry <b>water</b>",
 		},
+		"/search?q=water.in": {
+			"href=\"file-url#line",
+			"carry <b>water in</b>",
+		},
 		"/search?q=r:": {
 			"1234\">master",
 			"Found 1 repositories",


### PR DESCRIPTION
TODO this is not working for case insensitive search yet.

Co-authored-by: @eseliger 