### PR TITLE
build: factor out compareBranches helper

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -604,7 +604,8 @@ func (b *Builder) Finish() error {
 				repository.FileTombstones[f] = struct{}{}
 			}
 
-			if compareBranches(repository.Branches, b.opts.RepositoryDescription.Branches) != IndexStateEqual {
+			if compareBranches(repository.Branches, b.opts.RepositoryDescription.Branches) == IndexStateBranchSet {
+				// NOTE: Should we be handling IndexStateBranchVersion and IndexStateCorrupt here too?
 				return deltaBranchSetError{
 					shardName: shard,
 					old:       repository.Branches,


### PR DESCRIPTION
And reuse it in (*Builder).Finish, hence actually removing the usage of the cmp package in non-test code.