### PR TITLE
merging: add unit test for explode

### DIFF
--- a/merge_test.go
+++ b/merge_test.go
@@ -88,7 +88,7 @@ func TestExplode(t *testing.T) {
 	}
 }
 
-// checkSameShards compare 2 shards byte by byte. The shards are expected to be
+// checkSameShards compares 2 shards byte by byte. The shards are expected to be
 // small enough to be read in all at once.
 func checkSameShards(t *testing.T, shard1, shard2 string) {
 	t.Helper()

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,110 @@
+package zoekt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// We compare 2 simple shards before and after the transformation
+// explode(merge(shard1, shard2)). We expect the input and output shards to be
+// identical.
+func TestExplode(t *testing.T) {
+	simpleShards := []string{
+		"./testdata/shards/repo_v16.00000.zoekt",
+		"./testdata/shards/repo2_v16.00000.zoekt",
+	}
+
+	// repo name -> IndexMetadata
+	m := make(map[string]*IndexMetadata, 2)
+
+	// merge
+	var files []IndexFile
+	for _, fn := range simpleShards {
+		f, err := os.Open(fn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+
+		indexFile, err := NewIndexFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer indexFile.Close()
+
+		// We save indexMeta because the fields ID and IndexTime are the 2 sources of
+		// non-determinism when building a new shard.
+		repoMeta, indexMeta, err := ReadMetadata(indexFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(repoMeta) != 1 {
+			t.Fatal("this test assumes that indexFile contains only 1 repo")
+		}
+		m[repoMeta[0].Name] = indexMeta
+
+		files = append(files, indexFile)
+	}
+
+	tmpDir := t.TempDir()
+	cs, err := Merge(tmpDir, files...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// explode
+	f, err := os.Open(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	indexFile, err := NewIndexFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer indexFile.Close()
+
+	overwriteIndexTimeAndID := func(ib *IndexBuilder) {
+		ib.ID = m[ib.repoList[0].Name].ID
+		ib.IndexTime = m[ib.repoList[0].Name].IndexTime
+	}
+	exploded, err := explode(tmpDir, indexFile, overwriteIndexTimeAndID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tmp, final := range exploded {
+		err = os.Rename(tmp, final)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, s := range simpleShards {
+		checkSameShards(t, s, filepath.Join(tmpDir, filepath.Base(s)))
+	}
+}
+
+// checkSameShards compare 2 shards byte by byte. The shards are expected to be
+// small enough to be read in all at once.
+func checkSameShards(t *testing.T, shard1, shard2 string) {
+	t.Helper()
+	b1, err := os.ReadFile(shard1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b2, err := os.ReadFile(shard2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We could also use bytes.Equal, but the output of cmd.Diff is very helpful for
+	// differences in metadata.
+	if d := cmp.Diff(b1, b2); d != "" {
+		t.Fatalf("-%s\n+%s:\n%s", shard1, shard2, d)
+	}
+}


### PR DESCRIPTION
We compare 2 simple shards before and after the transformation
explode(merge(shard1, shard2)). We expect the input and output shards to
be identical.

Originally, I thought we have to add an option to zoekt-git-index to make it
build shards deterministically (see #276). However, by adding this test to
the zoekt package instead of to cmd/zoekt-merge-index, it was possible 
to achieve the same without changing the API.