### PR TITLE
zoekt-sourcegraph-indexserver: add support for preparing delta builds behind a feature flag 

### DIFF
--- a/api.go
+++ b/api.go
@@ -245,6 +245,10 @@ type RepositoryBranch struct {
 	Version string
 }
 
+func (r RepositoryBranch) String() string {
+	return fmt.Sprintf("%s@%s", r.Name, r.Version)
+}
+
 // Repository holds repository metadata.
 type Repository struct {
 	// Sourcergaph's repository ID

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -232,22 +232,18 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 		// Try fetching prior commits for delta builds
 		// If we're unable to fetch prior commits, we continue anyway
 		// knowing that zoekt-git-index will fall back to a "full" normal build
-
-		var priorCommits []string
-
 		existingRepository, found, err := findRepositoryMetadata(o)
 		if err != nil {
 			return fmt.Errorf("delta build: failed to get repository metadata: %w", err)
 		}
 
-		if found {
+		if found && len(existingRepository.Branches) > 0 {
+			var priorCommits []string
 			for _, b := range existingRepository.Branches {
 				priorCommits = append(priorCommits, b.Version)
 			}
-		}
 
-		if len(priorCommits) > 0 {
-			err = fetchCommits(priorCommits)
+			err := fetchCommits(priorCommits)
 			if err != nil {
 				repositoryName := buildOptions.RepositoryDescription.Name
 				repositoryID := buildOptions.RepositoryDescription.ID

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -73,10 +73,6 @@ type indexArgs struct {
 	// FileLimit is the maximum size of a file
 	FileLimit int
 
-	// DownloadLimitMBPS is the maximum MB/s to use when downloading the
-	// archive.
-	DownloadLimitMBPS string
-
 	// UseDelta is true if we want to use the new delta indexer. This should
 	// only be true for repositories we explicitly enable.
 	UseDelta bool

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -277,7 +277,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 		}
 	}
 
-	// create git gitConfiguration with options
+	// create git configuration with options
 	type configKV struct{ Key, Value string }
 	config := []configKV{{
 		// zoekt.name is used by zoekt-git-index to set the repository name.
@@ -291,7 +291,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 		return config[i].Key < config[j].Key
 	})
 
-	// write gitConfiguration to repo
+	// write git configuration to repo
 	for _, kv := range config {
 		cmd = exec.CommandContext(ctx, "git", "-C", gitDir, "config", "zoekt."+kv.Key, kv.Value)
 		cmd.Stdin = &bytes.Buffer{}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -237,7 +237,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 
 		existingRepository, found, err := findRepositoryMetadata(o)
 		if err != nil {
-			return fmt.Errorf("(delta build) failed to get repository metadata: %w", err)
+			return fmt.Errorf("delta build: failed to get repository metadata: %w", err)
 		}
 
 		if found {
@@ -257,7 +257,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 					formattedCommits = append(formattedCommits, fmt.Sprintf("%s@%s", b.Name, b.Version))
 				}
 
-				log.Printf("(delta build) failed to prepare delta build for %q (ID %d): failed to fetch prior commits (%s): %s", repositoryName, repositoryID, strings.Join(formattedCommits, ", "), err)
+				log.Printf("delta build: failed to prepare delta build for %q (ID %d): failed to fetch prior commits (%s): %s", repositoryName, repositoryID, strings.Join(formattedCommits, ", "), err)
 			}
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -196,6 +196,9 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 	}()
 
 	var fetchCommits = func(commits []string) error {
+		// We shallow fetch each commit specified in zoekt.Branches. This requires
+		// the server to have configured both uploadpack.allowAnySHA1InWant and
+		// uploadpack.allowFilter. (See gitservice.go in the Sourcegraph repository)
 		fetchArgs := []string{"-C", gitDir, "-c", "protocol.version=2", "fetch", "--depth=1", o.CloneURL}
 		fetchArgs = append(fetchArgs, commits...)
 
@@ -215,9 +218,6 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 		return nil
 	}
 
-	// We shallow fetch each commit specified in zoekt.Branches. This requires
-	// the server to have configured both uploadpack.allowAnySHA1InWant and
-	// uploadpack.allowFilter. (See gitservice.go in the Sourcegraph repository)
 	var branchCommits []string
 	for _, b := range o.Branches {
 		branchCommits = append(branchCommits, b.Version)

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -203,12 +203,11 @@ func TestIndex(t *testing.T) {
 	}, {
 		name: "delta",
 		args: indexArgs{
-			Incremental:       true,
-			IndexDir:          "/data/index",
-			Parallelism:       4,
-			FileLimit:         123,
-			DownloadLimitMBPS: "1000",
-			UseDelta:          true,
+			Incremental: true,
+			IndexDir:    "/data/index",
+			Parallelism: 4,
+			FileLimit:   123,
+			UseDelta:    true,
 			IndexOptions: IndexOptions{
 				RepoID:     0,
 				Name:       "test/repo",

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -122,7 +122,7 @@ func TestIndex(t *testing.T) {
 	cases := []struct {
 		name                      string
 		args                      indexArgs
-		mockGetRepositoryMetadata func(args *indexArgs) (*zoekt.Repository, error)
+		mockGetRepositoryMetadata func(args *indexArgs) (*zoekt.Repository, bool, error)
 		want                      []string
 	}{{
 		name: "minimal",
@@ -221,7 +221,7 @@ func TestIndex(t *testing.T) {
 				},
 			},
 		},
-		mockGetRepositoryMetadata: func(args *indexArgs) (*zoekt.Repository, error) {
+		mockGetRepositoryMetadata: func(args *indexArgs) (*zoekt.Repository, bool, error) {
 			return &zoekt.Repository{
 				ID:   0,
 				Name: args.IndexOptions.Name,
@@ -230,7 +230,7 @@ func TestIndex(t *testing.T) {
 					{Name: "dev", Version: "olddev"},
 					{Name: "release", Version: "oldrelease"},
 				},
-			}, nil
+			}, true, nil
 		},
 		want: []string{
 			"git -c init.defaultBranch=nonExistentBranchBB0FOFCH32 init --bare $TMPDIR/test%2Frepo.git",

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -472,7 +472,7 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	repositoryName := args.Name
 	if _, ok := s.deltaBuildRepositoriesAllowList[repositoryName]; ok {
 		repositoryID := args.BuildOptions().RepositoryDescription.ID
-		debug.Printf("(delta build) Server.Index: marking %q (ID %d) for delta build", repositoryName, repositoryID)
+		debug.Printf("delta build: Server.Index: marking %q (ID %d) for delta build", repositoryName, repositoryID)
 
 		args.UseDelta = true
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -511,9 +511,14 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	c := gitIndexConfig{
 		runCmd: func(cmd *exec.Cmd) error {
 			return s.loggedRun(tr, cmd)
-		}}
+		},
 
-	return indexStateSuccess, gitIndex(args, c)
+		findRepositoryMetadata: func(args *indexArgs) (repository *zoekt.Repository, ok bool, err error) {
+			return args.BuildOptions().FindRepositoryMetadata()
+		},
+	}
+
+	return indexStateSuccess, gitIndex(c, args)
 }
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -165,6 +165,10 @@ type Server struct {
 
 	// If true, shard merging is enabled.
 	shardMerging bool
+
+	// deltaBuildRepositoriesAllowList is an allowlist for repositories that we
+	// use delta-builds for instead of normal builds
+	deltaBuildRepositoriesAllowList map[string]struct{}
 }
 
 var debug = log.New(ioutil.Discard, "", log.LstdFlags)
@@ -465,13 +469,23 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		return indexStateEmpty, createEmptyShard(args)
 	}
 
+	repositoryName := args.Name
+	if _, ok := s.deltaBuildRepositoriesAllowList[repositoryName]; ok {
+		repositoryID := args.BuildOptions().RepositoryDescription.ID
+		debug.Printf("(delta build) Server.Index: marking %q (ID %d) for delta build", repositoryName, repositoryID)
+
+		args.UseDelta = true
+	}
+
 	reason := "forced"
+
 	if args.Incremental {
 		bo := args.BuildOptions()
 		bo.SetDefaults()
 		incrementalState, fn := bo.IndexState()
 		reason = string(incrementalState)
 		metricIndexIncrementalIndexState.WithLabelValues(string(incrementalState)).Inc()
+
 		switch incrementalState {
 		case build.IndexStateEqual:
 			debug.Printf("%s index already up to date. Shard=%s", args.String(), fn)
@@ -493,9 +507,13 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 
 	log.Printf("updating index %s reason=%s", args.String(), reason)
 
-	runCmd := func(cmd *exec.Cmd) error { return s.loggedRun(tr, cmd) }
 	metricIndexingTotal.Inc()
-	return indexStateSuccess, gitIndex(args, runCmd)
+	c := gitIndexConfig{
+		runCmd: func(cmd *exec.Cmd) error {
+			return s.loggedRun(tr, cmd)
+		}}
+
+	return indexStateSuccess, gitIndex(args, c)
 }
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
@@ -722,6 +740,17 @@ func getEnvWithDefaultString(k string, defaultVal string) string {
 	return v
 }
 
+func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, v := range strings.Split(os.Getenv(k), ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			set[v] = struct{}{}
+		}
+	}
+	return set
+}
+
 func setCompoundShardCounter(indexDir string) {
 	fns, err := filepath.Glob(filepath.Join(indexDir, "compound-*.zoekt"))
 	if err != nil {
@@ -843,22 +872,24 @@ func newServer(conf rootConfig) (*Server, error) {
 		debug = log.New(os.Stderr, "", log.LstdFlags)
 	}
 
-	indexingMetricsReposAllowlist := os.Getenv("INDEXING_METRICS_REPOS_ALLOWLIST")
-	if indexingMetricsReposAllowlist != "" {
+	reposWithSeparateIndexingMetrics = getEnvWithDefaultEmptySet("INDEXING_METRICS_REPOS_ALLOWLIST")
+	if len(reposWithSeparateIndexingMetrics) > 0 {
 		var repos []string
-
-		for _, r := range strings.Split(indexingMetricsReposAllowlist, ",") {
-			r = strings.TrimSpace(r)
-			if r != "" {
-				repos = append(repos, r)
-			}
+		for r := range reposWithSeparateIndexingMetrics {
+			repos = append(repos, r)
 		}
 
-		for _, r := range repos {
-			reposWithSeparateIndexingMetrics[r] = struct{}{}
+		debug.Printf("capturing separate indexing metrics for: %s", strings.Join(repos, ", "))
+	}
+
+	deltaBuildRepositoriesAllowList := getEnvWithDefaultEmptySet("DELTA_BUILD_REPOS_ALLOWLIST")
+	if len(deltaBuildRepositoriesAllowList) > 0 {
+		var repos []string
+		for r := range deltaBuildRepositoriesAllowList {
+			repos = append(repos, r)
 		}
 
-		debug.Printf("capturing separate indexing metrics for: %s", repos)
+		debug.Printf("using delta shard builds for: %s", strings.Join(repos, ", "))
 	}
 
 	var sg Sourcegraph
@@ -890,16 +921,18 @@ func newServer(conf rootConfig) (*Server, error) {
 	if cpuCount < 1 {
 		cpuCount = 1
 	}
+
 	return &Server{
-		Sourcegraph:     sg,
-		IndexDir:        conf.index,
-		Interval:        conf.interval,
-		VacuumInterval:  conf.vacuumInterval,
-		MergeInterval:   conf.mergeInterval,
-		CPUCount:        cpuCount,
-		TargetSizeBytes: conf.targetSize * 1024 * 1024,
-		minSizeBytes:    conf.minSize * 1024 * 1024,
-		shardMerging:    zoekt.ShardMergingEnabled(),
+		Sourcegraph:                     sg,
+		IndexDir:                        conf.index,
+		Interval:                        conf.interval,
+		VacuumInterval:                  conf.vacuumInterval,
+		MergeInterval:                   conf.mergeInterval,
+		CPUCount:                        cpuCount,
+		TargetSizeBytes:                 conf.targetSize * 1024 * 1024,
+		minSizeBytes:                    conf.minSize * 1024 * 1024,
+		shardMerging:                    zoekt.ShardMergingEnabled(),
+		deltaBuildRepositoriesAllowList: deltaBuildRepositoriesAllowList,
 	}, err
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -756,6 +756,15 @@ func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
 	return set
 }
 
+func joinStringSet(set map[string]struct{}, sep string) string {
+	var xs []string
+	for x := range set {
+		xs = append(xs, x)
+	}
+
+	return strings.Join(xs, sep)
+}
+
 func setCompoundShardCounter(indexDir string) {
 	fns, err := filepath.Glob(filepath.Join(indexDir, "compound-*.zoekt"))
 	if err != nil {
@@ -879,22 +888,12 @@ func newServer(conf rootConfig) (*Server, error) {
 
 	reposWithSeparateIndexingMetrics = getEnvWithDefaultEmptySet("INDEXING_METRICS_REPOS_ALLOWLIST")
 	if len(reposWithSeparateIndexingMetrics) > 0 {
-		var repos []string
-		for r := range reposWithSeparateIndexingMetrics {
-			repos = append(repos, r)
-		}
-
-		debug.Printf("capturing separate indexing metrics for: %s", strings.Join(repos, ", "))
+		debug.Printf("capturing separate indexing metrics for: %s", joinStringSet(reposWithSeparateIndexingMetrics, ", "))
 	}
 
 	deltaBuildRepositoriesAllowList := getEnvWithDefaultEmptySet("DELTA_BUILD_REPOS_ALLOWLIST")
 	if len(deltaBuildRepositoriesAllowList) > 0 {
-		var repos []string
-		for r := range deltaBuildRepositoriesAllowList {
-			repos = append(repos, r)
-		}
-
-		debug.Printf("using delta shard builds for: %s", strings.Join(repos, ", "))
+		debug.Printf("using delta shard builds for: %s", joinStringSet(deltaBuildRepositoriesAllowList, ", "))
 	}
 
 	var sg Sourcegraph


### PR DESCRIPTION
Stacks on top of https://github.com/sourcegraph/zoekt/pull/310

This PR adds an environment variable named `DELTA_BUILD_REPOS_ALLOWLIST`, which is a comma separated list of repositories that zoekt should try using the new delta build strategy for (as described in https://github.com/sourcegraph/sourcegraph/issues/29731).

For all such repositories, `zoekt-sourcegraph-indeserver` will now fetch both the current branch commits and the commits that were used to generate the shards from the most recent index. If any aspect of this process fails (such as if those older commits are no longer available), `zoekt-sourcegraph-indexserver` will still proceed. However, it'll rely on `zoekt-git-index` to fall back to a "normal" build.