### PR TITLE
rpc: aggregate Stats in List response

### DIFF
--- a/api.go
+++ b/api.go
@@ -461,6 +461,10 @@ type RepoList struct {
 
 	// Minimal response to a List request. Returned when ListOptions.Minimal is true.
 	Minimal map[uint32]*MinimalRepoListEntry
+
+	// Stats response to a List request.
+	// This is the aggregate RepoStats of all repos matching the input query.
+	Stats RepoStats
 }
 
 type Searcher interface {

--- a/eval.go
+++ b/eval.go
@@ -534,6 +534,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 			continue
 		}
 
+		l.Stats.Add(&rle.Stats)
 		if id := rle.Repository.ID; id != 0 && minimal {
 			l.Minimal[id] = &MinimalRepoListEntry{
 				HasSymbols: rle.Repository.HasSymbols,

--- a/index_test.go
+++ b/index_test.go
@@ -1097,6 +1097,15 @@ func TestListRepos(t *testing.T) {
 							OtherBranchesNewLinesCount: 3,
 						},
 					}},
+					Stats: RepoStats{
+						Documents:    4,
+						ContentBytes: 68,
+						Shards:       1,
+
+						NewLinesCount:              4,
+						DefaultBranchNewLinesCount: 2,
+						OtherBranchesNewLinesCount: 3,
+					},
 				}
 				ignored := []cmp.Option{
 					cmpopts.EquateEmpty(),
@@ -1148,6 +1157,15 @@ func TestListRepos(t *testing.T) {
 					HasSymbols: repo.HasSymbols,
 					Branches:   repo.Branches,
 				},
+			},
+			Stats: RepoStats{
+				Shards:                     1,
+				Documents:                  4,
+				IndexBytes:                 308,
+				ContentBytes:               68,
+				NewLinesCount:              4,
+				DefaultBranchNewLinesCount: 2,
+				OtherBranchesNewLinesCount: 3,
 			},
 		}
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -855,6 +855,7 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 		}
 
 		agg.Crashes += r.rl.Crashes
+		agg.Stats.Add(&r.rl.Stats)
 
 		for _, r := range r.rl.Repos {
 			prev, ok := uniq[r.Repository.Name]

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -469,6 +469,7 @@ func TestShardedSearcher_List(t *testing.T) {
 			ignored := []cmp.Option{
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(zoekt.RepoListEntry{}, "IndexMetadata"),
+				cmpopts.IgnoreFields(zoekt.RepoStats{}, "IndexBytes"),
 				cmpopts.IgnoreFields(zoekt.Repository{}, "SubRepoMap"),
 				cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 			}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -364,14 +364,33 @@ func TestShardedSearcher_List(t *testing.T) {
 		},
 	}
 
+	doc := zoekt.Document{
+		Name:     "foo.go",
+		Content:  []byte("bar\nbaz"),
+		Branches: []string{"main", "dev"},
+	}
+
 	// Test duplicate removal when ListOptions.Minimal is true and false
 	ss := newShardedSearcher(4)
 	ss.replace(map[string]zoekt.Searcher{
-		"1": searcherForTest(t, testIndexBuilder(t, repos[0])),
+		"1": searcherForTest(t, testIndexBuilder(t, repos[0], doc)),
 		"2": searcherForTest(t, testIndexBuilder(t, repos[0])),
-		"3": searcherForTest(t, testIndexBuilder(t, repos[1])),
+		"3": searcherForTest(t, testIndexBuilder(t, repos[1], doc)),
 		"4": searcherForTest(t, testIndexBuilder(t, repos[1])),
 	})
+
+	stats := zoekt.RepoStats{
+		Shards:                     2,
+		Documents:                  1,
+		IndexBytes:                 196,
+		ContentBytes:               13,
+		NewLinesCount:              1,
+		DefaultBranchNewLinesCount: 1,
+		OtherBranchesNewLinesCount: 1,
+	}
+
+	aggStats := stats
+	aggStats.Add(&aggStats) // since both repos have the exact same stats, this works
 
 	for _, tc := range []struct {
 		name string
@@ -385,13 +404,14 @@ func TestShardedSearcher_List(t *testing.T) {
 				Repos: []*zoekt.RepoListEntry{
 					{
 						Repository: *repos[0],
-						Stats:      zoekt.RepoStats{Shards: 2},
+						Stats:      stats,
 					},
 					{
 						Repository: *repos[1],
-						Stats:      zoekt.RepoStats{Shards: 2},
+						Stats:      stats,
 					},
 				},
+				Stats: aggStats,
 			},
 		},
 		{
@@ -401,13 +421,14 @@ func TestShardedSearcher_List(t *testing.T) {
 				Repos: []*zoekt.RepoListEntry{
 					{
 						Repository: *repos[0],
-						Stats:      zoekt.RepoStats{Shards: 2},
+						Stats:      stats,
 					},
 					{
 						Repository: *repos[1],
-						Stats:      zoekt.RepoStats{Shards: 2},
+						Stats:      stats,
 					},
 				},
+				Stats: aggStats,
 			},
 		},
 		{
@@ -417,7 +438,7 @@ func TestShardedSearcher_List(t *testing.T) {
 				Repos: []*zoekt.RepoListEntry{
 					{
 						Repository: *repos[1],
-						Stats:      zoekt.RepoStats{Shards: 2},
+						Stats:      stats,
 					},
 				},
 				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
@@ -426,6 +447,7 @@ func TestShardedSearcher_List(t *testing.T) {
 						Branches:   repos[0].Branches,
 					},
 				},
+				Stats: aggStats,
 			},
 		},
 	} {
@@ -447,10 +469,10 @@ func TestShardedSearcher_List(t *testing.T) {
 			ignored := []cmp.Option{
 				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(zoekt.RepoListEntry{}, "IndexMetadata"),
-				cmpopts.IgnoreFields(zoekt.RepoStats{}, "IndexBytes"),
 				cmpopts.IgnoreFields(zoekt.Repository{}, "SubRepoMap"),
 				cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 			}
+
 			if diff := cmp.Diff(tc.want, res, ignored...); diff != "" {
 				t.Fatalf("mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
This commit adds an aggregate `Stats` field in `RepoList` which will be
used by the Sourcegraph frontend to report new line statistics without
having to list the full repo representation. We can use minimal listing,
which is already used and cached there, but now that response will
include aggregate statistics as well.

Part of https://github.com/sourcegraph/sourcegraph/issues/28849