### PR TITLE
cleanup: log repos in deleted compound shards

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -453,12 +453,19 @@ func (s *Server) vacuum() {
 					debug.Printf("failed getting all file paths for %s", path)
 					continue
 				}
+				var shards []shard
+				if repos, _, err := zoekt.ReadMetadataPathAlive(path); err == nil {
+					for _, r := range repos {
+						shards = append(shards,
+							shard{RepoID: r.ID, RepoName: r.Name, Path: path})
+					}
+				}
 				s.muIndexDir.Lock()
 				for _, p := range paths {
 					os.Remove(p)
 				}
 				s.muIndexDir.Unlock()
-				shardsLog(s.IndexDir, "delete", []shard{{Path: path}})
+				shardsLog(s.IndexDir, "delete", shards)
 				continue
 			}
 		}


### PR DESCRIPTION
So far we only log the name of the compound shard we delete,
which makes it hard to track the lifecycle of a specific repository.

Note: this code path will go away eventually because of #271. 
The logs should help with debugging missing repos.

Test Plan: 
Created a compound shard locally and waited for it to be deleted by the vaccum job. Afterwards I inspected the zoekt-indexserver-shard-log.tsv.

![image](https://user-images.githubusercontent.com/26413131/153436334-6b79ab68-c9d5-4031-a19e-bdf8366a52f8.png)


