### PR TITLE
zoekt-mirror: allow to index only active projects

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -48,7 +48,8 @@ type ConfigEntry struct {
 	GerritApiURL           string
 	Topics                 []string
 	ExcludeTopics          []string
-	OnlyActive             bool
+	Active                 bool
+	NoArchived             bool
 }
 
 func randomize(entries []ConfigEntry) []ConfigEntry {
@@ -189,8 +190,8 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			for _, topic := range c.ExcludeTopics {
 				cmd.Args = append(cmd.Args, "-exclude_topic", topic)
 			}
-			if c.OnlyActive {
-				cmd.Args = append(cmd.Args, "-only-active")
+			if c.NoArchived {
+				cmd.Args = append(cmd.Args, "-no_archived")
 			}
 		} else if c.GitilesURL != "" {
 			cmd = exec.Command("zoekt-mirror-gitiles",
@@ -255,8 +256,8 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			if c.Exclude != "" {
 				cmd.Args = append(cmd.Args, "-exclude", c.Exclude)
 			}
-			if c.OnlyActive {
-				cmd.Args = append(cmd.Args, "-only-active")
+			if c.Active {
+				cmd.Args = append(cmd.Args, "-active")
 			}
 			cmd.Args = append(cmd.Args, c.GerritApiURL)
 		}

--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -189,6 +189,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			for _, topic := range c.ExcludeTopics {
 				cmd.Args = append(cmd.Args, "-exclude_topic", topic)
 			}
+			if c.OnlyActive {
+				cmd.Args = append(cmd.Args, "-only-active")
+			}
 		} else if c.GitilesURL != "" {
 			cmd = exec.Command("zoekt-mirror-gitiles",
 				"-dest", repoDir, "-name", c.Name)

--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -48,6 +48,7 @@ type ConfigEntry struct {
 	GerritApiURL           string
 	Topics                 []string
 	ExcludeTopics          []string
+	OnlyActive             bool
 }
 
 func randomize(entries []ConfigEntry) []ConfigEntry {
@@ -250,6 +251,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			}
 			if c.Exclude != "" {
 				cmd.Args = append(cmd.Args, "-exclude", c.Exclude)
+			}
+			if c.OnlyActive {
+				cmd.Args = append(cmd.Args, "-only-active")
 			}
 			cmd.Args = append(cmd.Args, c.GerritApiURL)
 		}

--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -77,7 +77,7 @@ func main() {
 	namePattern := flag.String("name", "", "only clone repos whose name matches the regexp.")
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
 	httpCrendentialsPath := flag.String("http-credentials", "", "path to a file containing http credentials stored like 'user:password'.")
-	onlyActive := flag.Bool("only-active", false, "mirror only active projects")
+	active := flag.Bool("active", false, "mirror only active projects")
 	flag.Parse()
 
 	if len(flag.Args()) < 1 {
@@ -139,7 +139,7 @@ func main() {
 		}
 
 		for k, v := range *page {
-			if *onlyActive == false || "ACTIVE" == v.State  {
+			if *active == false || "ACTIVE" == v.State  {
 				projects[k] = v
 			}
 			skip = skip + 1


### PR DESCRIPTION
Add -only-active option in configuration to ignore READ_ONLY and HIDDEN Gerrit projects and to ignore archived projects on Github
