### PR TITLE
all: use grafana/regexp fork for faster regexp

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -30,7 +30,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"runtime"
 	"runtime/pprof"
 	"sort"
@@ -42,6 +41,7 @@ import (
 	"github.com/bmatcuk/doublestar"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/ctags"
+	"github.com/grafana/regexp"
 	"github.com/rs/xid"
 	"gopkg.in/natefinch/lumberjack.v2"
 )

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -15,6 +15,7 @@
 package build
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -22,17 +23,15 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/shards"
+	"github.com/grafana/regexp"
 )
 
 func TestBasic(t *testing.T) {

--- a/cmd/zoekt-mirror-gitiles/cgit.go
+++ b/cmd/zoekt-mirror-gitiles/cgit.go
@@ -21,8 +21,9 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
+
+	"github.com/grafana/regexp"
 )
 
 // I will go to programmer hell for trying to parse HTML with

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/zoekt"
+	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"time"
 
 	"github.com/google/zoekt"
+	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/eval.go
+++ b/eval.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strings"
 
 	enry_data "github.com/go-enry/go-enry/v2/data"
 	"github.com/google/zoekt/query"
+	"github.com/grafana/regexp"
 )
 
 const maxUInt16 = 0xffff

--- a/eval_test.go
+++ b/eval_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"hash/fnv"
 	"reflect"
-	"regexp"
 	"regexp/syntax"
 	"strings"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt/query"
+	"github.com/grafana/regexp"
 )
 
 var opnames = map[syntax.Op]string{

--- a/gitindex/filter.go
+++ b/gitindex/filter.go
@@ -14,7 +14,7 @@
 
 package gitindex
 
-import "regexp"
+import "github.com/grafana/regexp"
 
 // Filter is a include/exclude filter to be used for repo names.
 type Filter struct {

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"github.com/google/zoekt/build"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/shards"
+	"github.com/grafana/regexp"
 )
 
 func createSubmoduleRepo(dir string) error {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github/v27 v27.0.6
 	github.com/google/slothfs v0.0.0-20190417171004-6b42407d9230
+	github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32
 	github.com/hashicorp/go-hclog v0.12.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/keegancsmith/rpc v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
+github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32 h1:M3wP8Hwic62qJsiydSgXtev03d4f92uN1I52nVjRgw0=
+github.com/grafana/regexp v0.0.0-20220202152701-6a046c4caf32/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/index_test.go
+++ b/index_test.go
@@ -20,16 +20,15 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"regexp"
 	"regexp/syntax"
 	"strings"
 	"testing"
 
-	"github.com/kylelemons/godebug/pretty"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt/query"
+	"github.com/grafana/regexp"
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func clearScores(r *SearchResult) {

--- a/matchtree.go
+++ b/matchtree.go
@@ -17,11 +17,11 @@ package zoekt
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/google/zoekt/query"
+	"github.com/grafana/regexp"
 )
 
 // A docIterator iterates over documents in order.

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -16,11 +16,11 @@ package zoekt
 
 import (
 	"reflect"
-	"regexp"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
 	"github.com/google/zoekt/query"
+	"github.com/grafana/regexp"
 )
 
 func Test_breakOnNewlines(t *testing.T) {

--- a/query/parse.go
+++ b/query/parse.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"regexp"
 	"regexp/syntax"
 
 	"github.com/go-enry/go-enry/v2"
+	"github.com/grafana/regexp"
 )
 
 var _ = log.Printf

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -17,9 +17,10 @@ package query
 import (
 	"log"
 	"reflect"
-	"regexp"
 	"regexp/syntax"
 	"testing"
+
+	"github.com/grafana/regexp"
 )
 
 func mustParseRE(s string) *syntax.Regexp {

--- a/query/query.go
+++ b/query/query.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 	"sync"
 
 	"github.com/RoaringBitmap/roaring"
+	"github.com/grafana/regexp"
 )
 
 var _ = log.Println

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -17,8 +17,9 @@ package query
 import (
 	"log"
 	"reflect"
-	"regexp"
 	"testing"
+
+	"github.com/grafana/regexp"
 )
 
 var _ = log.Println

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -23,7 +23,6 @@ import (
 	"math"
 	"os"
 	"reflect"
-	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -37,6 +36,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/stream"
+	"github.com/grafana/regexp"
 )
 
 type crashSearcher struct{}

--- a/web/server.go
+++ b/web/server.go
@@ -16,13 +16,13 @@ package web
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"log"
 	"net"
 	"net/http"
-	"regexp"
 	"regexp/syntax"
 	"sort"
 	"strconv"
@@ -30,12 +30,11 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	"github.com/google/zoekt/stream"
+	"github.com/grafana/regexp"
 )
 
 var Funcmap = template.FuncMap{


### PR DESCRIPTION
grafana/regexp's speedup branch contains the stdlib regexp with multiple patches applied to speed up regexp. The benchmark improvements are quite impressive across the board. The series of patches are being considered for inclusion in golang. I took a look over them, and they look legit enough for us to start using it.
