### PR TITLE
merging: remove obsolete maxSize

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -129,7 +129,7 @@ func TestDoNotDeleteSingleShards(t *testing.T) {
 		t.Errorf("Finish: %v", err)
 	}
 
-	err = doMerge(dir, 2000*1024*1024, 1800*1024*1024, false)
+	err = doMerge(dir, 2000*1024*1024, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This removes the obsolete `maxSize` from the merge policy and the
command line flags.

In one of the earlier versions of the merge policy we merged compound
shards with simple shards. The parameter `maxSize` was used to decide
whether a compound is too big to be part of a merge operation.

However, we abandoned this idea some time ago. Effectively  `maxSize`
has no effect, because large shards are already excluded by other
criteria in `isExcluded(...)`, such as
(1) don't merge repos with multiple shards
(2) don't merge compound shards.