### PR TITLE
debug: add more facilities for debugging

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -737,7 +737,9 @@ func main() {
 	dbg := flag.Bool("debug", srcLogLevelIsDebug(), "turn on more verbose logging.")
 
 	// non daemon mode for debugging/testing
+	debugFind := flag.String("debug-find", "", "find a shard by repo name.")
 	debugList := flag.Bool("debug-list", false, "do not start the indexserver, rather list the repositories owned by this indexserver then quit.")
+	debugListIndexed := flag.Bool("debug-list-indexed", false, "do not start the indexserver, rather list the repositories indexed by this indexserver then quit.")
 	debugIndex := flag.String("debug-index", "", "do not start the indexserver, rather index the repository ID then quit.")
 	debugShard := flag.String("debug-shard", "", "do not start the indexserver, rather print shard stats then quit.")
 	debugMeta := flag.String("debug-meta", "", "do not start the indexserver, rather print shard metadata then quit.")
@@ -778,7 +780,7 @@ func main() {
 		}
 	}
 
-	isDebugCmd := *debugList || *debugIndex != "" || *debugShard != "" || *debugMeta != "" || *debugMerge
+	isDebugCmd := *debugList || *debugIndex != "" || *debugShard != "" || *debugMeta != "" || *debugMerge || *debugFind != "" || *debugListIndexed
 
 	if err := setupTmpDir(*index, !isDebugCmd); err != nil {
 		log.Fatalf("failed to setup TMPDIR under %s: %v", *index, err)
@@ -855,6 +857,27 @@ func main() {
 		for _, r := range repos.IDs {
 			fmt.Println(r)
 		}
+		os.Exit(0)
+	}
+
+	if *debugListIndexed {
+		indexed := listIndexed(s.IndexDir)
+		for _, r := range indexed {
+			fmt.Println(r)
+		}
+		os.Exit(0)
+	}
+
+	if *debugFind != "" {
+		args := indexArgs{
+			IndexOptions: IndexOptions{
+				Name: *debugFind,
+			},
+			IndexDir: *index,
+		}
+		bo := args.BuildOptions()
+		shards := bo.FindAllShards()
+		fmt.Printf("shards=%+v\n", shards)
 		os.Exit(0)
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -465,12 +465,12 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	if args.Incremental {
 		bo := args.BuildOptions()
 		bo.SetDefaults()
-		incrementalState := bo.IndexState()
+		incrementalState, fn := bo.IndexState()
 		reason = string(incrementalState)
 		metricIndexIncrementalIndexState.WithLabelValues(string(incrementalState)).Inc()
 		switch incrementalState {
 		case build.IndexStateEqual:
-			debug.Printf("%s index already up to date", args.String())
+			debug.Printf("%s index already up to date. Shard=%s", args.String(), fn)
 			return indexStateNoop, nil
 
 		case build.IndexStateMeta:

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -876,8 +876,9 @@ func main() {
 			IndexDir: *index,
 		}
 		bo := args.BuildOptions()
-		shards := bo.FindAllShards()
-		fmt.Printf("shards=%+v\n", shards)
+		for _, s := range bo.FindAllShards() {
+			fmt.Println(s)
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This adds 2 new debug commands and more verbose logging for IndexState()

Why?
This is part of the effort to determine why we have a persistent gab between num_indexed and num_assigned. Apparently, Zoekt sometimes classifies a repo as "already up to date" although there seems to be no corresponding shard present on disk. The new commands and the more verbose logging should help debugging this issue.

Note: `--debug-find` and `--debug-list-indexed` could both be done by looping over all shards and parsing the output of `--debug-meta`. As it turns out the 2 new commands here are infinitely faster.

Test Plan
- I locally build zoekt-sourcegraph-indexserver based on this commit and copied the binary to one of our production instances.
- I tested `--debug-find` with an existing repo (1 match) and a missing repo (empty list).
- I tested `--debug-list-indexed` and compared the count to the number "num_indexed", which we report on our Zoekt dashboard.