### PR TITLE
zoekt-mirror-gerrit: fix issue when anonymous http is disabled on Gerrit

### DIFF
--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -119,9 +119,10 @@ func main() {
 
 	var projectURL string
 	for _, s := range []string{"http", "anonymous http"} {
-		if projectURL == "" {
-			projectURL = info.Download.Schemes[s].URL
-		}
+                if shemeInfo, ok := info.Download.Schemes[s]; ok {
+                    projectURL = schemeInfo.URL
+                    break
+                }
 	}
 	if projectURL == "" {
 		log.Fatalf("project URL is empty, got Schemes %#v", info.Download.Schemes)

--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -119,7 +119,9 @@ func main() {
 
 	var projectURL string
 	for _, s := range []string{"http", "anonymous http"} {
-		projectURL = info.Download.Schemes[s].URL
+		if projectURL == "" {
+			projectURL = info.Download.Schemes[s].URL
+		}
 	}
 	if projectURL == "" {
 		log.Fatalf("project URL is empty, got Schemes %#v", info.Download.Schemes)


### PR DESCRIPTION
The previous implementation would always end up selecting "anonymous http" scheme.
When this option is disabled on Gerrit it can't work.
So the change selects the first available scheme in Gerrit configuration instead.