### PR TITLE
indexserver: track number of repository options we fetch

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -54,6 +54,10 @@ var (
 		Buckets: prometheus.ExponentialBuckets(.25, 2, 4), // 250ms -> 2s
 	}, []string{"success"}) // success=true|false
 
+	metricGetIndexOptions = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "get_index_options_total",
+		Help: "The total number of times we tried to get index options for a repository. Includes errors.",
+	})
 	metricGetIndexOptionsError = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "get_index_options_error_total",
 		Help: "The total number of times we failed to get index options for a repository.",

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -148,6 +148,7 @@ func (s *sourcegraphClient) List(ctx context.Context, indexed []uint32) (*Source
 
 			metricResolveRevisionDuration.WithLabelValues("true").Observe(time.Since(start).Seconds())
 			for _, opt := range opts {
+				metricGetIndexOptions.Inc()
 				if opt.Error != "" {
 					metricGetIndexOptionsError.Inc()
 					tr.LazyPrintf("failed fetching options for %v: %v", opt.Name, opt.Error)


### PR DESCRIPTION
This will make it possible for us to tell what percentage of repo options fail. Currently we hardcode a threshold for alerting, but a percentage would scale better with different cluster sizes.

Part of https://github.com/sourcegraph/sourcegraph/issues/30796