### PR TITLE
eval: add ShardRepoMaxMatchCount

### DIFF
--- a/api.go
+++ b/api.go
@@ -504,6 +504,13 @@ type SearchOptions struct {
 	// once we have this many matches across shards.
 	TotalMaxMatchCount int
 
+	// Maximum number of matches: skip processing documents for a repository in
+	// a shard once we have found ShardRepoMaxMatchCount.
+	//
+	// A compound shard may contain multiple repositories. This will most often
+	// be set to 1 to find all repositories containing a result.
+	ShardRepoMaxMatchCount int
+
 	// Maximum number of important matches: skip processing
 	// shard after we found this many important matches.
 	ShardMaxImportantMatch int

--- a/eval.go
+++ b/eval.go
@@ -212,6 +212,13 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *SearchOptions) 
 		stats: &res.Stats,
 	}
 
+	// Track the number of documents found in a repository for
+	// ShardRepoMaxMatchCount
+	var (
+		lastRepoID     uint16
+		repoMatchCount int
+	)
+
 	docCount := uint32(len(d.fileBranchMasks))
 	lastDoc := int(-1)
 
@@ -228,14 +235,30 @@ nextFileMatch:
 		if int(nextDoc) <= lastDoc {
 			nextDoc = uint32(lastDoc + 1)
 		}
-		// Skip tombstoned docs
-		for nextDoc < docCount && d.repoMetaData[d.repos[nextDoc]].Tombstone {
-			nextDoc++
+		for ; nextDoc < docCount; nextDoc++ {
+			// Skip tombstoned docs
+			if d.repoMetaData[d.repos[nextDoc]].Tombstone {
+				continue
+			}
+			// Skip documents over ShardRepoMaxMatchCount if enabled.
+			if opts.ShardRepoMaxMatchCount > 0 {
+				if repoMatchCount >= opts.ShardRepoMaxMatchCount && d.repos[nextDoc] == lastRepoID {
+					res.Stats.FilesSkipped++
+					continue
+				}
+			}
+			break
 		}
 		if nextDoc >= docCount {
 			break
 		}
 		lastDoc = int(nextDoc)
+
+		// We track lastRepoID for ShardRepoMaxMatchCount
+		if lastRepoID != d.repos[nextDoc] {
+			lastRepoID = d.repos[nextDoc]
+			repoMatchCount = 0
+		}
 
 		if canceled || (res.Stats.MatchCount >= opts.ShardMaxMatchCount && opts.ShardMaxMatchCount > 0) ||
 			(opts.ShardMaxImportantMatch > 0 && importantMatchCount >= opts.ShardMaxImportantMatch) {
@@ -341,6 +364,8 @@ nextFileMatch:
 		if opts.Whole {
 			fileMatch.Content = cp.data(false)
 		}
+
+		repoMatchCount += len(fileMatch.LineMatches)
 
 		res.Files = append(res.Files, fileMatch)
 		res.Stats.MatchCount += len(fileMatch.LineMatches)

--- a/eval.go
+++ b/eval.go
@@ -235,23 +235,28 @@ nextFileMatch:
 		if int(nextDoc) <= lastDoc {
 			nextDoc = uint32(lastDoc + 1)
 		}
+
 		for ; nextDoc < docCount; nextDoc++ {
 			// Skip tombstoned docs
 			if d.repoMetaData[d.repos[nextDoc]].Tombstone {
 				continue
 			}
-			// Skip documents over ShardRepoMaxMatchCount if enabled.
+
+			// Skip documents over ShardRepoMaxMatchCount if specified.
 			if opts.ShardRepoMaxMatchCount > 0 {
 				if repoMatchCount >= opts.ShardRepoMaxMatchCount && d.repos[nextDoc] == lastRepoID {
 					res.Stats.FilesSkipped++
 					continue
 				}
 			}
+
 			break
 		}
+
 		if nextDoc >= docCount {
 			break
 		}
+
 		lastDoc = int(nextDoc)
 
 		// We track lastRepoID for ShardRepoMaxMatchCount


### PR DESCRIPTION
A common pattern we use is to search with ShardMaxMatchCount = 1 to find
all repositories with a match. However, with compound shards this breaks
since there may be multiple repositories in a shard. As such we
introduce a new option which covers that use case.

We now keep track of how many matches in a repository we have found and
skip documents once we hit that limit. This is done similarly to how we
support tombstones.

This commit is still missing a test. Additionally List can now be
updated to use this option instead of the search per repo code it
currently has.

Part of https://github.com/sourcegraph/sourcegraph/issues/28799