### PR TITLE
fix: sourcegraphFake only checks SG_PRIVATE

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -388,7 +388,7 @@ func (sf sourcegraphFake) GetIndexOptions(repos ...uint32) ([]indexOptionsItem, 
 func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 	dir := filepath.Join(sf.RootDir, filepath.FromSlash(name))
 	exists := func(p string) bool {
-		_, err := os.Stat(filepath.Join(dir, "SG_PRIVATE"))
+		_, err := os.Stat(filepath.Join(dir, p))
 		return err == nil
 	}
 


### PR DESCRIPTION
The other sentinel files were just ignored.