### PR TITLE
merging: convert feature flag to ENV variable

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -574,7 +574,7 @@ func (b *Builder) Finish() error {
 
 	for p := range toDelete {
 		// Don't delete compound shards, set tombstones instead.
-		if zoekt.TombstonesEnabled(filepath.Dir(p)) && strings.HasPrefix(filepath.Base(p), "compound-") {
+		if zoekt.ShardMergingEnabled() && strings.HasPrefix(filepath.Base(p), "compound-") {
 			if !strings.HasSuffix(p, ".zoekt") {
 				continue
 			}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -149,7 +149,7 @@ func TestCleanup(t *testing.T) {
 			for _, name := range tt.repos {
 				repoIDs = append(repoIDs, fakeID(name))
 			}
-			cleanup(dir, repoIDs, now)
+			cleanup(dir, repoIDs, now, false)
 
 			if d := cmp.Diff(tt.wantIndex, glob(filepath.Join(dir, "*.zoekt"))); d != "" {
 				t.Errorf("unexpected index (-want, +got):\n%s", d)

--- a/tombstones.go
+++ b/tombstones.go
@@ -12,9 +12,6 @@ import (
 // ShardMergingEnabled returns true if SRC_ENABLE_SHARD_MERGING is set to true.
 func ShardMergingEnabled() bool {
 	t := os.Getenv("SRC_ENABLE_SHARD_MERGING")
-	if t == "" {
-		return false
-	}
 	enabled, _ := strconv.ParseBool(t)
 	return enabled
 }

--- a/tombstones.go
+++ b/tombstones.go
@@ -5,13 +5,18 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"syscall"
 )
 
-// TombstoneEnabled returns true if a file "RIP" is present in dir.
-func TombstonesEnabled(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, "RIP"))
-	return err == nil
+// ShardMergingEnabled returns true if SRC_ENABLE_SHARD_MERGING is set to true.
+func ShardMergingEnabled() bool {
+	t := os.Getenv("SRC_ENABLE_SHARD_MERGING")
+	if t == "" {
+		return false
+	}
+	enabled, _ := strconv.ParseBool(t)
+	return enabled
 }
 
 var mockRepos []*Repository


### PR DESCRIPTION
So far, shard merging was activated by placing a RIP file in the index
directory. However, we have rolled out the feature to the full cluster
and it makes more sense to use an ENV variable instead.

Note: Before deploying this, I have to add the new ENV variable to the
Zoekt deployment.