### PR TITLE
shardedSearcher - implement functionality for filetombstones

### DIFF
--- a/api.go
+++ b/api.go
@@ -307,6 +307,10 @@ type Repository struct {
 	// The date might be time.Time's 0-value if the repository was last indexed
 	// before this field was added.
 	LatestCommitDate time.Time
+
+	// FileTombstones is a set of file paths that should be ignored across all branches
+	// in this shard.
+	FileTombstones map[string]struct{}
 }
 
 func (r *Repository) UnmarshalJSON(data []byte) error {
@@ -541,6 +545,12 @@ type SearchOptions struct {
 
 	// SpanContext is the opentracing span context, if it exists, from the zoekt client
 	SpanContext map[string]string
+
+	// EvaluateFileTombstones, if enabled, tells searcher to consider a repository's FileTombstones
+	// field when evaluating a search request.
+	//
+	// Note: This feature flag is off by default.
+	EvaluateFileTombstones bool
 }
 
 func (s *SearchOptions) String() string {

--- a/api.go
+++ b/api.go
@@ -310,7 +310,7 @@ type Repository struct {
 
 	// FileTombstones is a set of file paths that should be ignored across all branches
 	// in this shard.
-	FileTombstones map[string]struct{}
+	FileTombstones map[string]struct{} `json:",omitempty"`
 }
 
 func (r *Repository) UnmarshalJSON(data []byte) error {

--- a/api.go
+++ b/api.go
@@ -545,12 +545,6 @@ type SearchOptions struct {
 
 	// SpanContext is the opentracing span context, if it exists, from the zoekt client
 	SpanContext map[string]string
-
-	// EvaluateFileTombstones, if enabled, tells searcher to consider a repository's FileTombstones
-	// field when evaluating a search request.
-	//
-	// Note: This feature flag is off by default.
-	EvaluateFileTombstones bool
 }
 
 func (s *SearchOptions) String() string {

--- a/eval.go
+++ b/eval.go
@@ -245,7 +245,7 @@ nextFileMatch:
 				continue
 			}
 
-			if opts.EvaluateFileTombstones {
+			if opts.EvaluateFileTombstones && len(repoMetadata.FileTombstones) > 0 {
 				fileName := string(d.fileName(nextDoc))
 				if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
 					continue

--- a/eval.go
+++ b/eval.go
@@ -246,14 +246,10 @@ nextFileMatch:
 			}
 
 			if opts.EvaluateFileTombstones {
-
-				if repoMetadata.FileTombstones != nil {
-					fileName := string(d.fileName(nextDoc))
-					if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
-						continue
-					}
+				fileName := string(d.fileName(nextDoc))
+				if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
+					continue
 				}
-
 			}
 
 			// Skip documents over ShardRepoMaxMatchCount if specified.

--- a/eval.go
+++ b/eval.go
@@ -237,14 +237,28 @@ nextFileMatch:
 		}
 
 		for ; nextDoc < docCount; nextDoc++ {
+			repoID := d.repos[nextDoc]
+			repoMetadata := d.repoMetaData[repoID]
+
 			// Skip tombstoned docs
-			if d.repoMetaData[d.repos[nextDoc]].Tombstone {
+			if repoMetadata.Tombstone {
 				continue
+			}
+
+			if opts.EvaluateFileTombstones {
+
+				if repoMetadata.FileTombstones != nil {
+					fileName := string(d.fileName(nextDoc))
+					if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
+						continue
+					}
+				}
+
 			}
 
 			// Skip documents over ShardRepoMaxMatchCount if specified.
 			if opts.ShardRepoMaxMatchCount > 0 {
-				if repoMatchCount >= opts.ShardRepoMaxMatchCount && d.repos[nextDoc] == lastRepoID {
+				if repoMatchCount >= opts.ShardRepoMaxMatchCount && repoID == lastRepoID {
 					res.Stats.FilesSkipped++
 					continue
 				}

--- a/eval.go
+++ b/eval.go
@@ -240,7 +240,7 @@ nextFileMatch:
 			repoID := d.repos[nextDoc]
 			repoMetadata := &d.repoMetaData[repoID]
 
-			// Skip tombstoned docs
+			// Skip tombstoned repositories
 			if repoMetadata.Tombstone {
 				continue
 			}

--- a/eval.go
+++ b/eval.go
@@ -238,7 +238,7 @@ nextFileMatch:
 
 		for ; nextDoc < docCount; nextDoc++ {
 			repoID := d.repos[nextDoc]
-			repoMetadata := d.repoMetaData[repoID]
+			repoMetadata := &d.repoMetaData[repoID]
 
 			// Skip tombstoned docs
 			if repoMetadata.Tombstone {

--- a/eval.go
+++ b/eval.go
@@ -245,7 +245,7 @@ nextFileMatch:
 				continue
 			}
 
-			if opts.EvaluateFileTombstones && len(repoMetadata.FileTombstones) > 0 {
+			if len(repoMetadata.FileTombstones) > 0 {
 				fileName := string(d.fileName(nextDoc))
 				if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
 					continue

--- a/eval.go
+++ b/eval.go
@@ -245,6 +245,10 @@ nextFileMatch:
 				continue
 			}
 
+			// Skip documents that are tombstoned
+			// TODO: This FileTombstones implementation (looking up by filenames) creates a lot of small allocations
+			// (string filenames) and can have poor cache performance. This should be addressed before we officially
+			// roll this out.
 			if len(repoMetadata.FileTombstones) > 0 {
 				fileName := string(d.fileName(nextDoc))
 				if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -1066,8 +1066,7 @@ func TestSearchFileTombstones(t *testing.T) {
 			ss.replace(shardMap)
 
 			opts := &zoekt.SearchOptions{
-				Whole:                  true,
-				EvaluateFileTombstones: true,
+				Whole: true,
 			}
 
 			q := &query.Substring{Pattern: "common"}


### PR DESCRIPTION
This PR extracts the searcher functionality from the incremental work in https://github.com/sourcegraph/zoekt/pull/257 so that it can be merged separately. 

--- 

This PR does a few things:
- Adds a new field, `FileTombstones`  to the zoekt.Repository type. This field represents a set of file paths that should be ignored (across all branches) from this shard's search results. 
	- Right now, the set of FileTombstones is implemented as a hashset of file names. This isn't the best performance-wise, but it seemed like the most straightforward solution at the time. We can do better by keeping a sorted list of document IDs instead, but I will leave it for y'all to comment on whether or not we need it now, or closer to when we want to enable this feature.
- ShardedSearcher knows how to consult FileTombstones when calculating search results, and skipping over files that match one of the tombstones. 
	- A test is added for this functionality
- Adds a new SearchOption ,`EnableFileTombstones`, that feature flags the behavior above. Right now it isn't possible to programmatically enable/disable the feature (I figured it wasn't worth it since this PR alone doesn't implement a change that actually sets the filetombstones field). I figure that we can revisit this once the other parts land. 

Note that this PR doesn't tell builder to properly set filetombstones - this is only the searcher portion of the functioanlity. The builder logic will live in https://github.com/sourcegraph/zoekt/pull/274