### PR TITLE
all: resolve staticcheck issues

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -286,12 +286,12 @@ type IndexState string
 
 const (
 	IndexStateMissing IndexState = "missing"
-	IndexStateCorrupt            = "corrupt"
-	IndexStateVersion            = "version-mismatch"
-	IndexStateOption             = "option-mismatch"
-	IndexStateMeta               = "meta-mismatch"
-	IndexStateContent            = "content-mismatch"
-	IndexStateEqual              = "equal"
+	IndexStateCorrupt IndexState = "corrupt"
+	IndexStateVersion IndexState = "version-mismatch"
+	IndexStateOption  IndexState = "option-mismatch"
+	IndexStateMeta    IndexState = "meta-mismatch"
+	IndexStateContent IndexState = "content-mismatch"
+	IndexStateEqual   IndexState = "equal"
 )
 
 var readVersions = []struct {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -95,10 +95,10 @@ type indexState string
 
 const (
 	indexStateFail        indexState = "fail"
-	indexStateSuccess                = "success"
-	indexStateSuccessMeta            = "success_meta" // We only updated metadata
-	indexStateNoop                   = "noop"         // We didn't need to update index
-	indexStateEmpty                  = "empty"        // index is empty (empty repo)
+	indexStateSuccess     indexState = "success"
+	indexStateSuccessMeta indexState = "success_meta" // We only updated metadata
+	indexStateNoop        indexState = "noop"         // We didn't need to update index
+	indexStateEmpty       indexState = "empty"        // index is empty (empty repo)
 )
 
 // Server is the main functionality of zoekt-sourcegraph-indexserver. It

--- a/gitindex/ignore_test.go
+++ b/gitindex/ignore_test.go
@@ -93,6 +93,9 @@ func TestIgnore(t *testing.T) {
 	defer searcher.Close()
 
 	res, err := searcher.Search(context.Background(), &query.Substring{}, &zoekt.SearchOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(res.Files) != 3 {
 		t.Fatalf("expected 3 file matches")


### PR DESCRIPTION
- SA9004: only the first constant in this group has an explicit
- SA4006: this value of `err` is never used
- SA2002: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test

For solving goroutine and T.Fatalf there is quite a nice solution
used. Instead of starting a goroutine, we just create a buffered channel
that is overly sized to receive all the stream events. Then we can just
consume it in the same goroutine.

See output of staticcheck below:

<details>

``` shellsession
$ nix run nixpkgs.golangci-lint -c golangci-lint run --disable-all -E staticcheck
cmd/zoekt-sourcegraph-indexserver/main.go:97:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
	indexStateFail        indexState = "fail"
	^
gitindex/ignore_test.go:95:2: SA4006: this value of `err` is never used (staticcheck)
	res, err := searcher.Search(context.Background(), &query.Substring{}, &zoekt.SearchOptions{})
	^
stream/stream_test.go:41:2: SA2002: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (staticcheck)
	go func() {
	^
stream/stream_test.go:48:5: SA2002(related information): call to T.Fatalf (staticcheck)
				t.Fatalf("got %s, wanted %s", res.Files[0].FileName, "bin.go")
				^
stream/stream_test.go:85:2: SA2002: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (staticcheck)
	go func() {
	^
stream/stream_test.go:91:5: SA2002(related information): call to T.Fatal (staticcheck)
				t.Fatal("expected exactly 1 result, got at least 2")
				^
stream/stream_test.go:94:5: SA2002(related information): call to T.Fatalf (staticcheck)
				t.Fatalf("zoekt.Stats mismatch (-want +got): %s\n", d)
				^
build/builder.go:288:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
	IndexStateMissing IndexState = "missing"
	^
```

</details>