### PR TITLE
zoekt: add metric to track duration of commit fetch operations

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -71,7 +71,7 @@ var (
 	metricFetchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "index_fetch_seconds",
 		Help:    "A histogram of latencies for fetching a repository.",
-		Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60, 180, 300, 600, 900, 1200}, // 50ms -> 20 minutes
+		Buckets: []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60, 180, 300, 600}, // 50ms -> 10 minutes
 	}, []string{
 		"success", // true|false
 		"name",    // the name of the repository that the commits were fetched from


### PR DESCRIPTION
We should track how long it takes us to fetch commits from gitserver. This PR adds a metric to do so, and also allows us to filter the metrics by repository name. 

---

This PR is ready, but I want to see the duration data from the log lines that we [just enabled on sourcegraph.com](https://github.com/sourcegraph/deploy-sourcegraph-cloud/pull/15327/files) in order to know if the upper end of our histogram buckets is reasonable. See https://cloudlogging.app.goo.gl/6szMQ9kS9g5PcC536 that will contain the expected fetch durations for the megarepo whenever Zoekt catches up.