### PR TITLE
ci: run tests for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 name: CI
 jobs:
   test:


### PR DESCRIPTION
So far we only ran tests for pushes. However, for external contributers opening PRs from forks, GitHub doesn't send "push" events [but "pull_request" events (and variants thereof)](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories).

With this change we run tests for all PRs, including subsequent pushes to the the same PR. Once the PR is merged to master we run test and build just like before.