### PR TITLE
eval: re-enable result ranking

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -346,6 +346,7 @@ nextFileMatch:
 		res.Stats.MatchCount += len(fileMatch.LineMatches)
 		res.Stats.FileCount++
 	}
+	SortFilesByScore(res.Files)
 
 	for _, md := range d.repoMetaData {
 		r := md

--- a/index_test.go
+++ b/index_test.go
@@ -306,7 +306,7 @@ func TestAndSearch(t *testing.T) {
 
 	wantStats := Stats{
 		FilesLoaded:        1,
-		ContentBytesLoaded: 17,
+		ContentBytesLoaded: 18,
 		IndexBytesLoaded:   8,
 		NgramMatches:       3, // we look at doc 1, because it's max(0,1) due to AND
 		MatchCount:         1,
@@ -1551,8 +1551,8 @@ func TestIOStats(t *testing.T) {
 	q := &query.Substring{Pattern: "abc", CaseSensitive: true, Content: true}
 	res := searchForTest(t, b, q)
 
-	// 4096 (content) + 1 (overhead: newlines)
-	if got, want := res.Stats.ContentBytesLoaded, int64(4097); got != want {
+	// 4096 (content) + 2 (overhead: newlines or doc sections)
+	if got, want := res.Stats.ContentBytesLoaded, int64(4098); got != want {
 		t.Errorf("got content I/O %d, want %d", got, want)
 	}
 

--- a/read_test.go
+++ b/read_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt/query"
 )
 
@@ -219,8 +220,8 @@ func TestReadSearch(t *testing.T) {
 				continue
 			}
 
-			if !reflect.DeepEqual(res.Files, want.FileMatches[j]) {
-				t.Errorf("matches for %s on %s\ngot:\n%v\nwant:\n%v", q, name, res.Files[0], want.FileMatches[j])
+			if d := cmp.Diff(res.Files, want.FileMatches[j]); d != "" {
+				t.Errorf("matches for %s on %s\n%s", q, name, d)
 			}
 		}
 	}

--- a/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
@@ -27,6 +27,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -60,6 +62,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -70,7 +74,7 @@
     ],
     [
       {
-        "Score": 910,
+        "Score": 7910,
         "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
@@ -82,7 +86,7 @@
             "LineEnd": 46,
             "LineNumber": 6,
             "FileName": false,
-            "Score": 501,
+            "Score": 7501,
             "LineFragments": [
               {
                 "LineOffset": 1,
@@ -98,6 +102,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -108,7 +114,7 @@
     ],
     [
       {
-        "Score": 260,
+        "Score": 5760,
         "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
@@ -120,7 +126,7 @@
             "LineEnd": 65,
             "LineNumber": 7,
             "FileName": false,
-            "Score": 51,
+            "Score": 5551,
             "LineFragments": [
               {
                 "LineOffset": 4,
@@ -136,6 +142,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",

--- a/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
@@ -27,6 +27,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -60,6 +62,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -70,7 +74,7 @@
     ],
     [
       {
-        "Score": 910,
+        "Score": 7910,
         "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
@@ -82,7 +86,7 @@
             "LineEnd": 46,
             "LineNumber": 6,
             "FileName": false,
-            "Score": 501,
+            "Score": 7501,
             "LineFragments": [
               {
                 "LineOffset": 1,
@@ -98,6 +102,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",
@@ -108,7 +114,7 @@
     ],
     [
       {
-        "Score": 260,
+        "Score": 5760,
         "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
@@ -120,7 +126,7 @@
             "LineEnd": 65,
             "LineNumber": 7,
             "FileName": false,
-            "Score": 51,
+            "Score": 5551,
             "LineFragments": [
               {
                 "LineOffset": 4,
@@ -136,6 +142,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "go",

--- a/testdata/golden/TestReadSearch/repo17_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/repo17_v17.00000.golden
@@ -27,6 +27,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "Go",
@@ -60,6 +62,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "Go",

--- a/testdata/golden/TestReadSearch/repo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo_v16.00000.golden
@@ -27,6 +27,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "Go",
@@ -60,6 +62,8 @@
             ]
           }
         ],
+        "RepositoryID": 0,
+        "RepositoryPriority": 0,
         "Content": null,
         "Checksum": "n9fUYqacPXg=",
         "Language": "Go",


### PR DESCRIPTION
A long time ago we disabled zoekt's result ranking because in
Sourcegraph we sorted results by filename. This adds back the result
ranking which will rank results based on similarity to the query.

Additionally, in 7102177d we removed the code related to ranking based
on symbol data. This commit also partially reverts that.