### PR TITLE
zoekt-mirror-gerrit: delete stale repos

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -241,7 +241,7 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			}
 		} else if c.GerritApiURL != "" {
 			cmd = exec.Command("zoekt-mirror-gerrit",
-				"-dest", repoDir)
+				"-dest", repoDir, "-delete")
 			if c.CredentialPath != "" {
 				cmd.Args = append(cmd.Args, "-http-credentials", c.CredentialPath)
 			}

--- a/gitindex/delete.go
+++ b/gitindex/delete.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DeleteRepos deletes stale repos under a specific path in disk. The `names`
@@ -19,7 +20,9 @@ func DeleteRepos(baseDir string, urlPrefix *url.URL, names map[string]struct{}, 
 	var toDelete []string
 	for _, p := range paths {
 		_, exists := names[p]
-		if filter.Include(filepath.Base(p)) && !exists {
+		repoName := strings.Replace(p, filepath.Join(urlPrefix.Host, urlPrefix.Path), "", 1)
+		repoName = strings.TrimPrefix(repoName, "/")
+		if filter.Include(repoName) && !exists {
 			toDelete = append(toDelete, p)
 		}
 	}

--- a/gitindex/delete_test.go
+++ b/gitindex/delete_test.go
@@ -36,11 +36,13 @@ func TestDeleteRepos(t *testing.T) {
 	}
 
 	wantBefore := map[string]struct{}{
-		"gerrit.googlesource.com/bdir.git":     {},
-		"gerrit.googlesource.com/sub/bdir.git": {},
-		"adir/.git":                            {},
-		"bdir/.git":                            {},
-		"gerrit.googlesource.com/adir.git":     {},
+		"adir/.git":                                    {},
+		"bdir/.git":                                    {},
+		"gerrit.googlesource.com/adir.git":             {},
+		"gerrit.googlesource.com/bdir.git":             {},
+		"gerrit.googlesource.com/sub/bdir.git":         {},
+		"gerrit.googlesource.com/team/scope/repoa.git": {},
+		"gerrit.googlesource.com/team/scope/repob.git": {},
 	}
 
 	if !reflect.DeepEqual(gotBefore, wantBefore) {
@@ -59,6 +61,20 @@ func TestDeleteRepos(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteRepos: %T", err)
 	}
+
+	bURL, _ := url.Parse("http://gerrit.googlesource.com")
+	bURL.Path = ""
+	names = map[string]struct{}{
+		"gerrit.googlesource.com/adir.git":             {},
+		"gerrit.googlesource.com/bdir.git":             {},
+		"gerrit.googlesource.com/team/scope/repob.git": {},
+	}
+
+	err = DeleteRepos(dir, bURL, names, filter)
+	if err != nil {
+		t.Fatalf("DeleteRepos: %T", err)
+	}
+
 	reposAfter, err := FindGitRepos(dir)
 	if err != nil {
 		t.Error("FindGitRepos", err)
@@ -74,10 +90,11 @@ func TestDeleteRepos(t *testing.T) {
 		gotAfter[p] = struct{}{}
 	}
 	wantAfter := map[string]struct{}{
-		"gerrit.googlesource.com/bdir.git": {},
-		"adir/.git":                        {},
-		"bdir/.git":                        {},
-		"gerrit.googlesource.com/adir.git": {},
+		"adir/.git":                                    {},
+		"bdir/.git":                                    {},
+		"gerrit.googlesource.com/adir.git":             {},
+		"gerrit.googlesource.com/bdir.git":             {},
+		"gerrit.googlesource.com/team/scope/repob.git": {},
 	}
 
 	if !reflect.DeepEqual(gotAfter, wantAfter) {

--- a/gitindex/repocache_test.go
+++ b/gitindex/repocache_test.go
@@ -58,6 +58,8 @@ func TestListRepos(t *testing.T) {
 		"gerrit.googlesource.com/adir.git",
 		"gerrit.googlesource.com/bdir.git",
 		"gerrit.googlesource.com/sub/bdir.git",
+		"gerrit.googlesource.com/team/scope/repoa.git",
+		"gerrit.googlesource.com/team/scope/repob.git",
 	}
 	sort.Strings(rs)
 

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -71,6 +71,10 @@ mkdir gerrit.googlesource.com/bogus.git
 mkdir gerrit.googlesource.com/sub
 git clone --bare bdir gerrit.googlesource.com/sub/bdir.git
 
+mkdir -p gerrit.googlesource.com/team/scope/
+cp -r gerrit.googlesource.com/adir.git gerrit.googlesource.com/team/scope/repoa.git
+cp -r gerrit.googlesource.com/bdir.git gerrit.googlesource.com/team/scope/repob.git
+
 cat << EOF  > gerrit.googlesource.com/adir.git/config
 [core]
 	repositoryformatversion = 0
@@ -117,11 +121,13 @@ func TestFindGitRepos(t *testing.T) {
 	}
 
 	want := map[string]bool{
-		"gerrit.googlesource.com/bdir.git":     true,
-		"gerrit.googlesource.com/sub/bdir.git": true,
-		"adir/.git":                            true,
-		"bdir/.git":                            true,
-		"gerrit.googlesource.com/adir.git":     true,
+		"adir/.git":                                    true,
+		"bdir/.git":                                    true,
+		"gerrit.googlesource.com/adir.git":             true,
+		"gerrit.googlesource.com/bdir.git":             true,
+		"gerrit.googlesource.com/sub/bdir.git":         true,
+		"gerrit.googlesource.com/team/scope/repoa.git": true,
+		"gerrit.googlesource.com/team/scope/repob.git": true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)


### PR DESCRIPTION
This change adds an option on gerrit mirror to delete repos that don't match mirror criteria anymore.
It also changes the DeleteRepos to handle repository names with multiple /