### PR TITLE
webserver: add score to web templates in debug mode

### DIFF
--- a/api.go
+++ b/api.go
@@ -543,6 +543,9 @@ type SearchOptions struct {
 	// a command-line flag
 	Trace bool
 
+	// If set, the search results will contain debug information for scoring.
+	DebugScore bool
+
 	// SpanContext is the opentracing span context, if it exists, from the zoekt client
 	SpanContext map[string]string
 }

--- a/eval.go
+++ b/eval.go
@@ -29,12 +29,8 @@ import (
 
 const maxUInt16 = 0xffff
 
-// DebugScore controls whether we collect data on match scores are
-// constructed. Intended for use in tests.
-var DebugScore = false
-
-func (m *FileMatch) addScore(what string, s float64) {
-	if DebugScore {
+func (m *FileMatch) addScore(what string, s float64, debugScore bool) {
+	if debugScore {
 		m.Debug += fmt.Sprintf("%s:%f, ", what, s)
 	}
 	m.Score += s
@@ -368,12 +364,12 @@ nextFileMatch:
 		// Maintain ordering of input files. This
 		// strictly dominates the in-file ordering of
 		// the matches.
-		fileMatch.addScore("fragment", maxFileScore)
-		fileMatch.addScore("atom", float64(atomMatchCount)/float64(totalAtomCount)*scoreFactorAtomMatch)
+		fileMatch.addScore("fragment", maxFileScore, opts.DebugScore)
+		fileMatch.addScore("atom", float64(atomMatchCount)/float64(totalAtomCount)*scoreFactorAtomMatch, opts.DebugScore)
 
 		// Prefer earlier docs.
-		fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(nextDoc)/float64(len(d.boundaries))))
-		fileMatch.addScore("shard-order", scoreShardRankFactor*float64(md.Rank)/maxUInt16)
+		fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(nextDoc)/float64(len(d.boundaries))), opts.DebugScore)
+		fileMatch.addScore("shard-order", scoreShardRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
 
 		if fileMatch.Score > scoreImportantThreshold {
 			importantMatchCount++

--- a/web/api.go
+++ b/web/api.go
@@ -33,13 +33,6 @@ type LastInput struct {
 	AutoFocus bool
 }
 
-// resultInputDebug is a helper type that lets us send additional information to
-// the templates we render without polluting the exported types.
-type resultInputDebug struct {
-	*ResultInput
-	ShowScoreDebug bool
-}
-
 // Result holds the data provided to the search results template.
 type ResultInput struct {
 	Last        LastInput

--- a/web/api.go
+++ b/web/api.go
@@ -33,6 +33,13 @@ type LastInput struct {
 	AutoFocus bool
 }
 
+// resultInputDebug is a helper type that lets us send additional information to
+// the templates we render without polluting the exported types.
+type resultInputDebug struct {
+	*ResultInput
+	ShowScoreDebug bool `json:"-"`
+}
+
 // Result holds the data provided to the search results template.
 type ResultInput struct {
 	Last        LastInput
@@ -56,6 +63,10 @@ type FileMatch struct {
 	Branches []string
 	Matches  []Match
 	URL      string
+
+	// Don't expose to caller of JSON API
+	Score      float64 `json:"-"`
+	ScoreDebug string  `json:"-"`
 }
 
 // Match holds the per line data provided to the search results template
@@ -67,6 +78,9 @@ type Match struct {
 	Fragments []Fragment
 	Before    string `json:",omitempty"`
 	After     string `json:",omitempty"`
+
+	// Don't expose to caller of JSON API
+	Score float64 `json:"-"`
 }
 
 // Fragment holds data of a single contiguous match within in a line

--- a/web/api.go
+++ b/web/api.go
@@ -37,7 +37,7 @@ type LastInput struct {
 // the templates we render without polluting the exported types.
 type resultInputDebug struct {
 	*ResultInput
-	ShowScoreDebug bool `json:"-"`
+	ShowScoreDebug bool
 }
 
 // Result holds the data provided to the search results template.

--- a/web/server.go
+++ b/web/server.go
@@ -203,7 +203,7 @@ func (s *Server) serveSearch(w http.ResponseWriter, r *http.Request) {
 		debugScore = true
 		fmt.Println("debug for scores enabled")
 	}
-	result, err := s.serveSearchErr(r, serveSearchErrOpts{score: debugScore})
+	result, err := s.serveSearchErr(r, serveSearchErrOpts{debugScore: debugScore})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusTeapot)
 		return
@@ -232,7 +232,7 @@ func (s *Server) serveSearch(w http.ResponseWriter, r *http.Request) {
 type serveSearchErrOpts struct {
 	// If set, searches will gather debug information for scoring and return it as
 	// part of ApiSearchResult.
-	score bool
+	debugScore bool
 }
 
 func (s *Server) serveSearchErr(r *http.Request, opts serveSearchErrOpts) (*ApiSearchResult, error) {
@@ -318,7 +318,7 @@ func (s *Server) serveSearchErr(r *http.Request, opts serveSearchErrOpts) (*ApiS
 		sOpts.TotalMaxImportantMatch = n
 	}
 	sOpts.MaxDocDisplayCount = num
-	sOpts.DebugScore = opts.score
+	sOpts.DebugScore = opts.debugScore
 
 	result, err := s.Searcher.Search(ctx, q, &sOpts)
 	if err != nil {

--- a/web/server.go
+++ b/web/server.go
@@ -198,11 +198,12 @@ func (s *Server) serveHealthz(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) serveSearch(w http.ResponseWriter, r *http.Request) {
 	qvals := r.URL.Query()
+
 	debugScore := false
 	if qvals.Get("debug") == "1" {
 		debugScore = true
-		fmt.Println("debug for scores enabled")
 	}
+
 	result, err := s.serveSearchErr(r, serveSearchErrOpts{debugScore: debugScore})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusTeapot)

--- a/web/snippets.go
+++ b/web/snippets.go
@@ -92,11 +92,13 @@ func (s *Server) formatResults(result *zoekt.SearchResult, query string, localPr
 	seenFiles := map[string]string{}
 	for _, f := range result.Files {
 		fMatch := FileMatch{
-			FileName: f.FileName,
-			Repo:     f.Repository,
-			ResultID: f.Repository + ":" + f.FileName,
-			Branches: f.Branches,
-			Language: f.Language,
+			FileName:   f.FileName,
+			Repo:       f.Repository,
+			ResultID:   f.Repository + ":" + f.FileName,
+			Branches:   f.Branches,
+			Language:   f.Language,
+			Score:      f.Score,
+			ScoreDebug: f.Debug,
 		}
 
 		if dup, ok := seenFiles[string(f.Checksum)]; ok {
@@ -122,6 +124,7 @@ func (s *Server) formatResults(result *zoekt.SearchResult, query string, localPr
 				FileName: f.FileName,
 				LineNum:  m.LineNumber,
 				URL:      fMatch.URL + fragment,
+				Score:    m.Score,
 			}
 
 			md.Before = string(m.Before)

--- a/web/templates.go
+++ b/web/templates.go
@@ -218,7 +218,7 @@ document.onkeydown=function(e){
            href="search?q={{.Last.Query}}&num={{More .Last.Num}}">show more</a>).
       {{else}}.{{end}}
     </h5>
-	{{$showScoreDebug := .ShowScoreDebug}}
+    {{$showScoreDebug := .ShowScoreDebug}}
     {{range .FileMatches}}
     <table class="table table-hover table-condensed">
       <thead>

--- a/web/templates.go
+++ b/web/templates.go
@@ -218,8 +218,8 @@ document.onkeydown=function(e){
            href="search?q={{.Last.Query}}&num={{More .Last.Num}}">show more</a>).
       {{else}}.{{end}}
     </h5>
-    {{$showScoreDebug := .ShowScoreDebug}}
     {{range .FileMatches}}
+    {{$showScoreDebug := .ScoreDebug}}
     <table class="table table-hover table-condensed">
       <thead>
         <tr>

--- a/web/templates.go
+++ b/web/templates.go
@@ -218,6 +218,7 @@ document.onkeydown=function(e){
            href="search?q={{.Last.Query}}&num={{More .Last.Num}}">show more</a>).
       {{else}}.{{end}}
     </h5>
+	{{$showScoreDebug := .ShowScoreDebug}}
     {{range .FileMatches}}
     <table class="table table-hover table-condensed">
       <thead>
@@ -225,7 +226,7 @@ document.onkeydown=function(e){
           <th>
             {{if .URL}}<a name="{{.ResultID}}" class="result"></a><a href="{{.URL}}" >{{else}}<a name="{{.ResultID}}">{{end}}
             <small>
-              {{.Repo}}:{{.FileName}}</a>:
+              {{.Repo}}:{{.FileName}} {{if $showScoreDebug}}<i>(score:{{.Score}} <-- {{.ScoreDebug}})</i>{{end}}</a>:
               <span style="font-weight: normal">[ {{if .Branches}}{{range .Branches}}<span class="label label-default">{{.}}</span>,{{end}}{{end}} ]</span>
               {{if .Language}}<button
                    title="restrict search to files written in {{.Language}}"
@@ -240,7 +241,7 @@ document.onkeydown=function(e){
         {{range .Matches}}
         <tr>
           <td style="background-color: rgba(238, 238, 255, 0.6);">
-            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}}</pre>
+            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}} {{if $showScoreDebug}}<i>(score:{{.Score}})</i>{{end}}</pre>
           </td>
         </tr>
         {{end}}


### PR DESCRIPTION
With this change we display scores for files and matches on the search
results page. The behavior can be toggled by adding `&debug=1` to
the URL.

The debug info is not part of the JSON API and is only used for
template evaluation.

![image](https://user-images.githubusercontent.com/26413131/158632240-e7d9df77-72c2-49bd-9ff4-d6142ee77181.png)
