### PR TITLE
ctags: only include log output for debug

### DIFF
--- a/ctags/json.go
+++ b/ctags/json.go
@@ -122,10 +122,10 @@ func (lp *lockedParser) close() {
 func NewParser(bin string) (Parser, error) {
 	if strings.Contains(bin, "universal-ctags") {
 		opts := goctags.Options{
-			Bin:  bin,
-			Info: log.New(os.Stderr, "CTAGS INF: ", log.LstdFlags),
+			Bin: bin,
 		}
 		if debug {
+			opts.Info = log.New(os.Stderr, "CTAGS INF: ", log.LstdFlags)
 			opts.Debug = log.New(os.Stderr, "CTAGS DBG: ", log.LstdFlags)
 		}
 		return &lockedParser{


### PR DESCRIPTION
We have a very large amount of logspam due to enabling info logging. For example every binary file causes logspam, etc. Right now to index the gigarepo we get 5.5mb of logs due to ctags. This goes down to 100 lines of logs when removed.
