### PR TITLE
merging: tolerate process interruptions during merging

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -453,9 +453,12 @@ func createTestCompoundShard(t *testing.T, indexDir string, repositories []zoekt
 		files = append(files, indexFile)
 	}
 
-	// merge all the normal shards into a compound shard
-	_, err := zoekt.Merge(indexDir, files...)
+	// merge all the simple shards into a compound shard
+	tmpName, dstName, err := zoekt.Merge(indexDir, files...)
 	if err != nil {
 		t.Fatalf("merging index files into compound shard: %s", err)
+	}
+	if err := os.Rename(tmpName, dstName); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,16 +14,20 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	dir := t.TempDir()
-
 	v16Shards, err := filepath.Glob("../../testdata/shards/*_v16.*.zoekt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	sort.Strings(v16Shards)
-	t.Log(v16Shards)
 
-	err = merge(dir, v16Shards, renameCompoundShard)
+	testShards, err := copyTestShards(t.TempDir(), v16Shards)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(testShards)
+
+	dir := t.TempDir()
+	err = merge(dir, testShards)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,16 +61,20 @@ func TestMerge(t *testing.T) {
 
 // Merge 2 simple shards and then explode them.
 func TestExplode(t *testing.T) {
-	dir := t.TempDir()
-
 	v16Shards, err := filepath.Glob("../../testdata/shards/repo*_v16.*.zoekt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	sort.Strings(v16Shards)
-	t.Log(v16Shards)
 
-	err = merge(dir, v16Shards, renameCompoundShard)
+	testShards, err := copyTestShards(t.TempDir(), v16Shards)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(testShards)
+
+	dir := t.TempDir()
+	err = merge(dir, testShards)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,8 +102,8 @@ func TestExplode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(exploded) != len(v16Shards) {
-		t.Fatalf("the number of simple shards before %d and after %d should be the same", len(v16Shards), len(exploded))
+	if len(exploded) != len(testShards) {
+		t.Fatalf("the number of simple shards before %d and after %d should be the same", len(testShards), len(exploded))
 	}
 
 	ss, err := shards.NewDirectorySearcher(dir)
@@ -141,9 +150,32 @@ func TestExplode(t *testing.T) {
 	}
 }
 
-// helper function. Renames the compound shard but leaves the input files
-// untouched. This is just useful for testing where we don't want each test to
-// delete the shards in testdata.
-func renameCompoundShard(tmpName, dstName string, _ []string) error {
-	return os.Rename(tmpName, dstName)
+func copyTestShards(dstDir string, srcShards []string) ([]string, error) {
+	var tmpShards []string
+	for _, s := range srcShards {
+		dst := filepath.Join(dstDir, filepath.Base(s))
+		tmpShards = append(tmpShards, dst)
+		if err := copyFile(s, dst); err != nil {
+			return nil, err
+		}
+	}
+	return tmpShards, nil
+}
+
+func copyFile(src, dst string) (err error) {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+	return d.Close()
 }

--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -21,7 +22,7 @@ func TestMerge(t *testing.T) {
 	sort.Strings(v16Shards)
 	t.Log(v16Shards)
 
-	err = merge(dir, v16Shards)
+	err = merge(dir, v16Shards, renameCompoundShard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestExplode(t *testing.T) {
 	sort.Strings(v16Shards)
 	t.Log(v16Shards)
 
-	err = merge(dir, v16Shards)
+	err = merge(dir, v16Shards, renameCompoundShard)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,4 +139,11 @@ func TestExplode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// helper function. Renames the compound shard but leaves the input files
+// untouched. This is just useful for testing where we don't want each test to
+// delete the shards in testdata.
+func renameCompoundShard(tmpName, dstName string, _ []string) error {
+	return os.Rename(tmpName, dstName)
 }

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -480,14 +480,19 @@ func createCompoundShard(t *testing.T, dir string, ids []uint32, optFns ...func(
 	}
 
 	// create a compound shard.
-	fn, err := merge(dir, repoFns)
+	tmpFn, dstFn, err := merge(dir, repoFns)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, old := range repoFns {
-		os.Remove(old)
+		if err := os.Remove(old); err != nil {
+			t.Fatal(err)
+		}
 	}
-	return fn
+	if err := os.Rename(tmpFn, dstFn); err != nil {
+		t.Fatal(err)
+	}
+	return dstFn
 }
 
 func mergeHelper(t *testing.T, fn string) error {
@@ -505,6 +510,6 @@ func mergeHelper(t *testing.T, fn string) error {
 	}
 	defer indexFile.Close()
 
-	_, err = zoekt.Merge(filepath.Dir(fn), indexFile)
+	_, _, err = zoekt.Merge(filepath.Dir(fn), indexFile)
 	return err
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -233,20 +233,5 @@ func callMerge(shards []candidate) ([]byte, []byte, error) {
 	}()
 
 	err = cmd.Run()
-	// If err==nil we can safely delete the candidate shards. In case err!=nil we
-	// don't know if a compound shard was created or not, so it is best to just
-	// delete the candidate shards to avoid duplicate results in case a compound
-	// shard was created after all.
-	for _, s := range shards {
-		paths, err := zoekt.IndexFilePaths(s.path)
-		if err != nil {
-			debug.Printf("failed to remove s %s: %v", s.path, err)
-		}
-		for _, p := range paths {
-			if err := os.Remove(p); err != nil {
-				debug.Printf("failed to remove shard file %s: %v", p, err)
-			}
-		}
-	}
 	return outBuf.Bytes(), errBuf.Bytes(), err
 }

--- a/merge.go
+++ b/merge.go
@@ -13,20 +13,22 @@ import (
 	"sort"
 )
 
-// Merge files into a compound shard fn in the directory dstDir.
-func Merge(dstDir string, files ...IndexFile) (fn string, _ error) {
+// Merge files into a compound shard in dstDir. Merge returns tmpName and a
+// dstName. It is the responsibility of the caller to delete the input shards and
+// rename the temporary compound shard from tmpName to dstName.
+func Merge(dstDir string, files ...IndexFile) (tmpName, dstName string, _ error) {
 	var ds []*indexData
 	for _, f := range files {
 		searcher, err := NewSearcher(f)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		ds = append(ds, searcher.(*indexData))
 	}
 
 	ib, err := merge(ds...)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	hasher := sha1.New()
@@ -40,11 +42,12 @@ func Merge(dstDir string, files ...IndexFile) (fn string, _ error) {
 		}
 	}
 
-	fn = filepath.Join(dstDir, fmt.Sprintf("compound-%x_v%d.%05d.zoekt", hasher.Sum(nil), NextIndexFormatVersion, 0))
-	if err := builderWriteAll(fn, ib); err != nil {
-		return "", err
+	dstName = filepath.Join(dstDir, fmt.Sprintf("compound-%x_v%d.%05d.zoekt", hasher.Sum(nil), NextIndexFormatVersion, 0))
+	tmpName = dstName + ".tmp"
+	if err := builderWriteAll(tmpName, ib); err != nil {
+		return "", "", err
 	}
-	return fn, nil
+	return tmpName, dstName, nil
 }
 
 func builderWriteAll(fn string, ib *IndexBuilder) error {

--- a/merge_test.go
+++ b/merge_test.go
@@ -50,13 +50,17 @@ func TestExplode(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	cs, err := Merge(tmpDir, files...)
+	tmpName, dstName, err := Merge(tmpDir, files...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Rename(tmpName, dstName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// explode
-	f, err := os.Open(cs)
+	f, err := os.Open(dstName)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently the call to `zoekt-merge-index` does not tollerate process interruptions, which can potentially lead to duplicate indexes. This could be the root cause for the duplicate indexes we see in production.

With this PR

- `merge.Merge` returns a temporary compound shard (*.tmp)
- `zoekt-merge-index` calls `merge.Merge` and is reponsible to delete the input shards and rename the temporary compound shard returned by `merge.Merge`.
- `zoekt-sourcegraph-indexserver` just calls `zoekt-merge-index` and always expects a consistent state.

A positive side-effect is that both merge and explode now behave the same when called from the command line: both remove the input shards and leave the output shards behind.

Test Plan:
- Unit tests needed only obvious adjustments.
- I ran a local instance of indexserver and verified that merging doesn't leave any temp files behind.

Can be reviewed commit by commit.
