### PR TITLE
merging: support unsetting tombstones during cleanup

### DIFF
--- a/tombstones.go
+++ b/tombstones.go
@@ -20,6 +20,15 @@ var mockRepos []*Repository
 
 // SetTombstone idempotently sets a tombstone for repoName in .meta.
 func SetTombstone(shardPath string, repoID uint32) error {
+	return setTombstone(shardPath, repoID, true)
+}
+
+// UnsetTombstone idempotently removes a tombstones for reopName in .meta.
+func UnsetTombstone(shardPath string, repoID uint32) error {
+	return setTombstone(shardPath, repoID, false)
+}
+
+func setTombstone(shardPath string, repoID uint32, tombstone bool) error {
 	var repos []*Repository
 	var err error
 
@@ -34,7 +43,7 @@ func SetTombstone(shardPath string, repoID uint32) error {
 
 	for _, repo := range repos {
 		if repo.ID == repoID {
-			repo.Tombstone = true
+			repo.Tombstone = tombstone
 		}
 	}
 


### PR DESCRIPTION
With this change tombstones are removed during cleanup if a repository is tombstoned and required to be indexed. This will speed up the recovery in case we accidentally drop a lot of indexes.

The mechanics are largely the same for shards in .trash/ and tombstoned repos. However, for the case in which a repo is tombstoned and in the .trash/ directory, the shard in the .trash/ directory takes precedence because we can assume it is newer.

Commits can be reviewed separately.