### PR TITLE
docker: patch alpine dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   # We build a shared docker image called "zoekt". This is not pushed, but is
   # used for creating the indexserver and webserver images.
   docker:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -43,7 +44,8 @@ jobs:
         tags: ${{ steps.version.outputs.value }},latest
         dockerfile: Dockerfile.webserver
         add_git_labels: "true"
-        push: "false"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: build-push-indexserver
       uses: docker/build-push-action@v1
@@ -52,4 +54,5 @@ jobs:
         tags: ${{ steps.version.outputs.value }},latest
         dockerfile: Dockerfile.indexserver
         add_git_labels: "true"
-        push: "false"
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   # We build a shared docker image called "zoekt". This is not pushed, but is
   # used for creating the indexserver and webserver images.
   docker:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -44,8 +43,7 @@ jobs:
         tags: ${{ steps.version.outputs.value }},latest
         dockerfile: Dockerfile.webserver
         add_git_labels: "true"
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        push: "false"
 
     - name: build-push-indexserver
       uses: docker/build-push-action@v1
@@ -54,5 +52,4 @@ jobs:
         tags: ${{ steps.version.outputs.value }},latest
         dockerfile: Dockerfile.indexserver
         add_git_labels: "true"
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        push: "false"

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git python3 expat~=2.4.3
+    apk add --no-cache ca-certificates bind-tools tini git python3 expat=~2.4.3
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git python3
+    apk add --no-cache ca-certificates bind-tools tini git python3 expat~=2.4.3
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph


### PR DESCRIPTION
```
docker build --platform linux/amd64 -t docker.io/library/zoekt:latest -f Dockerfile . 
docker build --platform linux/amd64 -t zoekt-indexserver:local -f Dockerfile.indexserver .

docker run --platform linux/amd64 -it --entrypoint /bin/sh zoekt-indexserver:local 
~ $ apk info expat
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/main: No such file or directory
WARNING: Ignoring https://dl-cdn.alpinelinux.org/alpine/v3.15/community: No such file or directory
expat-2.4.3-r0 description:
XML Parser library written in C

expat-2.4.3-r0 webpage:
http://www.libexpat.org/

expat-2.4.3-r0 installed size:
192 KiB
```

To patch the following report from trivy
![image](https://user-images.githubusercontent.com/9081680/149820920-f9fc477e-3977-4111-bba6-66674f9c16ed.png)

```
% trivy image zoekt-indexserver:local
2022-01-17T12:21:54.913-0600	INFO	Need to update DB
2022-01-17T12:21:54.913-0600	INFO	Downloading DB...
25.56 MiB / 25.56 MiB [----------------------------------------------------------------------------------------------------------------------------------] 100.00% 43.02 MiB p/s 1s
2022-01-17T12:22:03.528-0600	INFO	Detected OS: alpine
2022-01-17T12:22:03.528-0600	INFO	Detecting Alpine vulnerabilities...
2022-01-17T12:22:03.530-0600	INFO	Number of language-specific files: 4
2022-01-17T12:22:03.530-0600	INFO	Detecting gobinary vulnerabilities...

zoekt-indexserver:local (alpine 3.15.0)
=======================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-archive-index (gobinary)
============================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-git-index (gobinary)
========================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-merge-index (gobinary)
==========================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-sourcegraph-indexserver (gobinary)
======================================================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|      LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| golang.org/x/text | CVE-2021-38561   | UNKNOWN  | v0.3.6            | 0.3.7         | -->avd.aquasec.com/nvd/cve-2021-38561 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```