### PR TITLE
build: respect order in compareBranches

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -690,22 +690,16 @@ func (b *Builder) Finish() error {
 }
 
 func compareBranches(a, b []zoekt.RepositoryBranch) IndexState {
-	set := make(map[string]string, len(a))
-	for _, branch := range a {
-		if _, ok := set[branch.Name]; ok { // Duplicate branch
-			return IndexStateCorrupt
-		}
-		set[branch.Name] = branch.Version
-	}
-
-	if len(set) != len(b) {
+	if len(a) != len(b) {
 		return IndexStateBranchSet
 	}
 
-	for _, branch := range b {
-		if version, ok := set[branch.Name]; !ok {
+	for i := range a {
+		x, y := a[i], b[i]
+		if x.Name != y.Name {
 			return IndexStateBranchSet
-		} else if version != branch.Version {
+		}
+		if x.Version != y.Version {
 			return IndexStateBranchVersion
 		}
 	}

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -411,14 +411,6 @@ func TestBuilder_DeltaShardsIndexState(t *testing.T) {
 			newBranches:   []zoekt.RepositoryBranch{{Name: "main", Version: "v1"}},
 			expectedState: IndexStateBranchSet,
 		},
-		{
-			oldBranches: []zoekt.RepositoryBranch{
-				{Name: "main", Version: "v1"},
-				{Name: "main", Version: "v2"},
-			},
-			newBranches:   []zoekt.RepositoryBranch{{Name: "main", Version: "v3"}},
-			expectedState: IndexStateCorrupt,
-		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			indexDir := t.TempDir()


### PR DESCRIPTION
For non-delta we don't treat branches as a set, but rather as a slice
where order is significant. Relying on this makes it easier to reason
about and implement. It also avoids the footgun we had around accidently
mutating repobranches on the read path when sorting. The order is
significant in the shard since each document records which branches it
is part of by the index.

Note we had to remove the IndexStateCorrupt test. We may want a way to
check this invariant somewhere else since this feels like a bug we could
introduce with delta.

Test Plan: unit tests.