### PR TITLE
zoekt-git-index: add support for delta shards

### DIFF
--- a/api.go
+++ b/api.go
@@ -245,6 +245,10 @@ type RepositoryBranch struct {
 	Version string
 }
 
+func (r RepositoryBranch) String() string {
+	return fmt.Sprintf("%s@%s", r.Name, r.Version)
+}
+
 // Repository holds repository metadata.
 type Repository struct {
 	// Sourcergaph's repository ID

--- a/build/builder.go
+++ b/build/builder.go
@@ -535,14 +535,6 @@ func NewBuilder(opts Options) (*Builder, error) {
 	return b, nil
 }
 
-// MarkFileAsChangedOrRemoved indicates that the file specified by the given path
-// has been changed or removed since the last indexing job for this repository.
-//
-// If this build is a delta build, these files will be tombstoned in the older shards for this repository.
-func (o *Options) MarkFileAsChangedOrRemoved(path string) {
-	o.changedOrRemovedFiles = append(o.changedOrRemovedFiles, path)
-}
-
 // AddFile is a convenience wrapper for the Add method
 func (b *Builder) AddFile(name string, content []byte) error {
 	return b.Add(zoekt.Document{Name: name, Content: content})
@@ -585,6 +577,14 @@ func (b *Builder) Add(doc zoekt.Document) error {
 	}
 
 	return nil
+}
+
+// MarkFileAsChangedOrRemoved indicates that the file specified by the given path
+// has been changed or removed since the last indexing job for this repository.
+//
+// If this build is a delta build, these files will be tombstoned in the older shards for this repository.
+func (b *Builder) MarkFileAsChangedOrRemoved(path string) {
+	b.opts.changedOrRemovedFiles = append(b.opts.changedOrRemovedFiles, path)
 }
 
 // Finish creates a last shard from the buffered documents, and clears

--- a/build/builder.go
+++ b/build/builder.go
@@ -378,10 +378,10 @@ func (o *Options) IndexState() (IndexState, string) {
 	return IndexStateEqual, fn
 }
 
-// RepositoryMetadata returns the index metadata for the repository
+// FindRepositoryMetadata returns the index metadata for the repository
 // specified in the options. 'ok' is false if the repository's metadata
 // couldn't be found or if an error occurred.
-func (o *Options) RepositoryMetadata() (repository *zoekt.Repository, ok bool, err error) {
+func (o *Options) FindRepositoryMetadata() (repository *zoekt.Repository, ok bool, err error) {
 	shard := o.findShard()
 	if shard == "" {
 		return nil, false, nil

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -516,7 +516,7 @@ func TestBuilder_DeltaShardsUpdateVersionsInOlderShards(t *testing.T) {
 	}
 }
 
-func TestRepositoryMetadata(t *testing.T) {
+func TestFindRepositoryMetadata(t *testing.T) {
 	tests := []struct {
 		name                      string
 		normalShardRepositories   []zoekt.Repository
@@ -594,7 +594,7 @@ func TestRepositoryMetadata(t *testing.T) {
 			o.SetDefaults()
 
 			// run test
-			got, gotOk, err := o.RepositoryMetadata()
+			got, gotOk, err := o.FindRepositoryMetadata()
 			if err != nil {
 				t.Errorf("received unexpected error: %v", err)
 				return

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -120,6 +120,7 @@ func TestFlags(t *testing.T) {
 	ignored := []cmp.Option{
 		// depends on $PATH setting.
 		cmpopts.IgnoreFields(Options{}, "CTags"),
+		cmpopts.IgnoreFields(Options{}, "changedOrRemovedFiles"),
 		cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 	}
 

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -506,7 +506,7 @@ func TestBuilder_DeltaShardsUpdateVersionsInOlderShards(t *testing.T) {
 
 		diffOptions := []cmp.Option{
 			cmpopts.IgnoreUnexported(zoekt.Repository{}),
-			cmpopts.IgnoreFields(zoekt.Repository{}, "IndexOptions", "HasSymbols"),
+			cmpopts.IgnoreFields(zoekt.Repository{}, "IndexOptions"),
 			cmpopts.EquateEmpty(),
 		}
 

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -645,7 +645,7 @@ func TestDeltaShards(t *testing.T) {
 					documents: []zoekt.Document{fooAtMainV2},
 					optFn: func(t *testing.T, o *Options) {
 						o.IsDelta = true
-						o.ChangedOrRemovedFiles = []string{"foo.go"}
+						o.changedOrRemovedFiles = []string{"foo.go"}
 					},
 					query:             "common",
 					expectedDocuments: []zoekt.Document{barAtMain, fooAtMainV2},
@@ -655,7 +655,7 @@ func TestDeltaShards(t *testing.T) {
 					documents: []zoekt.Document{barAtMainV2},
 					optFn: func(t *testing.T, o *Options) {
 						o.IsDelta = true
-						o.ChangedOrRemovedFiles = []string{"bar.go"}
+						o.changedOrRemovedFiles = []string{"bar.go"}
 					},
 					query:             "common",
 					expectedDocuments: []zoekt.Document{barAtMainV2, fooAtMainV2},
@@ -677,7 +677,7 @@ func TestDeltaShards(t *testing.T) {
 					documents: nil,
 					optFn: func(t *testing.T, o *Options) {
 						o.IsDelta = true
-						o.ChangedOrRemovedFiles = []string{"foo.go"}
+						o.changedOrRemovedFiles = []string{"foo.go"}
 					},
 					query:             "common",
 					expectedDocuments: []zoekt.Document{barAtMain},
@@ -699,7 +699,7 @@ func TestDeltaShards(t *testing.T) {
 					documents: nil,
 					optFn: func(t *testing.T, o *Options) {
 						o.IsDelta = true
-						o.ChangedOrRemovedFiles = []string{"foo.go"}
+						o.changedOrRemovedFiles = []string{"foo.go"}
 					},
 					query:             "common",
 					expectedDocuments: []zoekt.Document{barAtMain},

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -725,6 +726,12 @@ func TestDeltaShards(t *testing.T) {
 				for b := range branchSet {
 					repository.Branches = append(repository.Branches, zoekt.RepositoryBranch{Name: b})
 				}
+
+				sort.Slice(repository.Branches, func(i, j int) bool {
+					a, b := repository.Branches[i], repository.Branches[j]
+
+					return a.Name < b.Name
+				})
 
 				buildOpts := Options{
 					IndexDir:              indexDir,

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -748,6 +748,15 @@ func TestDeltaShards(t *testing.T) {
 					}
 				}
 
+				// Call b.Finish() multiple times to ensure that it is idempotent
+				for i := 0; i < 3; i++ {
+
+					err = b.Finish()
+					if err != nil {
+						t.Fatalf("step %q: finishing builder (call #%d): %s", step.name, i, err)
+					}
+				}
+
 				err = b.Finish()
 				if err != nil {
 					t.Fatalf("step %q: finishing builder: %s", step.name, err)
@@ -794,74 +803,6 @@ func TestDeltaShards(t *testing.T) {
 				if diff := cmp.Diff(step.expectedDocuments, receivedDocuments, cmpOpts...); diff != "" {
 					t.Errorf("step %q: diff in received documents (-want +got):%s\n:", step.name, diff)
 				}
-			}
-		})
-	}
-}
-
-// With this test we want to capture regressions in the names returned by our
-// language detection. We rely on the detected language and its spelling, for
-// example, in scoring (see scoreKind).
-func TestDetectLanguage(t *testing.T) {
-	dir := t.TempDir()
-
-	opts := Options{
-		IndexDir: dir,
-		RepositoryDescription: zoekt.Repository{
-			Name: "repo",
-		},
-	}
-
-	cases := []struct {
-		fileName     string
-		content      []byte
-		wantLanguage string
-	}{
-		{
-			fileName: "hw.java",
-			content: []byte(`
-public class HelloWorld
-{
-       public static void main (String[] args)
-       {
-             System.out.println("Hello World!");
-       }
-}
-`),
-			wantLanguage: "Java",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.wantLanguage, func(t *testing.T) {
-			b, err := NewBuilder(opts)
-			if err != nil {
-				t.Fatalf("NewBuilder: %v", err)
-			}
-			if err := b.AddFile(c.fileName, c.content); err != nil {
-				t.Fatal(err)
-			}
-			if err := b.Finish(); err != nil {
-				t.Fatalf("Finish: %v", err)
-			}
-
-			ss, err := shards.NewDirectorySearcher(dir)
-			if err != nil {
-				t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
-			}
-			defer ss.Close()
-
-			srs, err := ss.Search(context.Background(), &query.Const{true}, new(zoekt.SearchOptions))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if got, want := len(srs.Files), 1; got != want {
-				t.Fatalf("file matches: want %d, got %d", want, got)
-			}
-
-			if got := srs.Files[0].Language; got != c.wantLanguage {
-				t.Fatalf("want %s, got %s", c.wantLanguage, got)
 			}
 		})
 	}

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -814,3 +814,71 @@ func TestDeltaShards(t *testing.T) {
 		})
 	}
 }
+
+// With this test we want to capture regressions in the names returned by our
+// language detection. We rely on the detected language and its spelling, for
+// example, in scoring (see scoreKind).
+func TestDetectLanguage(t *testing.T) {
+	dir := t.TempDir()
+
+	opts := Options{
+		IndexDir: dir,
+		RepositoryDescription: zoekt.Repository{
+			Name: "repo",
+		},
+	}
+
+	cases := []struct {
+		fileName     string
+		content      []byte
+		wantLanguage string
+	}{
+		{
+			fileName: "hw.java",
+			content: []byte(`
+public class HelloWorld
+{
+       public static void main (String[] args)
+       {
+             System.out.println("Hello World!");
+       }
+}
+`),
+			wantLanguage: "Java",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.wantLanguage, func(t *testing.T) {
+			b, err := NewBuilder(opts)
+			if err != nil {
+				t.Fatalf("NewBuilder: %v", err)
+			}
+			if err := b.AddFile(c.fileName, c.content); err != nil {
+				t.Fatal(err)
+			}
+			if err := b.Finish(); err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+
+			ss, err := shards.NewDirectorySearcher(dir)
+			if err != nil {
+				t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
+			}
+			defer ss.Close()
+
+			srs, err := ss.Search(context.Background(), &query.Const{true}, new(zoekt.SearchOptions))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := len(srs.Files), 1; got != want {
+				t.Fatalf("file matches: want %d, got %d", want, got)
+			}
+
+			if got := srs.Files[0].Language; got != c.wantLanguage {
+				t.Fatalf("want %s, got %s", c.wantLanguage, got)
+			}
+		})
+	}
+}

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -90,11 +90,7 @@ func main() {
 		}
 
 		if err := gitindex.IndexGitRepo(gitOpts); err != nil {
-			if gitOpts.BuildOptions.IsDelta {
-				log.Printf("(delta build) indexGitRepo(%s): %v", dir, err)
-			}
-
-			log.Printf("indexGitRepo(%s): %v", dir, err)
+			log.Printf("indexGitRepo(%s, delta=%t): %v", dir, gitOpts.BuildOptions.IsDelta, err)
 			exitStatus = 1
 		}
 	}

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -36,6 +36,7 @@ func main() {
 	repoCacheDir := flag.String("repo_cache", "", "directory holding bare git repos, named by URL. "+
 		"this is used to find repositories for submodules. "+
 		"It also affects name if the indexed repository is under this directory.")
+	isDelta := flag.Bool("delta", false, "whether we should use delta build")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
@@ -49,6 +50,7 @@ func main() {
 		*repoCacheDir = dir
 	}
 	opts := cmd.OptionsFromFlags()
+	opts.IsDelta = *isDelta
 
 	var branches []string
 	if *branchesStr != "" {
@@ -88,6 +90,10 @@ func main() {
 		}
 
 		if err := gitindex.IndexGitRepo(gitOpts); err != nil {
+			if gitOpts.BuildOptions.IsDelta {
+				log.Printf("(delta build) indexGitRepo(%s): %v", dir, err)
+			}
+
 			log.Printf("indexGitRepo(%s): %v", dir, err)
 			exitStatus = 1
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -120,9 +120,10 @@ func TestGetIndexOptions(t *testing.T) {
 
 func TestIndex(t *testing.T) {
 	cases := []struct {
-		name string
-		args indexArgs
-		want []string
+		name                   string
+		args                   indexArgs
+		mockRepositoryMetadata *zoekt.Repository
+		want                   []string
 	}{{
 		name: "minimal",
 		args: indexArgs{
@@ -199,10 +200,58 @@ func TestIndex(t *testing.T) {
 				"-file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
 				"$TMPDIR/test%2Frepo.git",
 		},
+	}, {
+		name: "delta",
+		args: indexArgs{
+			Incremental: true,
+			IndexDir:    "/data/index",
+			Parallelism: 4,
+			FileLimit:   123,
+			UseDelta:    true,
+			IndexOptions: IndexOptions{
+				RepoID:     0,
+				Name:       "test/repo",
+				CloneURL:   "http://api.test/.internal/git/test/repo",
+				LargeFiles: []string{"foo", "bar"},
+				Symbols:    true,
+				Branches: []zoekt.RepositoryBranch{
+					{Name: "HEAD", Version: "deadbeef"},
+					{Name: "dev", Version: "feebdaed"},
+					{Name: "release", Version: "12345678"},
+				},
+			},
+		},
+		mockRepositoryMetadata: &zoekt.Repository{
+			ID:   0,
+			Name: "test/repo",
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "oldhead"},
+				{Name: "dev", Version: "olddev"},
+				{Name: "release", Version: "oldrelease"},
+			},
+		},
+		want: []string{
+			"git -c init.defaultBranch=nonExistentBranchBB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",
+			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo deadbeef feebdaed 12345678",
+			"git -C $TMPDIR/test%2Frepo.git -c protocol.version=2 fetch --depth=1 http://api.test/.internal/git/test/repo oldhead olddev oldrelease",
+			"git -C $TMPDIR/test%2Frepo.git update-ref HEAD deadbeef",
+			"git -C $TMPDIR/test%2Frepo.git update-ref refs/heads/dev feebdaed",
+			"git -C $TMPDIR/test%2Frepo.git update-ref refs/heads/release 12345678",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.archived 0",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.fork 0",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.name test/repo",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.priority 0",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.public 0",
+			"git -C $TMPDIR/test%2Frepo.git config zoekt.repoid 0",
+			"zoekt-git-index -submodules=false -incremental -branches HEAD,dev,release " +
+				"-delta -file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
+				"$TMPDIR/test%2Frepo.git",
+		},
 	}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+
 			var got []string
 			runCmd := func(c *exec.Cmd) error {
 				cmd := strings.Join(c.Args, " ")
@@ -211,7 +260,20 @@ func TestIndex(t *testing.T) {
 				return nil
 			}
 
-			if err := gitIndex(&tc.args, runCmd); err != nil {
+			findRepositoryMetadata := func(args *indexArgs) (repository *zoekt.Repository, ok bool, err error) {
+				if tc.mockRepositoryMetadata == nil {
+					return args.BuildOptions().FindRepositoryMetadata()
+				}
+
+				return tc.mockRepositoryMetadata, true, nil
+			}
+
+			c := gitIndexConfig{
+				runCmd:                 runCmd,
+				findRepositoryMetadata: findRepositoryMetadata,
+			}
+
+			if err := gitIndex(c, &tc.args); err != nil {
 				t.Fatal(err)
 			}
 			if !cmp.Equal(got, tc.want) {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -165,6 +165,10 @@ type Server struct {
 
 	// If true, shard merging is enabled.
 	shardMerging bool
+
+	// deltaBuildRepositoriesAllowList is an allowlist for repositories that we
+	// use delta-builds for instead of normal builds
+	deltaBuildRepositoriesAllowList map[string]struct{}
 }
 
 var debug = log.New(ioutil.Discard, "", log.LstdFlags)
@@ -465,13 +469,23 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		return indexStateEmpty, createEmptyShard(args)
 	}
 
+	repositoryName := args.Name
+	if _, ok := s.deltaBuildRepositoriesAllowList[repositoryName]; ok {
+		repositoryID := args.BuildOptions().RepositoryDescription.ID
+		debug.Printf("delta build: Server.Index: marking %q (ID %d) for delta build", repositoryName, repositoryID)
+
+		args.UseDelta = true
+	}
+
 	reason := "forced"
+
 	if args.Incremental {
 		bo := args.BuildOptions()
 		bo.SetDefaults()
 		incrementalState, fn := bo.IndexState()
 		reason = string(incrementalState)
 		metricIndexIncrementalIndexState.WithLabelValues(string(incrementalState)).Inc()
+
 		switch incrementalState {
 		case build.IndexStateEqual:
 			debug.Printf("%s index already up to date. Shard=%s", args.String(), fn)
@@ -493,9 +507,18 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 	log.Printf("updating index %s reason=%s", args.String(), reason)
 
-	runCmd := func(cmd *exec.Cmd) error { return s.loggedRun(tr, cmd) }
 	metricIndexingTotal.Inc()
-	return indexStateSuccess, gitIndex(args, runCmd)
+	c := gitIndexConfig{
+		runCmd: func(cmd *exec.Cmd) error {
+			return s.loggedRun(tr, cmd)
+		},
+
+		findRepositoryMetadata: func(args *indexArgs) (repository *zoekt.Repository, ok bool, err error) {
+			return args.BuildOptions().FindRepositoryMetadata()
+		},
+	}
+
+	return indexStateSuccess, gitIndex(c, args)
 }
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
@@ -722,6 +745,26 @@ func getEnvWithDefaultString(k string, defaultVal string) string {
 	return v
 }
 
+func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, v := range strings.Split(os.Getenv(k), ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			set[v] = struct{}{}
+		}
+	}
+	return set
+}
+
+func joinStringSet(set map[string]struct{}, sep string) string {
+	var xs []string
+	for x := range set {
+		xs = append(xs, x)
+	}
+
+	return strings.Join(xs, sep)
+}
+
 func setCompoundShardCounter(indexDir string) {
 	fns, err := filepath.Glob(filepath.Join(indexDir, "compound-*.zoekt"))
 	if err != nil {
@@ -843,22 +886,14 @@ func newServer(conf rootConfig) (*Server, error) {
 		debug = log.New(os.Stderr, "", log.LstdFlags)
 	}
 
-	indexingMetricsReposAllowlist := os.Getenv("INDEXING_METRICS_REPOS_ALLOWLIST")
-	if indexingMetricsReposAllowlist != "" {
-		var repos []string
+	reposWithSeparateIndexingMetrics = getEnvWithDefaultEmptySet("INDEXING_METRICS_REPOS_ALLOWLIST")
+	if len(reposWithSeparateIndexingMetrics) > 0 {
+		debug.Printf("capturing separate indexing metrics for: %s", joinStringSet(reposWithSeparateIndexingMetrics, ", "))
+	}
 
-		for _, r := range strings.Split(indexingMetricsReposAllowlist, ",") {
-			r = strings.TrimSpace(r)
-			if r != "" {
-				repos = append(repos, r)
-			}
-		}
-
-		for _, r := range repos {
-			reposWithSeparateIndexingMetrics[r] = struct{}{}
-		}
-
-		debug.Printf("capturing separate indexing metrics for: %s", repos)
+	deltaBuildRepositoriesAllowList := getEnvWithDefaultEmptySet("DELTA_BUILD_REPOS_ALLOWLIST")
+	if len(deltaBuildRepositoriesAllowList) > 0 {
+		debug.Printf("using delta shard builds for: %s", joinStringSet(deltaBuildRepositoriesAllowList, ", "))
 	}
 
 	var sg Sourcegraph
@@ -890,16 +925,18 @@ func newServer(conf rootConfig) (*Server, error) {
 	if cpuCount < 1 {
 		cpuCount = 1
 	}
+
 	return &Server{
-		Sourcegraph:     sg,
-		IndexDir:        conf.index,
-		Interval:        conf.interval,
-		VacuumInterval:  conf.vacuumInterval,
-		MergeInterval:   conf.mergeInterval,
-		CPUCount:        cpuCount,
-		TargetSizeBytes: conf.targetSize * 1024 * 1024,
-		minSizeBytes:    conf.minSize * 1024 * 1024,
-		shardMerging:    zoekt.ShardMergingEnabled(),
+		Sourcegraph:                     sg,
+		IndexDir:                        conf.index,
+		Interval:                        conf.interval,
+		VacuumInterval:                  conf.vacuumInterval,
+		MergeInterval:                   conf.mergeInterval,
+		CPUCount:                        cpuCount,
+		TargetSizeBytes:                 conf.targetSize * 1024 * 1024,
+		minSizeBytes:                    conf.minSize * 1024 * 1024,
+		shardMerging:                    zoekt.ShardMergingEnabled(),
+		deltaBuildRepositoriesAllowList: deltaBuildRepositoriesAllowList,
 	}, err
 }
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -570,7 +570,7 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 		return nil, nil, nil, nil, fmt.Errorf("delta builds currently don't support submodule indexing")
 	}
 
-	existingRepository, ok, err := options.BuildOptions.RepositoryMetadata()
+	existingRepository, ok, err := options.BuildOptions.FindRepositoryMetadata()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get repository metadata: %w", err)
 	}

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -574,12 +574,11 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 		return nil, nil, nil, nil, fmt.Errorf("no existing shards found for repository")
 	}
 
-	// Check to see if the branch set is consistent with what we last indexed.
+	// Check to see if the set of branch names is consistent with what we last indexed.
 	// If it isn't consistent, that we can't proceed with a delta build (and the caller should fall back to a
 	// normal one).
 
-	indexState := build.CompareBranches(existingRepository.Branches, options.BuildOptions.RepositoryDescription.Branches)
-	if !(indexState == build.IndexStateBranchVersion || indexState == build.IndexStateEqual) {
+	if !build.BranchNamesEqual(existingRepository.Branches, options.BuildOptions.RepositoryDescription.Branches) {
 		var existingBranchNames []string
 		for _, b := range existingRepository.Branches {
 			existingBranchNames = append(existingBranchNames, b.Name)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -422,10 +422,15 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 	var branchVersions map[string]map[string]plumbing.Hash
 
 	if opts.BuildOptions.IsDelta {
-		repos, branchMap, branchVersions, opts.BuildOptions.ChangedOrRemovedFiles, err = prepareDeltaBuild(opts, repo)
+		var changedOrRemovedFiles []string
+		repos, branchMap, branchVersions, changedOrRemovedFiles, err = prepareDeltaBuild(opts, repo)
 		if err != nil {
 			log.Printf("(delta build) falling back to normal build since delta build failed, repository=%q, err=%s", opts.BuildOptions.RepositoryDescription.Name, err)
 			opts.BuildOptions.IsDelta = false
+		} else {
+			for _, f := range changedOrRemovedFiles {
+				opts.BuildOptions.MarkFileAsChangedOrRemoved(f)
+			}
 		}
 	}
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -579,7 +579,7 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 	// normal one).
 
 	indexState := build.CompareBranches(existingRepository.Branches, options.BuildOptions.RepositoryDescription.Branches)
-	if indexState != build.IndexStateBranchVersion {
+	if !(indexState == build.IndexStateBranchVersion || indexState == build.IndexStateEqual) {
 		var existingBranchNames []string
 		for _, b := range existingRepository.Branches {
 			existingBranchNames = append(existingBranchNames, b.Name)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -564,12 +564,12 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 		return nil, nil, nil, nil, fmt.Errorf("delta builds currently don't support submodule indexing")
 	}
 
-	existingRepository, err := options.BuildOptions.RepositoryMetadata()
+	existingRepository, ok, err := options.BuildOptions.RepositoryMetadata()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get repository metadata: %w", err)
 	}
 
-	if existingRepository == nil {
+	if !ok {
 		return nil, nil, nil, nil, fmt.Errorf("no existing shards found for repository")
 	}
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -425,7 +425,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 		var changedOrRemovedFiles []string
 		repos, branchMap, branchVersions, changedOrRemovedFiles, err = prepareDeltaBuild(opts, repo)
 		if err != nil {
-			log.Printf("(delta build) falling back to normal build since delta build failed, repository=%q, err=%s", opts.BuildOptions.RepositoryDescription.Name, err)
+			log.Printf("delta build: falling back to normal build since delta build failed, repository=%q, err=%s", opts.BuildOptions.RepositoryDescription.Name, err)
 			opts.BuildOptions.IsDelta = false
 		} else {
 			for _, f := range changedOrRemovedFiles {

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -560,6 +560,10 @@ type gitIndexConfig struct {
 func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[fileKey]BlobLocation, branchMap map[fileKey][]string, branchVersions map[string]map[string]plumbing.Hash, changedOrDeletedPaths []string, err error) {
 	// discover what commits we indexed during our last build
 
+	if options.Submodules {
+		return nil, nil, nil, nil, fmt.Errorf("delta builds currently don't support submodule indexing")
+	}
+
 	existingRepository, err := options.BuildOptions.RepositoryMetadata()
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to get repository metadata: %w", err)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -597,9 +597,6 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 	// fileKey => branches
 	branchMap = map[fileKey][]string{}
 
-	// Branch => Repo => SHA1
-	//branchVersions := map[string]map[string]plumbing.Hash{}
-
 	// branch name -> git worktree at most current commit
 	branchToCurrentTree := make(map[string]*object.Tree, len(options.Branches))
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -352,10 +352,7 @@ func expandBranches(repo *git.Repository, bs []string, prefix string) ([]string,
 
 // IndexGitRepo indexes the git repository as specified by the options.
 func IndexGitRepo(opts Options) error {
-	return indexGitRepo(opts, gitIndexConfig{
-		prepareDeltaBuild:  prepareDeltaBuild,
-		prepareNormalBuild: prepareNormalBuild,
-	})
+	return indexGitRepo(opts, gitIndexConfig{})
 }
 
 // indexGitRepo indexes the git repository as specified by the options and the provided gitIndexConfig.

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -320,12 +320,6 @@ func TestIndexDeltaBasic(t *testing.T) {
 				},
 			},
 		},
-		// TODO@ggilmore: I'm a bit torn as to whether or not these
-		// fallback tests should be here or in their own separate test.
-		//
-		// I can see arguments for both (whether or not it a delta build)
-		// is an internal detail from the perspective of the caller, but it's
-		// also externally observable (from the shards that are produced).
 		{
 			name:     "should fallback to normal build if no prior shards exist",
 			branches: []string{"main"},

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -380,8 +380,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 
 					// run test
 					err := indexGitRepo(options, gitIndexConfig{
-						prepareDeltaBuildMetadata:  prepareDeltaSpy,
-						prepareNormalBuildMetadata: prepareNormalSpy,
+						prepareDeltaBuild:  prepareDeltaSpy,
+						prepareNormalBuild: prepareNormalSpy,
 					})
 					if err != nil {
 						t.Fatalf("IndexGitRepo: %s", err)

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -15,14 +15,24 @@
 package gitindex
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"testing"
 
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
+	"github.com/google/zoekt/query"
+	"github.com/google/zoekt/shards"
 )
 
 func TestIndexEmptyRepo(t *testing.T) {
@@ -52,5 +62,392 @@ func TestIndexEmptyRepo(t *testing.T) {
 
 	if err := IndexGitRepo(opts); err != nil {
 		t.Fatalf("IndexGitRepo: %v", err)
+	}
+}
+
+func TestIndexDeltaBasic(t *testing.T) {
+	type branchToDocumentMap map[string][]zoekt.Document
+
+	type step struct {
+		name             string
+		addedDocuments   branchToDocumentMap
+		deletedDocuments branchToDocumentMap
+		optFn            func(t *testing.T, options *Options)
+
+		expectedFallbackToNormalBuild bool
+		expectedDocuments             []zoekt.Document
+	}
+
+	helloWorld := zoekt.Document{Name: "hello_world.txt", Content: []byte("hello")}
+
+	fruitV1 := zoekt.Document{Name: "best_fruit.txt", Content: []byte("strawberry")}
+	fruitV1WithNewName := fruitV1
+	fruitV1WithNewName.Name = "new_fruit.txt"
+
+	fruitV2 := zoekt.Document{Name: "best_fruit.txt", Content: []byte("grapes")}
+	fruitV3 := zoekt.Document{Name: "best_fruit.txt", Content: []byte("oranges")}
+	fruitV4 := zoekt.Document{Name: "best_fruit.txt", Content: []byte("apples")}
+
+	foo := zoekt.Document{Name: "foo.txt", Content: []byte("bar")}
+
+	for _, test := range []struct {
+		name     string
+		branches []string
+		steps    []step
+	}{
+		{
+			name:     "modification",
+			branches: []string{"main"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{helloWorld, fruitV1},
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV1},
+				},
+				{
+					name: "add newer version of fruits",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV2},
+					},
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV2},
+				},
+			},
+		},
+		{
+			name:     "addition",
+			branches: []string{"main"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{helloWorld, fruitV1},
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV1},
+				},
+				{
+					name: "add new file - foo",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{foo},
+					},
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV1, foo},
+				},
+			},
+		},
+		{
+			name:     "deletion",
+			branches: []string{"main"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{helloWorld, fruitV1, foo},
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV1, foo},
+				},
+				{
+					name:           "delete foo file",
+					addedDocuments: nil,
+					deletedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{foo},
+					},
+
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{helloWorld, fruitV1},
+				},
+			},
+		},
+		{
+			name:     "addition and deletion on only one branch",
+			branches: []string{"main", "release", "dev"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main":    []zoekt.Document{fruitV1},
+						"release": []zoekt.Document{fruitV2},
+						"dev":     []zoekt.Document{fruitV3},
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV1, fruitV2, fruitV3},
+				},
+				{
+					name: "replace fruits v3 with v4 on 'dev', delete fruits on 'main'",
+					addedDocuments: branchToDocumentMap{
+						"dev": []zoekt.Document{fruitV4},
+					},
+					deletedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1},
+					},
+
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV2, fruitV4},
+				},
+			},
+		},
+		{
+			name:     "rename",
+			branches: []string{"main", "release"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main":    []zoekt.Document{fruitV1},
+						"release": []zoekt.Document{fruitV2},
+					},
+					expectedDocuments: []zoekt.Document{fruitV1, fruitV2},
+				},
+				{
+					name: "rename fruits file on main branch",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1WithNewName},
+					},
+					deletedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1},
+					},
+
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV1WithNewName, fruitV2},
+				},
+			},
+		},
+		// TODO@ggilmore: I'm a bit torn as to whether or not these
+		// fallback tests should be here or in their own separate test.
+		//
+		// I can see arguments for both (whether or not it a delta build)
+		// is an internal detail from the perspective of the caller, but it's
+		// also externally observable (from the shards that are produced).
+		{
+			name:     "should fallback to normal build if no prior shards exist",
+			branches: []string{"main"},
+			steps: []step{
+				{
+					name: "attempt delta build on a repository that hasn't been indexed yet",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{helloWorld},
+					},
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedFallbackToNormalBuild: true,
+					expectedDocuments:             []zoekt.Document{helloWorld},
+				},
+			},
+		},
+		{
+			name:     "should fallback to normal build if the set of requested repository branches changes on",
+			branches: []string{"main", "release", "dev"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main":    []zoekt.Document{fruitV1},
+						"release": []zoekt.Document{fruitV2},
+						"dev":     []zoekt.Document{fruitV3},
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV1, fruitV2, fruitV3},
+				},
+				{
+					name: "try delta build after dropping 'main' branch from index",
+					addedDocuments: branchToDocumentMap{
+						"release": []zoekt.Document{fruitV4},
+					},
+					optFn: func(t *testing.T, options *Options) {
+						options.Branches = []string{"HEAD", "release", "dev"} // a bit of a hack to override it this way, but it gets the job done
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedFallbackToNormalBuild: true,
+					expectedDocuments:             []zoekt.Document{fruitV3, fruitV4},
+				},
+			},
+		},
+	} {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexDir := t.TempDir()
+			repositoryDir := t.TempDir()
+
+			runScript(t, repositoryDir, "git init")
+			runScript(t, repositoryDir, fmt.Sprintf("git config user.email %q", "you@example.com"))
+			runScript(t, repositoryDir, fmt.Sprintf("git config user.name %q", "Your Name"))
+
+			for _, b := range test.branches {
+				runScript(t, repositoryDir, fmt.Sprintf("git checkout -b %q", b))
+				runScript(t, repositoryDir, fmt.Sprintf("git commit --allow-empty -m %q", "empty commit"))
+			}
+
+			for _, step := range test.steps {
+				t.Run(step.name, func(t *testing.T) {
+					for _, b := range test.branches {
+						hadChange := false
+
+						runScript(t, repositoryDir, fmt.Sprintf("git checkout %q", b))
+
+						for _, d := range step.deletedDocuments[b] {
+							hadChange = true
+
+							err := os.Remove(filepath.Join(repositoryDir, d.Name))
+							if err != nil {
+								t.Fatalf("deleting file %q: %s", d.Name, err)
+							}
+
+							runScript(t, repositoryDir, fmt.Sprintf("git add %q", d.Name))
+						}
+
+						for _, d := range step.addedDocuments[b] {
+							hadChange = true
+
+							err := os.WriteFile(filepath.Join(repositoryDir, d.Name), d.Content, 0644)
+							if err != nil {
+								t.Fatalf("writing file %q: %s", d.Name, err)
+							}
+
+							runScript(t, repositoryDir, fmt.Sprintf("git add %q", d.Name))
+						}
+
+						if !hadChange {
+							continue
+						}
+
+						runScript(t, repositoryDir, fmt.Sprintf("git commit -m %q", step.name))
+					}
+
+					buildOptions := build.Options{
+						IndexDir: indexDir,
+						RepositoryDescription: zoekt.Repository{
+							Name: "repository",
+						},
+						IsDelta: false,
+					}
+					buildOptions.SetDefaults()
+
+					branches := append([]string{"HEAD"}, test.branches...)
+
+					options := Options{
+						RepoDir:      filepath.Join(repositoryDir, ".git"),
+						BuildOptions: buildOptions,
+						Branches:     branches,
+					}
+
+					if step.optFn != nil {
+						step.optFn(t, &options)
+					}
+
+					deltaBuildCalled := false
+					prepareDeltaSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobLocation, branchMap map[fileKey][]string, branchVersions map[string]map[string]plumbing.Hash, changedOrDeletedPaths []string, err error) {
+						deltaBuildCalled = true
+						return prepareDeltaBuild(options, repository)
+					}
+
+					normalBuildCalled := false
+					prepareNormalSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobLocation, branchMap map[fileKey][]string, branchVersions map[string]map[string]plumbing.Hash, err error) {
+						normalBuildCalled = true
+						return prepareNormalBuild(options, repository)
+					}
+
+					err := indexGitRepo(options, gitIndexConfig{
+						prepareDeltaBuildMetadata:  prepareDeltaSpy,
+						prepareNormalBuildMetadata: prepareNormalSpy,
+					})
+					if err != nil {
+						t.Fatalf("IndexGitRepo: %s", err)
+					}
+
+					if options.BuildOptions.IsDelta != deltaBuildCalled {
+						// We should always try a delta build if we request it in the options.
+						t.Fatalf("expected deltaBuildCalled to be %t, got %t", options.BuildOptions.IsDelta, deltaBuildCalled)
+					}
+
+					if options.BuildOptions.IsDelta && (step.expectedFallbackToNormalBuild != normalBuildCalled) {
+						// We only check the normal spy on delta builds because it's only considered a "fallback" if we
+						// asked for a delta build in the first place.
+						t.Fatalf("expected normalBuildCalled to be %t, got %t", step.expectedFallbackToNormalBuild, normalBuildCalled)
+					}
+
+					ss, err := shards.NewDirectorySearcher(indexDir)
+					if err != nil {
+						t.Fatalf("NewDirectorySearcher(%s): %s", indexDir, err)
+					}
+					defer ss.Close()
+
+					searchOpts := &zoekt.SearchOptions{Whole: true}
+					result, err := ss.Search(context.Background(), &query.Const{Value: true}, searchOpts)
+					if err != nil {
+						t.Fatalf("Search: %s", err)
+					}
+
+					var receivedDocuments []zoekt.Document
+					for _, f := range result.Files {
+						receivedDocuments = append(receivedDocuments, zoekt.Document{
+							Name:    f.FileName,
+							Content: f.Content,
+						})
+					}
+
+					for _, docs := range [][]zoekt.Document{step.expectedDocuments, receivedDocuments} {
+						sort.Slice(docs, func(i, j int) bool {
+							a, b := docs[i], docs[j]
+
+							// first compare names, then fallback to contents if the names are equal
+
+							if a.Name < b.Name {
+								return true
+							}
+
+							if a.Name > b.Name {
+								return false
+							}
+
+							return bytes.Compare(a.Content, b.Content) < 0
+						})
+					}
+
+					if diff := cmp.Diff(step.expectedDocuments, receivedDocuments, cmpopts.IgnoreFields(zoekt.Document{}, "Branches")); diff != "" {
+						t.Errorf("diff in received documents (-want +got):%s\n:", diff)
+					}
+				})
+			}
+		})
+	}
+}
+
+func runScript(t *testing.T, cwd string, script string) {
+	err := os.MkdirAll(cwd, 0755)
+	if err != nil {
+		t.Fatalf("ensuring path %q exists: %s", cwd, err)
+	}
+
+	cmd := exec.Command("sh", "-euxc", script)
+	cmd.Dir = cwd
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("execution error: %v, output %s", err, out)
 	}
 }

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -216,7 +216,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 					expectedDocuments: []zoekt.Document{fruitV1, fruitV2},
 				},
 				{
-					name: "rename fruits file on main branch",
+					name: "rename fruits file on 'main' + ensure that unmodified fruits file on 'release' is still searchable",
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{fruitV1WithNewName},
 					},
@@ -271,7 +271,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 					expectedDocuments: []zoekt.Document{fruitV1, fruitV2, fruitV3},
 				},
 				{
-					name: "try delta build after dropping 'main' branch from index",
+					name: "try delta build after dropping 'main' branch from index ",
 					addedDocuments: branchToDocumentMap{
 						"release": []zoekt.Document{fruitV4},
 					},

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -259,6 +259,36 @@ func TestIndexDeltaBasic(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "no-op delta builds (reindexing the same commits)",
+			branches: []string{"main", "dev"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1, foo},
+						"dev":  []zoekt.Document{helloWorld},
+					},
+					expectedDocuments: []zoekt.Document{fruitV1, foo, helloWorld},
+				},
+				{
+					name: "first no-op (normal build -> delta build)",
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV1, foo, helloWorld},
+				},
+				{
+					name: "second no-op (delta build -> delta build)",
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV1, foo, helloWorld},
+				},
+			},
+		},
 		// TODO@ggilmore: I'm a bit torn as to whether or not these
 		// fallback tests should be here or in their own separate test.
 		//

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -127,19 +127,19 @@ func TestIndexDeltaBasic(t *testing.T) {
 			},
 		},
 		{
-			name:     "modification in nested folder",
+			name:     "modification only inside nested folder",
 			branches: []string{"main"},
 			steps: []step{
 				{
 					name: "setup",
 					addedDocuments: branchToDocumentMap{
-						"main": []zoekt.Document{fruitV1InFolder},
+						"main": []zoekt.Document{foo, fruitV1InFolder},
 					},
 
-					expectedDocuments: []zoekt.Document{fruitV1InFolder},
+					expectedDocuments: []zoekt.Document{foo, fruitV1InFolder},
 				},
 				{
-					name: "add newer version of fruits",
+					name: "add newer version of fruits inside folder",
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{fruitV2InFolder},
 					},
@@ -147,7 +147,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 						options.BuildOptions.IsDelta = true
 					},
 
-					expectedDocuments: []zoekt.Document{fruitV2InFolder},
+					expectedDocuments: []zoekt.Document{foo, fruitV2InFolder},
 				},
 			},
 		},

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -257,7 +257,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 			},
 		},
 		{
-			name:     "should fallback to normal build if the set of requested repository branches changes on",
+			name:     "should fallback to normal build if the set of requested repository branches changes",
 			branches: []string{"main", "release", "dev"},
 			steps: []step{
 				{

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -232,6 +232,33 @@ func TestIndexDeltaBasic(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "modification: update one branch with version of document from another branch (a.k.a. Keegan's test)",
+			branches: []string{"main", "dev"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1},
+						"dev":  []zoekt.Document{fruitV2},
+					},
+					expectedDocuments: []zoekt.Document{fruitV1, fruitV2},
+				},
+				{
+					name: "switch main to dev's older version of fruits + bump dev's fruits to new version",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV2},
+						"dev":  []zoekt.Document{fruitV3},
+					},
+
+					optFn: func(t *testing.T, options *Options) {
+						options.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{fruitV2, fruitV3},
+				},
+			},
+		},
 		// TODO@ggilmore: I'm a bit torn as to whether or not these
 		// fallback tests should be here or in their own separate test.
 		//


### PR DESCRIPTION
Closes https://github.com/sourcegraph/zoekt/pull/259 

`zoekt-git-index` now supports a new CLI argument `-delta`. 

If this flag is provided, `zoekt-git-index` will first attempt to build the requested repository using the new delta shard strategy described in https://github.com/sourcegraph/sourcegraph/issues/29731. If this attempt fails , it will automatically fall back to try a "normal" (non-delta) build.

--- 

Note: This PR pulls in https://github.com/sourcegraph/zoekt/pull/259 as part of its changes, since looking up RepositoryMetadata() in this fashion is now a common operation. 