### PR TITLE
Reduce struct sizes by ordering fields to respect alignment

### DIFF
--- a/api.go
+++ b/api.go
@@ -243,9 +243,6 @@ type RepositoryBranch struct {
 
 // Repository holds repository metadata.
 type Repository struct {
-	// Sourcergaph's repository ID
-	ID uint32
-
 	// The repository name
 	Name string
 
@@ -276,19 +273,27 @@ type Repository struct {
 	// separator, generally '#' or ';'.
 	LineFragmentTemplate string
 
-	// Perf optimization: priority is set when we load the shard. It corresponds to
-	// the value of "priority" stored in RawConfig.
-	priority float64
-
 	// All zoekt.* configuration settings.
 	RawConfig map[string]string
-
-	// Importance of the repository, bigger is more important
-	Rank uint16
 
 	// IndexOptions is a hash of the options used to create the index for the
 	// repo.
 	IndexOptions string
+
+	// LatestCommitDate is the date of the latest commit among all indexed Branches.
+	// The date might be time.Time's 0-value if the repository was last indexed
+	// before this field was added.
+	LatestCommitDate time.Time
+
+	// Perf optimization: priority is set when we load the shard. It corresponds to
+	// the value of "priority" stored in RawConfig.
+	priority float64
+
+	// Sourcegraph's repository ID
+	ID uint32
+
+	// Importance of the repository, bigger is more important
+	Rank uint16
 
 	// HasSymbols is true if this repository has indexed ctags
 	// output. Sourcegraph specific: This field is more appropriate for
@@ -298,11 +303,6 @@ type Repository struct {
 
 	// Tombstone is true if we are not allowed to search this repo.
 	Tombstone bool
-
-	// LatestCommitDate is the date of the latest commit among all indexed Branches.
-	// The date might be time.Time's 0-value if the repository was last indexed
-	// before this field was added.
-	LatestCommitDate time.Time
 }
 
 func (r *Repository) UnmarshalJSON(data []byte) error {
@@ -489,12 +489,8 @@ func (o *ListOptions) String() string {
 }
 
 type SearchOptions struct {
-	// Return an upper-bound estimate of eligible documents in
-	// stats.ShardFilesConsidered.
-	EstimateDocCount bool
-
-	// Return the whole file.
-	Whole bool
+	// SpanContext is the opentracing span context, if it exists, from the zoekt client
+	SpanContext map[string]string
 
 	// Maximum number of matches: skip all processing an index
 	// shard after we found this many non-overlapping matches.
@@ -525,12 +521,16 @@ type SearchOptions struct {
 	// results
 	MaxDocDisplayCount int
 
+	// Return an upper-bound estimate of eligible documents in
+	// stats.ShardFilesConsidered.
+	EstimateDocCount bool
+
+	// Return the whole file.
+	Whole bool
+
 	// Trace turns on opentracing for this request if true and if the Jaeger address was provided as
 	// a command-line flag
 	Trace bool
-
-	// SpanContext is the opentracing span context, if it exists, from the zoekt client
-	SpanContext map[string]string
 }
 
 func (s *SearchOptions) String() string {

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -31,12 +31,12 @@ type contentProvider struct {
 
 	// mutable
 	err      error
-	idx      uint32
 	_data    []byte
 	_nl      []uint32
 	_nlBuf   []uint32
 	_sects   []DocumentSection
 	_sectBuf []DocumentSection
+	idx      uint32
 	fileSize uint32
 }
 

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -150,19 +150,12 @@ func (s *postingsBuilder) newSearchableString(data []byte, byteSections []Docume
 
 // IndexBuilder builds a single index shard.
 type IndexBuilder struct {
-	// The version we will write to disk. Sourcegraph Specific. This is to
-	// enable feature flagging new format versions.
-	indexFormatVersion int
-	featureVersion     int
-
 	contentStrings  []*searchableString
 	nameStrings     []*searchableString
 	docSections     [][]DocumentSection
 	runeDocSections []DocumentSection
 
-	symID        uint32
 	symIndex     map[string]uint32
-	symKindID    uint32
 	symKindIndex map[string]uint32
 	symMetaData  []uint32
 
@@ -200,6 +193,14 @@ type IndexBuilder struct {
 
 	// a sortable 20 chars long id.
 	ID string
+
+	// The version we will write to disk. Sourcegraph Specific. This is to
+	// enable feature flagging new format versions.
+	indexFormatVersion int
+	featureVersion     int
+
+	symID     uint32
+	symKindID uint32
 }
 
 func (d *Repository) verify() error {

--- a/matchtree.go
+++ b/matchtree.go
@@ -146,13 +146,15 @@ type regexpMatchTree struct {
 type substrMatchTree struct {
 	matchIterator
 
-	query         *query.Substring
-	caseSensitive bool
-	fileName      bool
+	query *query.Substring
 
 	// mutable
 	current       []*candidateMatch
 	contEvaluated bool
+
+	// immutable
+	caseSensitive bool
+	fileName      bool
 }
 
 type branchQueryMatchTree struct {
@@ -219,14 +221,14 @@ func (t *symbolRegexpMatchTree) matches(cp *contentProvider, cost int, known map
 type symbolSubstrMatchTree struct {
 	*substrMatchTree
 
-	patternSize   uint32
 	fileEndRunes  []uint32
 	fileEndSymbol []uint32
 
-	doc      uint32
 	sections []DocumentSection
 
-	secID uint32
+	patternSize uint32
+	doc         uint32
+	secID       uint32
 }
 
 func (t *symbolSubstrMatchTree) prepare(doc uint32) {


### PR DESCRIPTION
[This article](https://wagslane.dev/posts/go-struct-ordering/) reminded
me that I've been meaning to check some of our structs for alignment
issues.

So I used [`aligncheck`](https://gitlab.com/opennota/check) here to see
whether there's some low-hanging fruit. Turns out we can save a few
bytes.

Feel free to say "no", though. This is a rather mechanical change and I
don't know the code base enough to know whether some semantics get lost
here by reordering things.

Since Zoekt does use a bunch of memory though, I thought why not try and
open a PR :)

before:

    /Users/thorstenball/work/zoekt/api.go:245:6: struct Repository could have size 192 (currently 208)
    /Users/thorstenball/work/zoekt/api.go:491:6: struct SearchOptions could have size 72 (currently 80)
    /Users/thorstenball/work/zoekt/contentprovider.go:28:6: struct contentProvider could have size 160 (currently 168)
    /Users/thorstenball/work/zoekt/indexbuilder.go:152:6: struct IndexBuilder could have size 480 (currently 488)
    /Users/thorstenball/work/zoekt/indexdata.go:31:6: struct indexData could have size 872 (currently 880)
    /Users/thorstenball/work/zoekt/matchtree.go:146:6: struct substrMatchTree could have size 56 (currently 64)
    /Users/thorstenball/work/zoekt/matchtree.go:219:6: struct symbolSubstrMatchTree could have size 96 (currently 104)

after (I didn't dare touch indexData yet):

    /Users/thorstenball/work/zoekt/indexdata.go:31:6: struct indexData could have size 872 (currently 880)