### PR TITLE
build: disable ctags for TestBuilder

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -490,7 +490,9 @@ func TestBuilder_DeltaShardsUpdateVersionsInOlderShards(t *testing.T) {
 		},
 	}
 
-	createTestShard(t, indexDir, repositoryV1, 2)
+	createTestShard(t, indexDir, repositoryV1, 2, func(o *Options) {
+		o.DisableCTags = true
+	})
 
 	repositoryV2 := zoekt.Repository{
 		Name: "repo",
@@ -503,6 +505,7 @@ func TestBuilder_DeltaShardsUpdateVersionsInOlderShards(t *testing.T) {
 
 	shards := createTestShard(t, indexDir, repositoryV2, 1, func(o *Options) {
 		o.IsDelta = true
+		o.DisableCTags = true
 	})
 
 	if len(shards) < 3 {


### PR DESCRIPTION
The test assumed that ctags is available. Since ctags is not essential
for the this test, we should disable it like we do in other tests.