### PR TITLE
docker: Update OpenSSL libs for CVE 2022-0778 patch

### DIFF
--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,8 @@
 FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git jansson
+    apk add --no-cache ca-certificates bind-tools tini git jansson && \
+    apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,7 +1,8 @@
 FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-   apk add --no-cache ca-certificates bind-tools tini
+   apk add --no-cache ca-certificates bind-tools tini && \
+   apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph


### PR DESCRIPTION
## Test Plan
```
kwojkovich@Kevins-MBP-2 zoekt % docker build -f Dockerfile -t zoekt:latest .
[+] Building 47.6s (20/20) FINISHED                                                                                                                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                0.0s
 => => transferring dockerfile: 1.10kB                                                                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                   0.0s
 => => transferring context: 34B                                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15.0                                                                                                                                                                                                                    0.3s
 => [internal] load metadata for docker.io/library/golang:1.17.6-alpine3.15                                                                                                                                                                                                         1.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                                                                                                                       0.0s
 => [builder 1/7] FROM docker.io/library/golang:1.17.6-alpine3.15@sha256:519c827ec22e5cf7417c9ff063ec840a446cdd30681700a16cf42eb43823e27c                                                                                                                                           6.4s
 => => resolve docker.io/library/golang:1.17.6-alpine3.15@sha256:519c827ec22e5cf7417c9ff063ec840a446cdd30681700a16cf42eb43823e27c                                                                                                                                                   0.0s
 => => sha256:1a89e8eeedd549875510e5e4e14010906a58878526814e6df25d14009856c6ff 281.90kB / 281.90kB                                                                                                                                                                                  0.1s
 => => sha256:94645a83ff95687e6f078c140cfcac8def006923ed4019ef74fa189e6d9f0b14 153B / 153B                                                                                                                                                                                          0.1s
 => => sha256:3f3a8bcf1eabba76537bfe5e366464a1b0945685149b09bfd0be21674035efdb 104.37MB / 104.37MB                                                                                                                                                                                  2.9s
 => => sha256:519c827ec22e5cf7417c9ff063ec840a446cdd30681700a16cf42eb43823e27c 1.65kB / 1.65kB                                                                                                                                                                                      0.0s
 => => sha256:8feab4c7597bc7d265ec49e835e9eee65de2000860f07b7f27774da37b108e90 1.36kB / 1.36kB                                                                                                                                                                                      0.0s
 => => sha256:ccd27c9e17031434256b10001ceacd6b056719658b09d1eeb27a609da7891183 5.21kB / 5.21kB                                                                                                                                                                                      0.0s
 => => extracting sha256:1a89e8eeedd549875510e5e4e14010906a58878526814e6df25d14009856c6ff                                                                                                                                                                                           0.1s
 => => sha256:0c92f367c5e773df00e89143be1b98a66727e464d2b3486747607d3cfd447f21 125B / 125B                                                                                                                                                                                          0.3s
 => => extracting sha256:94645a83ff95687e6f078c140cfcac8def006923ed4019ef74fa189e6d9f0b14                                                                                                                                                                                           0.0s
 => => extracting sha256:3f3a8bcf1eabba76537bfe5e366464a1b0945685149b09bfd0be21674035efdb                                                                                                                                                                                           3.2s
 => => extracting sha256:0c92f367c5e773df00e89143be1b98a66727e464d2b3486747607d3cfd447f21                                                                                                                                                                                           0.0s
 => https://raw.githubusercontent.com/sourcegraph/sourcegraph/20497508d57afd4bbd35597629779255d772a7f8/cmd/symbols/ctags-install-alpine.sh                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                   0.1s
 => => transferring context: 1.07MB                                                                                                                                                                                                                                                 0.1s
 => CACHED [zoekt 1/5] FROM docker.io/library/alpine:3.15.0@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300                                                                                                                                                 0.0s
 => [zoekt 2/5] RUN apk update --no-cache && apk upgrade --no-cache &&     apk add --no-cache git ca-certificates bind-tools tini jansson                                                                                                                                           3.3s
 => [zoekt 3/5] ADD https://raw.githubusercontent.com/sourcegraph/sourcegraph/20497508d57afd4bbd35597629779255d772a7f8/cmd/symbols/ctags-install-alpine.sh /tmp/                                                                                                                    0.0s 
 => [zoekt 4/5] RUN sh /tmp/ctags-install-alpine.sh && rm /tmp/ctags-install-alpine.sh                                                                                                                                                                                             41.4s 
 => [builder 2/7] RUN apk add --no-cache ca-certificates                                                                                                                                                                                                                            0.7s 
 => [builder 3/7] WORKDIR /go/src/github.com/google/zoekt                                                                                                                                                                                                                           0.1s 
 => [builder 4/7] COPY go.mod go.sum ./                                                                                                                                                                                                                                             0.1s 
 => [builder 5/7] RUN go mod download                                                                                                                                                                                                                                              20.9s
 => [builder 6/7] COPY . ./                                                                                                                                                                                                                                                         0.1s
 => [builder 7/7] RUN go install -ldflags "-X github.com/google/zoekt.Version=$VERSION" ./cmd/...                                                                                                                                                                                  16.0s
 => [zoekt 5/5] COPY --from=builder /go/bin/* /usr/local/bin/                                                                                                                                                                                                                       0.3s 
 => exporting to image                                                                                                                                                                                                                                                              0.5s 
 => => exporting layers                                                                                                                                                                                                                                                             0.5s 
 => => writing image sha256:09d399b0e4f6efa397a88c03f9a416ef5aa353983cd882f8bbc48684d405b945                                                                                                                                                                                        0.0s 
 => => naming to docker.io/library/zoekt:latest                                                                                                                                                                                                                                     0.0s 
kwojkovich@Kevins-MBP-2 zoekt % docker build -f Dockerfile.indexserver -t zoekt-index:test0 .
[+] Building 3.5s (12/12) FINISHED                                                                                                                                                                                                                                                       
 => [internal] load build definition from Dockerfile.indexserver                                                                                                                                                                                                                    0.0s
 => => transferring dockerfile: 1.21kB                                                                                                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                   0.0s
 => => transferring context: 34B                                                                                                                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/alpine:3.15.0                                                                                                                                                                                                                    0.3s
 => CACHED [stage-0 1/7] FROM docker.io/library/alpine:3.15.0@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300                                                                                                                                               0.0s
 => FROM docker.io/library/zoekt:latest                                                                                                                                                                                                                                             0.1s
 => [stage-0 2/7] RUN apk update --no-cache && apk upgrade --no-cache &&     apk add --no-cache ca-certificates bind-tools tini git jansson &&     apk add --upgrade --no-cache libcrypto1.1>=1.1.1n-r0 libssl1.1>=1.1.1n-r0                                                        2.0s
 => [stage-0 3/7] RUN mkdir -p /home/sourcegraph                                                                                                                                                                                                                                    0.2s
 => [stage-0 4/7] RUN addgroup -S sourcegraph && adduser -S -G sourcegraph -h /home/sourcegraph sourcegraph && mkdir -p /data && chown -R sourcegraph:sourcegraph /data                                                                                                             0.3s 
 => [stage-0 5/7] WORKDIR /home/sourcegraph                                                                                                                                                                                                                                         0.0s 
 => [stage-0 6/7] RUN mkdir -p /data/index                                                                                                                                                                                                                                          0.2s 
 => [stage-0 7/7] COPY --from=zoekt     /usr/local/bin/universal-*     /usr/local/bin/zoekt-sourcegraph-indexserver     /usr/local/bin/zoekt-archive-index     /usr/local/bin/zoekt-git-index     /usr/local/bin/zoekt-merge-index     /usr/local/bin/                              0.2s 
 => exporting to image                                                                                                                                                                                                                                                              0.2s 
 => => exporting layers                                                                                                                                                                                                                                                             0.2s
 => => writing image sha256:816c6ee2237f07ba2a20382c22646cb8305c19ecaa43fd1d121ca5ef5b6aa6bd                                                                                                                                                                                        0.0s
 => => naming to docker.io/library/zoekt-index:test0                                                                                                                                                                                                                                0.0s
kwojkovich@Kevins-MBP-2 zoekt % trivy image --exit-code 27 --ignore-unfixed --severity HIGH,CRITICAL zoekt-index:test0                                        
2022-03-17T08:12:46.393-0500	INFO	Detected OS: alpine
2022-03-17T08:12:46.393-0500	INFO	Detecting Alpine vulnerabilities...
2022-03-17T08:12:46.396-0500	INFO	Number of language-specific files: 4
2022-03-17T08:12:46.396-0500	INFO	Detecting gobinary vulnerabilities...

zoekt-index:test0 (alpine 3.15.0)
=================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-archive-index (gobinary)
============================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-git-index (gobinary)
========================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-merge-index (gobinary)
==========================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/zoekt-sourcegraph-indexserver (gobinary)
======================================================```