### PR TITLE
explode: delete input shard first

### DIFF
--- a/cmd/zoekt-merge-index/main.go
+++ b/cmd/zoekt-merge-index/main.go
@@ -71,11 +71,8 @@ func mergeCmd(paths []string) error {
 	return merge(filepath.Dir(paths[0]), paths)
 }
 
-// explode splits a shard into individual shards and places them in dstDir.
-// If it returns without error, the input shard was deleted and the first
-// result contains the list of all new shards.
-//
-// explode cleans up tmp files created in the process on a best effort basis.
+// explode splits the input shard into individual shards and places them in dstDir.
+// Temporary files created in the process are removed on a best effort basis.
 func explode(dstDir string, inputShard string) error {
 	f, err := os.Open(inputShard)
 	if err != nil {
@@ -91,7 +88,7 @@ func explode(dstDir string, inputShard string) error {
 
 	exploded, err := zoekt.Explode(dstDir, indexFile)
 	defer func() {
-		// best effort removal of tmp files. If os.Remove failes, indexserver will delete
+		// best effort removal of tmp files. If os.Remove fails, indexserver will delete
 		// the leftover tmp files during the next cleanup.
 		for tmpFn := range exploded {
 			os.Remove(tmpFn)
@@ -100,53 +97,28 @@ func explode(dstDir string, inputShard string) error {
 	if err != nil {
 		return fmt.Errorf("zoekt.Explode: %w", err)
 	}
-	var fns []string
-	for tmpFn, dstFn := range exploded {
-		err = os.Rename(tmpFn, dstFn)
-		if err != nil {
-			// clean up the shards we already renamed to avoid duplicate results.
-			for _, fn := range fns {
-				os.Remove(fn)
-			}
-			return fmt.Errorf("explode: rename failed: %w", err)
-		}
-		fns = append(fns, dstFn)
+
+	// remove the input shard first to avoid duplicate indexes. In the worst case,
+	// the process is interrupted just after we delete the compound shard, in which
+	// case we have to reindex the lost repos.
+	paths, err := zoekt.IndexFilePaths(inputShard)
+	if err != nil {
+		return err
 	}
-
-	// Don't remove the input shard if its name matches one of the destination
-	// shards. This can happen, for example, if the input shard is a simple shard.
-	for _, dstFn := range exploded {
-		if dstFn == inputShard {
-			return nil
-		}
-	}
-
-	removeInputShard := func() (err error) {
-		defer func() {
-			if err != nil {
-				// delete the new shards to avoid duplicate results.
-				for _, fn := range fns {
-					os.Remove(fn)
-				}
-			}
-		}()
-
-		paths, err := zoekt.IndexFilePaths(inputShard)
+	for _, path := range paths {
+		err = os.Remove(path)
 		if err != nil {
 			return err
 		}
-		for _, path := range paths {
-			err = os.Remove(path)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
 	}
 
-	if err = removeInputShard(); err != nil {
-		return fmt.Errorf("explode: error removing input shard %s: %w", inputShard, err)
+	// best effort rename shards.
+	for tmpFn, dstFn := range exploded {
+		if err := os.Rename(tmpFn, dstFn); err != nil {
+			log.Printf("explode: rename failed: %s", err)
+		}
 	}
+
 	return nil
 }
 

--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -56,9 +56,6 @@ func TestMerge(t *testing.T) {
 	}
 }
 
-// TODO (stefan): make zoekt-git-index deterministic to compare the simple shards
-// byte by byte instead of by search results.
-
 // Merge 2 simple shards and then explode them.
 func TestExplode(t *testing.T) {
 	v16Shards, err := filepath.Glob("../../testdata/shards/repo*_v16.*.zoekt")
@@ -92,7 +89,6 @@ func TestExplode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	if len(cs) != 0 {
 		t.Fatalf("explode should have deleted the compound shard if it returned without error")
 	}


### PR DESCRIPTION
If "explode" is interrupted while renaming the tmp files, we might end
up with duplicate indexes.

This changes the order from

(1) rename tmp files
(2) remove input shard

to

(1) remove input shard
(2) rename tmp files

While previously we accepted the rare event of duplicate indexes, we now
accept the rare event of loosing indexes. The new trade-off leads to
an eventually consistent state, while the previous one doesn't.

While reviewing the existing tests, I found and removed a TODO which is
obsolete since #279.  

Test Plan:
I merged and then exploded a set of shards locally and verified that no
temporary files remained. The existing unit tests already provide a decent
coverage.