### PR TITLE
Document how to run ctags with custom settings

### DIFF
--- a/doc/ctags.md
+++ b/doc/ctags.md
@@ -1,6 +1,5 @@
 
-CTAGS
-=====
+# CTAGS
 
 Ctags generates indices of symbol definitions in source files. It
 started its life as part of the BSD Unix, but there are several more
@@ -21,9 +20,21 @@ compiled in. Zoekt expects the `universal-ctags` binary to be on
 `$PATH`. Note: only Ubuntu names the binary `universal-ctags`, while
 most distributions name it `ctags`.
 
-Use the following invocation to compile and install universal-ctags:
+## Setup
+
+### Option 1: Install through package manager
+
+It is possible to install `ctags` on Ubuntu via `apt`:
 
 ```
+sudo apt install universal-ctags
+```
+
+### Option 2: Compile from source
+
+Use the following invocation to compile and install universal-ctags:
+
+```sh
 sudo apt-get install
   pkg-config autoconf \
   libseccomp-dev libseccomp \
@@ -38,4 +49,35 @@ NAME=ctags-$(date --iso-8601=minutes | tr -d ':' | sed 's|\+.*$||')-$(git show -
 mkdir ${NAME}
 cp ctags ${NAME}/universal-ctags
 tar zcf ${NAME}.tar.gz ${NAME}/
+```
+
+## Indexing with ctags
+
+Zoekt runs `ctags` with a hard coded list of languages by default.
+However, it's possible to pass only the languages available on your system
+by wrapping `ctags` in a script.
+
+1. Create a file `custom-ctags.sh`:
+
+```sh
+#!/usr/bin/bash
+
+set -o pipefail
+set -eux
+
+CTAGS_LANGUAGES=$(/usr/bin/universal-ctags --list-languages | grep -v 'disabled' | tr '\n' ',' | sed 's/.$//')
+/usr/bin/universal-ctags --languages=$CTAGS_LANGUAGES $@
+```
+
+2. Make it executable:
+
+```sh
+chmod +x custom-ctags.sh
+```
+
+3. Set the environment variable when indexing with Zoekt:
+
+```sh
+export CTAGS_COMMAND=$PWD/custom-ctags.sh
+go run cmd/zoekt-index/main.go -index /tmp/zoekt-index /path/to/repository
 ```


### PR DESCRIPTION
Zoekt supports starting a custom `ctags` binary which can be useful when the default settings cause `ctags` to fail (e.g when a language isn't available on the host system)