### PR TITLE
merging: run vacuum every 24h instead of every hour

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -723,7 +723,7 @@ func main() {
 
 	root := flag.String("sourcegraph_url", os.Getenv("SRC_FRONTEND_INTERNAL"), "http://sourcegraph-frontend-internal or http://localhost:3090. If a path to a directory, we fake the Sourcegraph API and index all repos rooted under path.")
 	interval := flag.Duration("interval", time.Minute, "sync with sourcegraph this often")
-	vacuumInterval := flag.Duration("vacuum_interval", time.Hour, "run vacuum this often")
+	vacuumInterval := flag.Duration("vacuum_interval", 24*time.Hour, "run vacuum this often")
 	mergeInterval := flag.Duration("merge_interval", time.Hour, "run merge this often")
 	targetSize := flag.Int64("merge_target_size", getEnvWithDefaultInt64("SRC_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
 	maxSize := flag.Int64("merge_max_size", getEnvWithDefaultInt64("SRC_MAX_SIZE", 1800), "the maximum size in MiB a shard can have to be considered for merging")


### PR DESCRIPTION
We are probably too aggresive with running vacuum every hour.

I am changing the default instead of setting the ENV variable
because the old default doesn't make sense in the context of 
soft-deleting repos within compoud shards, AKA unsetting 
tombstones. Ideally we would like a couple of hours before  
soft-deleted repos are actually deleted. 

I would expect the duration of the vacuum op to increase. However, since
it doesn't hold the lock over the entire duration, we should be fine.