### PR TITLE
use the ctags build script from sourcegraph

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,28 +13,16 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/google/zoekt.Version=$VERSION" ./cmd/...
 
-# >3.11 don't have a statically linkable jansson-dev
-FROM alpine:3.11 AS ctags
-
-RUN apk add --no-cache --virtual build-deps ca-certificates curl jansson-dev \
-    libseccomp-dev linux-headers autoconf pkgconfig make automake \
-    gcc g++ binutils
-
-ENV CTAGS_VERSION=7c4df9d38c4fe4bb494e5f3b2279034d7d8bd7b7
-
-RUN curl -fsSL -o ctags.tar.gz "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" && \
-    tar -C /tmp -xzf ctags.tar.gz && cd /tmp/ctags-$CTAGS_VERSION && \
-    ./autogen.sh && LDFLAGS=-static ./configure --program-prefix=universal- --enable-json --enable-seccomp && \
-    make -j8 && make install && cd && \
-    rm -rf /tmp/ctags-$CTAGS_VERSION && \
-    apk --no-cache --purge del build-deps
-
 FROM alpine:3.15.0 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git ca-certificates bind-tools tini
+    apk add --no-cache git ca-certificates bind-tools tini jansson
 
-COPY --from=ctags /usr/local/bin/universal-* /usr/local/bin/
+# Commit from 2022-02-09. Please always pick a commit from the main branch.
+ENV SOURCEGRAPH_COMMIT=70028a0bde4bbffe1919635b3d1fee99c2e28625
+ADD https://raw.githubusercontent.com/sourcegraph/sourcegraph/$SOURCEGRAPH_COMMIT/cmd/symbols/ctags-install-alpine.sh /tmp/
+RUN sh /tmp/ctags-install-alpine.sh && rm /tmp/ctags-install-alpine.sh
+
 COPY --from=builder /go/bin/* /usr/local/bin/
 
 # zoekt-webserver has a large stable heap size (10s of gigs), and as such the

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git
+    apk add --no-cache ca-certificates bind-tools tini git jansson
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph


### PR DESCRIPTION
This makes it easier to keep the ctags used in sourcegraph and zoekt in sync.

Note: ctags is no longer statically linked to jansson, so we need to ensure jansson is installed for each container that has ctags.

See https://github.com/sourcegraph/sourcegraph/pull/30832
