### PR TITLE
gitindex: index symbolic links

### DIFF
--- a/gitindex/tree.go
+++ b/gitindex/tree.go
@@ -178,7 +178,7 @@ func (r *repoWalker) handleEntry(p string, e *object.TreeEntry) error {
 	}
 
 	switch e.Mode {
-	case filemode.Regular, filemode.Executable:
+	case filemode.Regular, filemode.Executable, filemode.Symlink:
 	default:
 		return nil
 	}

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
 	"github.com/google/zoekt/query"
@@ -53,7 +54,8 @@ cd ..
 cd bdir
 git init -b master
 echo bcont > bfile
-git add bfile
+ln -s bfile bsymlink
+git add bfile bsymlink
 git config user.email "you@example.com"
 git config user.name "Your Name"
 git commit -am bmsg
@@ -179,7 +181,7 @@ func TestTreeToFiles(t *testing.T) {
 	}
 	sort.Strings(paths)
 
-	want := []string{".gitmodules", "afile", "bname/bfile", "subdir/sub-file"}
+	want := []string{".gitmodules", "afile", "bname/bfile", "bname/bsymlink", "subdir/sub-file"}
 	if !reflect.DeepEqual(paths, want) {
 		t.Errorf("got %v, want %v", paths, want)
 	}
@@ -254,6 +256,111 @@ func TestSubmoduleIndex(t *testing.T) {
 		t.Errorf("got %v, want 1 result", results.Files)
 	} else if f := results.Files[0]; f.Version == subVersion {
 		t.Errorf("version in super repo matched version is subrepo.")
+	}
+}
+
+func createSymlinkRepo(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	script := `mkdir adir bdir
+git init
+git config user.email "you@example.com"
+git config user.name "Your Name"
+
+echo acont > adir/afile
+git add adir/afile
+
+echo bcont > bdir/bfile
+git add bdir/bfile
+
+ln -s ./adir/afile asymlink
+git add asymlink
+
+git commit -am amsg
+
+cat << EOF  > .git/config
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = true
+[remote "origin"]
+	url = http://codehost.com/arepo
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master
+EOF
+`
+	cmd := exec.Command("/bin/sh", "-euxc", script)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("execution error: %v, output %s", err, out)
+	}
+	return nil
+}
+
+func TestSearchSymlinkByContent(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("TempDir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := createSymlinkRepo(dir); err != nil {
+		t.Fatalf("createSubmoduleRepo: %v", err)
+	}
+
+	indexDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(indexDir)
+
+	buildOpts := build.Options{
+		IndexDir: indexDir,
+	}
+	opts := Options{
+		RepoDir:      filepath.Join(dir),
+		BuildOptions: buildOpts,
+		BranchPrefix: "refs/heads/",
+		Branches:     []string{"master"},
+		Submodules:   true,
+		Incremental:  true,
+		RepoCacheDir: dir,
+	}
+	if err := IndexGitRepo(opts); err != nil {
+		t.Fatalf("IndexGitRepo: %v", err)
+	}
+
+	searcher, err := shards.NewDirectorySearcher(indexDir)
+	if err != nil {
+		t.Fatal("NewDirectorySearcher", err)
+	}
+	defer searcher.Close()
+
+	// The content of the symlink and the file path the symlink points to both
+	// contain the string "afile". Hence we expect 1 path match and 1 content match.
+	results, err := searcher.Search(context.Background(),
+		&query.Substring{Pattern: "afile"},
+		&zoekt.SearchOptions{})
+	if err != nil {
+		t.Fatal("Search", err)
+	}
+
+	if len(results.Files) != 2 {
+		t.Fatalf("got search result %v, want 2 files", results.Files)
+	}
+
+	got := make([]string, 0, 2)
+	for _, file := range results.Files {
+		got = append(got, file.FileName)
+	}
+	sort.Strings(got)
+
+	want := []string{"adir/afile", "asymlink"}
+
+	if d := cmp.Diff(want, got); d != "" {
+		t.Fatalf("-want, +got %s\n", d)
 	}
 }
 


### PR DESCRIPTION
Up to now we skipped symbolic links when compiling the list of files
during indexing. With this change we index symbolic links with the
relative path of their target file as their content.