### PR TITLE
indexserver: remove DownloadLimitMBPS

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -72,10 +72,6 @@ type indexArgs struct {
 
 	// FileLimit is the maximum size of a file
 	FileLimit int
-
-	// DownloadLimitMBPS is the maximum MB/s to use when downloading the
-	// archive.
-	DownloadLimitMBPS string
 }
 
 // BuildOptions returns a build.Options represented by indexArgs. Note: it

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -169,11 +169,10 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "all",
 		args: indexArgs{
-			Incremental:       true,
-			IndexDir:          "/data/index",
-			Parallelism:       4,
-			FileLimit:         123,
-			DownloadLimitMBPS: "1000",
+			Incremental: true,
+			IndexDir:    "/data/index",
+			Parallelism: 4,
+			FileLimit:   123,
 			IndexOptions: IndexOptions{
 				Name:       "test/repo",
 				CloneURL:   "http://api.test/.internal/git/test/repo",

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -509,20 +509,6 @@ func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
 
 		// 1 MB; match https://sourcegraph.sgdev.org/github.com/sourcegraph/sourcegraph/-/blob/cmd/symbols/internal/symbols/search.go#L22
 		FileLimit: 1 << 20,
-
-		// We are downloading archives from within the same network from
-		// another Sourcegraph service (gitserver). This can end up being
-		// so fast that we harm gitserver's network connectivity and our
-		// own. In the case of zoekt-indexserver and gitserver running on
-		// the same host machine, we can even reach up to ~100 Gbps and
-		// effectively DoS the Docker network, temporarily disrupting other
-		// containers running on the host.
-		//
-		// Google Compute Engine has a network bandwidth of about 1.64 Gbps
-		// between nodes, and AWS varies widely depending on instance type.
-		// We play it safe and default to 1 Gbps here (~119 MiB/s), which
-		// means we can fetch a 1 GiB archive in ~8.5 seconds.
-		DownloadLimitMBPS: "1000", // 1 Gbps
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -33,11 +33,10 @@ func TestServer_defaultArgs(t *testing.T) {
 		IndexOptions: IndexOptions{
 			Name: "testName",
 		},
-		IndexDir:          "/testdata/index",
-		Parallelism:       6,
-		Incremental:       true,
-		FileLimit:         1 << 20,
-		DownloadLimitMBPS: "1000",
+		IndexDir:    "/testdata/index",
+		Parallelism: 6,
+		Incremental: true,
+		FileLimit:   1 << 20,
 	}
 	got := s.indexArgs(IndexOptions{Name: "testName"})
 	if !cmp.Equal(got, want) {


### PR DESCRIPTION
This value was unread. It stopped being read when we removed support for zoekt-index-archive. We have a rate limiter now running on the server side rate limiting the git clone speeds to ensure we don't overwhelm the network.
