### PR TITLE
merging: add metrics for shard count and janitor jobs

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -273,10 +273,23 @@ func shardsLog(indexDir, action string, shards []shard) {
 	}
 }
 
+var metricVacuumRunning = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "zoekt_vacuum_running",
+	Help: "is vacuum running?",
+})
+
+var metricNumberCompoundShards = promauto.NewGauge(prometheus.GaugeOpts{
+	Name: "zoekt_number_compound_shards",
+	Help: "the number of compound shards",
+})
+
 // vacuum removes tombstoned repos from compound shards and removes compound
 // shards if they shrink below minSizeBytes. Vacuum locks the index directory for
 // each compound shard it vacuums.
 func (s *Server) vacuum() {
+	metricVacuumRunning.Set(1)
+	defer metricVacuumRunning.Set(0)
+
 	d, err := os.Open(s.IndexDir)
 	if err != nil {
 		return
@@ -307,6 +320,7 @@ func (s *Server) vacuum() {
 			s.muIndexDir.Lock()
 			for _, p := range paths {
 				os.Remove(p)
+				metricNumberCompoundShards.Dec()
 			}
 			s.muIndexDir.Unlock()
 			shardsLog(s.IndexDir, "delete", []shard{{Path: path}})

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -274,12 +274,12 @@ func shardsLog(indexDir, action string, shards []shard) {
 }
 
 var metricVacuumRunning = promauto.NewGauge(prometheus.GaugeOpts{
-	Name: "zoekt_vacuum_running",
+	Name: "index_vacuum_running",
 	Help: "is vacuum running?",
 })
 
 var metricNumberCompoundShards = promauto.NewGauge(prometheus.GaugeOpts{
-	Name: "zoekt_number_compound_shards",
+	Name: "index_number_compound_shards",
 	Help: "the number of compound shards",
 })
 

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -275,12 +275,12 @@ func shardsLog(indexDir, action string, shards []shard) {
 
 var metricVacuumRunning = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "index_vacuum_running",
-	Help: "is vacuum running?",
+	Help: "Set to 1 if indexserver's vacuum job is running.",
 })
 
 var metricNumberCompoundShards = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "index_number_compound_shards",
-	Help: "the number of compound shards",
+	Help: "The number of compound shards.",
 })
 
 // vacuum removes tombstoned repos from compound shards and removes compound

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -674,20 +674,12 @@ func getEnvWithDefaultInt64(k string, defaultVal int64) int64 {
 }
 
 func initializeCompoundShardCounter(indexDir string) {
-	fns, err := filepath.Glob(filepath.Join(indexDir, "*.zoekt"))
+	fns, err := filepath.Glob(filepath.Join(indexDir, "compound-*.zoekt"))
 	if err != nil {
 		log.Printf("initializeCompoundShardCounter: %s\n", err)
 		return
 	}
-
-	numCompoundShards := 0
-	for _, fn := range fns {
-		if !strings.HasPrefix(fn, "compound-") {
-			continue
-		}
-		numCompoundShards++
-	}
-	metricNumberCompoundShards.Set(float64(numCompoundShards))
+	metricNumberCompoundShards.Set(float64(len(fns)))
 }
 
 func main() {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -674,17 +674,15 @@ func getEnvWithDefaultInt64(k string, defaultVal int64) int64 {
 }
 
 func initializeCompoundShardCounter(indexDir string) {
-	d, err := os.Open(indexDir)
+	fns, err := filepath.Glob(filepath.Join(indexDir, "*.zoekt"))
 	if err != nil {
 		log.Printf("initializeCompoundShardCounter: %s\n", err)
 		return
 	}
-	defer d.Close()
-	fns, _ := d.Readdirnames(-1)
 
 	numCompoundShards := 0
 	for _, fn := range fns {
-		if !strings.HasPrefix(fn, "compound-") || !strings.HasSuffix(fn, ".zoekt") {
+		if !strings.HasPrefix(fn, "compound-") {
 			continue
 		}
 		numCompoundShards++

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -21,18 +21,18 @@ var reCompound = regexp.MustCompile(`compound-.*\.zoekt`)
 
 var metricShardMergingRunning = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "index_shard_merging_running",
-	Help: "is merging running?",
+	Help: "Set to 1 if indexserver's merge job is running.",
 })
 
 var metricShardMergingErrors = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "index_shard_merging_errors",
-	Help: "the number of calls to merge that returned an error",
+	Help: "The number of calls to merge that returned an error.",
 })
 
 var metricShardMergingDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "index_shard_merging_duration_seconds",
-	Help:    "The duration of 1 shard merge operation",
-	Buckets: prometheus.LinearBuckets(0, 30, 10),
+	Help:    "The duration of 1 shard merge operation.",
+	Buckets: prometheus.LinearBuckets(30, 30, 10),
 })
 
 // doMerge drives the merge process.

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -24,11 +24,6 @@ var metricShardMergingRunning = promauto.NewGauge(prometheus.GaugeOpts{
 	Help: "Set to 1 if indexserver's merge job is running.",
 })
 
-var metricShardMergingErrors = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "index_shard_merging_errors",
-	Help: "The number of calls to merge that returned an error.",
-})
-
 var metricShardMergingDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "index_shard_merging_duration_seconds",
 	Help:    "The duration of 1 shard merge operation.",
@@ -72,7 +67,6 @@ func doMerge(dir string, targetSizeBytes, maxSizeBytes int64, simulate bool) err
 			metricShardMergingDuration.WithLabelValues(strconv.FormatBool(err != nil)).Observe(time.Since(start).Seconds())
 			debug.Printf("callMerge: OUT: %s, ERR: %s\n", string(stdOut), string(stdErr))
 			if err != nil {
-				metricShardMergingErrors.Inc()
 				debug.Printf("error during merging compound %d, stdErr: %s, err: %s\n", ix, stdErr, err)
 				continue
 			}


### PR DESCRIPTION
This change gives us real time metrics for compound shard count, vacuuming and merging.

Co-authored-by: geoffrey@sourcegraph.com