### PR TITLE
merging: count compound shards in loop

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -320,7 +320,6 @@ func (s *Server) vacuum() {
 			s.muIndexDir.Lock()
 			for _, p := range paths {
 				os.Remove(p)
-				metricNumberCompoundShards.Dec()
 			}
 			s.muIndexDir.Unlock()
 			shardsLog(s.IndexDir, "delete", []shard{{Path: path}})

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -301,6 +301,8 @@ func (s *Server) Run() {
 			missing := s.queue.Bump(repos.IDs)
 			s.Sourcegraph.ForceIterateIndexOptions(s.queue.AddOrUpdate, missing...)
 
+			setCompoundShardCounter(s.IndexDir)
+
 			<-cleanupDone
 		}
 	}()
@@ -673,10 +675,10 @@ func getEnvWithDefaultInt64(k string, defaultVal int64) int64 {
 	return i
 }
 
-func initializeCompoundShardCounter(indexDir string) {
+func setCompoundShardCounter(indexDir string) {
 	fns, err := filepath.Glob(filepath.Join(indexDir, "compound-*.zoekt"))
 	if err != nil {
-		log.Printf("initializeCompoundShardCounter: %s\n", err)
+		log.Printf("setCompoundShardCounter: %s\n", err)
 		return
 	}
 	metricNumberCompoundShards.Set(float64(len(fns)))
@@ -844,7 +846,7 @@ func main() {
 	}
 
 	initializeGoogleCloudProfiler()
-	initializeCompoundShardCounter(s.IndexDir)
+	setCompoundShardCounter(s.IndexDir)
 
 	if *listen != "" {
 		go func() {

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -70,7 +70,6 @@ func doMerge(dir string, targetSizeBytes, maxSizeBytes int64, simulate bool) err
 				debug.Printf("error during merging compound %d, stdErr: %s, err: %s\n", ix, stdErr, err)
 				continue
 			}
-			metricNumberCompoundShards.Inc()
 			// for len(comp.shards)<=1, callMerge is a NOP. Hence there is no need to log
 			// anything here.
 			if len(comp.shards) > 1 {


### PR DESCRIPTION
incrementing and decrementing the counter turned out to be too brittle,
especially because we want to be able delete shards on disk manually if
necessary. It make most sense to just count them in the main loop that is running
to fetch new repo options from frontend.