### PR TITLE
feature flag lazy runeDocSection decoding

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -16,6 +16,7 @@ package zoekt
 
 import (
 	"encoding/binary"
+	"log"
 	"sort"
 	"unicode"
 	"unicode/utf8"
@@ -187,6 +188,7 @@ func unmarshalDocSections(in []byte, buf []DocumentSection) (secs []DocumentSect
 	// Defensive, this shouldn't happen. While we have the feature flag for lazy
 	// doc section decoding lets be extra defensive.
 	if len(in) == 0 {
+		log.Println("WARN unmarshalDocSections received an empty slice to unmarshal")
 		return nil
 	}
 

--- a/bits.go
+++ b/bits.go
@@ -184,6 +184,12 @@ func marshalDocSections(secs []DocumentSection) []byte {
 }
 
 func unmarshalDocSections(in []byte, buf []DocumentSection) (secs []DocumentSection) {
+	// Defensive, this shouldn't happen. While we have the feature flag for lazy
+	// doc section decoding lets be extra defensive.
+	if len(in) == 0 {
+		return nil
+	}
+
 	// TODO - ints is unnecessary garbage here.
 	ints := fromSizedDeltas(in, nil)
 	if cap(buf) >= len(ints)/2 {

--- a/index_test.go
+++ b/index_test.go
@@ -1115,7 +1115,7 @@ func TestListRepos(t *testing.T) {
 			Stats: RepoStats{
 				Shards:                     1,
 				Documents:                  4,
-				IndexBytes:                 308,
+				IndexBytes:                 300,
 				ContentBytes:               68,
 				NewLinesCount:              4,
 				DefaultBranchNewLinesCount: 2,

--- a/indexdata.go
+++ b/indexdata.go
@@ -41,7 +41,8 @@ type indexData struct {
 	docSectionsStart uint32
 	docSectionsIndex []uint32
 
-	runeDocSections []byte
+	runeDocSections    []DocumentSection
+	runeDocSectionsRaw []byte
 
 	// rune offset=>byte offset mapping, relative to the start of the content corpus
 	runeOffsets runeOffsetMap

--- a/matchtree.go
+++ b/matchtree.go
@@ -889,12 +889,19 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 		}
 
 		if substr, ok := subMT.(*substrMatchTree); ok {
+			// Temporary: We have a feature flag for lazy decoding. If
+			// runeDocSections is nil it means we need to lazily decode on request.
+			sections := d.runeDocSections
+			if sections == nil {
+				sections = unmarshalDocSections(d.runeDocSectionsRaw, nil)
+			}
+
 			return &symbolSubstrMatchTree{
 				substrMatchTree: substr,
 				patternSize:     uint32(utf8.RuneCountInString(substr.query.Pattern)),
 				fileEndRunes:    d.fileEndRunes,
 				fileEndSymbol:   d.fileEndSymbol,
-				sections:        unmarshalDocSections(d.runeDocSections, nil),
+				sections:        sections,
 			}, nil
 		}
 

--- a/read.go
+++ b/read.go
@@ -340,7 +340,12 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.runeDocSections = blob
+
+	if os.Getenv("ZOEKT_DISABLE_LAZY_DOC_SECTIONS") == "" {
+		d.runeDocSectionsRaw = blob
+	} else {
+		d.runeDocSections = unmarshalDocSections(blob, nil)
+	}
 
 	var runeOffsets, fileNameRuneOffsets []uint32
 


### PR DESCRIPTION
Currently this takes up 30% of production CPU. We are unsure if its worth the tradeoff so we will experiment with enabling vs disabling and measure the impact.

We default to the current behaviour. To disable you set the environment variable ZOEKT_DISABLE_LAZY_DOC_SECTIONS to a non empty value.

Test Plan: locally run zoekt-webserver with and without the feature flag. With the feature flag we should have higher memory usage. Ensure in both cases symbol search works.
