### PR TITLE
ranking: add test for scoring based on ctags

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -228,26 +228,25 @@ type finishedShard struct {
 	temp, final string
 }
 
+func checkCTags() string {
+	if ctags := os.Getenv("CTAGS_COMMAND"); ctags != "" {
+		return ctags
+	}
+
+	if ctags, err := exec.LookPath("universal-ctags"); err == nil {
+		return ctags
+	}
+
+	if ctags, err := exec.LookPath("ctags-exuberant"); err == nil {
+		return ctags
+	}
+	return ""
+}
+
 // SetDefaults sets reasonable default options.
 func (o *Options) SetDefaults() {
 	if o.CTags == "" {
-		if ctags := os.Getenv("CTAGS_COMMAND"); ctags != "" {
-			o.CTags = ctags
-		}
-	}
-
-	if o.CTags == "" {
-		ctags, err := exec.LookPath("universal-ctags")
-		if err == nil {
-			o.CTags = ctags
-		}
-	}
-
-	if o.CTags == "" {
-		ctags, err := exec.LookPath("ctags-exuberant")
-		if err == nil {
-			o.CTags = ctags
-		}
+		o.CTags = checkCTags()
 	}
 
 	if o.Parallelism == 0 {

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -789,9 +789,12 @@ func TestDeltaShards(t *testing.T) {
 }
 
 // With this test we want to capture regressions in the names returned by our
-// language detection. We rely on the detected language and its spelling, for
-// example, in scoring (see scoreKind).
-func TestDetectLanguage(t *testing.T) {
+// language detection and the scores assigned to file matches. We rely on the
+// detected language and its spelling, for example, in scoring (see scoreKind).
+func TestScoring(t *testing.T) {
+	if checkCTags() == "" {
+		t.Skip("ctags not available")
+	}
 	dir := t.TempDir()
 
 	opts := Options{
@@ -804,7 +807,9 @@ func TestDetectLanguage(t *testing.T) {
 	cases := []struct {
 		fileName     string
 		content      []byte
+		query        query.Q
 		wantLanguage string
+		wantScore    float64
 	}{
 		{
 			fileName: "hw.java",
@@ -817,7 +822,10 @@ public class HelloWorld
        }
 }
 `),
+			query:        &query.Substring{Content: true, Pattern: "lloWorld"},
 			wantLanguage: "Java",
+			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
+			wantScore: 6960,
 		},
 	}
 
@@ -840,13 +848,17 @@ public class HelloWorld
 			}
 			defer ss.Close()
 
-			srs, err := ss.Search(context.Background(), &query.Const{true}, new(zoekt.SearchOptions))
+			srs, err := ss.Search(context.Background(), c.query, new(zoekt.SearchOptions))
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if got, want := len(srs.Files), 1; got != want {
 				t.Fatalf("file matches: want %d, got %d", want, got)
+			}
+
+			if got := srs.Files[0].Score; got != c.wantScore {
+				t.Fatalf("score: want %f, got %f", c.wantScore, got)
 			}
 
 			if got := srs.Files[0].Language; got != c.wantLanguage {

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -792,7 +792,7 @@ func TestDeltaShards(t *testing.T) {
 // language detection and the scores assigned to file matches. We rely on the
 // detected language and its spelling, for example, in scoring (see scoreKind).
 func TestScoring(t *testing.T) {
-	if checkCTags() == "" {
+	if os.Getenv("CI") == "" && checkCTags() == "" {
 		t.Skip("ctags not available")
 	}
 	dir := t.TempDir()

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -348,7 +348,10 @@ func scoreKind(language string, kind string) float64 {
 	switch language {
 	case "Java":
 		switch kind {
-		case "c": // classes
+		// 2022-03-30 go-ctags contains a regex rule for Java classes that sets kind to
+		// "classes" instead of "c". We have to cover both cases to support existing
+		// indexes.
+		case "c", "classes":
 			return scoreKindMatch
 		}
 	}

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -348,8 +348,8 @@ func scoreKind(language string, kind string) float64 {
 	switch language {
 	case "Java":
 		switch kind {
-		// 2022-03-30 go-ctags contains a regex rule for Java classes that sets kind to
-		// "classes" instead of "c". We have to cover both cases to support existing
+		// 2022-03-30: go-ctags contains a regex rule for Java classes that sets "kind"
+		// to "classes" instead of "c". We have to cover both cases to support existing
 		// indexes.
 		case "c", "classes":
 			return scoreKindMatch


### PR DESCRIPTION
Now that we have ctags available on CI we can add tests that check
regressions of our scoring.