### PR TITLE
indexserver: remove shards with inconsistent repo name

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -126,7 +126,7 @@ func cleanup(indexDir string, repos []uint32, now time.Time, shardMerging bool) 
 			continue
 		}
 		moveAll(trashDir, shards)
-		shardsLog(indexDir, "removename", shards)
+		shardsLog(indexDir, "remove", shards)
 	}
 
 	// Remove old .tmp files from crashed indexer runs-- for example, if
@@ -311,7 +311,7 @@ func maybeSetTombstone(shards []shard, repoID uint32) bool {
 	}
 
 	if err := zoekt.SetTombstone(shards[0].Path, repoID); err != nil {
-		log.Printf("error setting tombstone for %v in shard %s: %s. Removing shard\n", repoID, shards[0].Path, err)
+		log.Printf("error setting tombstone for %d in shard %s: %s. Removing shard\n", repoID, shards[0].Path, err)
 		_ = os.Remove(shards[0].Path)
 	}
 	return true


### PR DESCRIPTION
When we switched to being based on ID we stopped cleaning up repositories after rename. So the old repository shard would remain on disk and never get updated. This is since zoekt will look for a repository by name rather than by ID. So the old shard would be invisible when updating an index.

This fix is to add to our cleanup process something which ensures the names are consistent with a repository ID. If not it bails out by just removing the shards and letting us converge to the correct state. This means when a rename occurs we have this unfortunate steps:

1. index newname
2. delete newname and oldname
3. index newname

Given the rareness of this, I believe this is an acceptable fix. However, the better (and more involved) fix is to move the shard names from being based on repo name to repo ID. Or we provide a way to inform zoekt-git-index about all shards based on ID. We already do something like this for compound shards. However, I believe that should be future work.

This PR also contains a refactor commit to factor out maybeSetTombstone.

Fixes https://github.com/sourcegraph/sourcegraph/issues/29685