### PR TITLE
implement queue debug command

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
@@ -154,10 +153,6 @@ func debugListIndexed() *ffcli.Command {
 func debugQueue() *ffcli.Command {
 	fs := flag.NewFlagSet("debug queue", flag.ExitOnError)
 
-	printHeader := fs.Bool("header", true, "print column headers")
-
-	connectionTimeout := fs.Duration("timeout", 10*time.Second, "max timeout for establishing a connection to the zoekt-sourcegraph-indexserver instance")
-
 	hostname := fs.String("hostname", "localhost", "the hostname of the zoekt-sourcegraph-indexserver instance to connect to")
 	port := fs.Uint("port", 6072, "the port of the zoekt-sourcegraph-indexserver instance to connect to")
 
@@ -167,15 +162,12 @@ func debugQueue() *ffcli.Command {
 		ShortHelp:  "list the repositories in the indexing queue, sorted by descending priority",
 		FlagSet:    fs,
 		Exec: func(ctx context.Context, args []string) error {
-			ctx, cancel := context.WithTimeout(ctx, *connectionTimeout)
-			defer cancel()
 
 			raw := fmt.Sprintf("http://%s:%d/debug/queue", *hostname, *port)
 			address, err := url.Parse(raw)
 			if err != nil {
 				return fmt.Errorf("parsing URL %q: %s", raw, err)
 			}
-			address.Query().Add("header", strconv.FormatBool(*printHeader))
 
 			request, err := http.NewRequestWithContext(ctx, http.MethodGet, address.String(), nil)
 			if err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -212,7 +212,7 @@ func debugQueue() *ffcli.Command {
 			defer writer.Flush()
 
 			if printHeader {
-				_, err := fmt.Fprintf(writer, "Position\tName\tID\tBranches\n")
+				_, err := fmt.Fprintf(writer, "Position\tName\tID\tBranches\t\n")
 				if err != nil {
 					return fmt.Errorf("writing headers to output: %w", err)
 				}
@@ -228,7 +228,7 @@ func debugQueue() *ffcli.Command {
 					branches = append(branches, b.String())
 				}
 
-				_, err := fmt.Fprintf(writer, "%d\t%s\t%d\t%s\n", position, item.Opts.Name, item.RepoID, strings.Join(branches, ", "))
+				_, err := fmt.Fprintf(writer, "%d\t%s\t%d\t%s\t\n", position, item.Opts.Name, item.RepoID, strings.Join(branches, ", "))
 				if err != nil {
 					return fmt.Errorf("writing entry to stdout: %w", err)
 				}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -169,8 +169,6 @@ type Server struct {
 	// deltaBuildRepositoriesAllowList is an allowlist for repositories that we
 	// use delta-builds for instead of normal builds
 	deltaBuildRepositoriesAllowList map[string]struct{}
-
-	httpHandlersRegisteredOnce sync.Once
 }
 
 var debug = log.New(ioutil.Discard, "", log.LstdFlags)
@@ -554,10 +552,8 @@ func createEmptyShard(args *indexArgs) error {
 }
 
 func (s *Server) AddHandlers(mux *http.ServeMux) {
-	s.httpHandlersRegisteredOnce.Do(func() {
-		mux.Handle("/", http.HandlerFunc(s.handleHTTPRoot))
-		mux.Handle("/debug/queue", http.HandlerFunc(s.queue.handleDebugQueue))
-	})
+	mux.Handle("/", http.HandlerFunc(s.handleHTTPRoot))
+	mux.Handle("/debug/queue", http.HandlerFunc(s.queue.handleDebugQueue))
 }
 
 var repoTmpl = template.Must(template.New("name").Parse(`

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"container/heap"
-	"encoding/gob"
 	"fmt"
-	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -364,27 +362,6 @@ func lessQueueItemPriority(x, y *queueItem) bool {
 
 	// tiebreaker is to prefer the item added to the queue first
 	return x.seq < y.seq
-}
-
-// queueItemStreamDecoder processes streams of gob-encoded queueItems.
-type queueItemStreamDecoder struct {
-	gobDecoder *gob.Decoder
-	item       *queueItem
-
-	err error
-}
-
-// newQueueItemStreamDecoder returns a decoder that will process the provided
-// stream.
-func newQueueItemStreamDecoder(stream io.Reader) *queueItemStreamDecoder {
-	d := gob.NewDecoder(stream)
-
-	return &queueItemStreamDecoder{
-		gobDecoder: d,
-
-		item: nil,
-		err:  nil,
-	}
 }
 
 var (

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -173,31 +172,17 @@ func (q *Queue) handleDebugQueue(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/plain")
 
-	printHeaders := true
-	if raw := r.URL.Query().Get("header"); raw != "" {
-		parsed, err := strconv.ParseBool(raw)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("invalid %q parameter: %s", "header", err), http.StatusBadRequest)
-			return
-		}
-
-		printHeaders = parsed
-	}
-
 	var bufferedWriter bytes.Buffer
 
 	writer := tabwriter.NewWriter(&bufferedWriter, 16, 8, 4, ' ', 0)
 
-	if printHeaders {
-		_, err := fmt.Fprintf(writer, "Position\tName\tID\tIsOnQueue\tBranches\t\n")
-		if err != nil {
-			http.Error(w, fmt.Sprintf("writing column headers: %s", err), http.StatusInternalServerError)
-			return
-		}
+	_, err := fmt.Fprintf(writer, "Position\tName\tID\tIsOnQueue\tBranches\t\n")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("writing column headers: %s", err), http.StatusInternalServerError)
+		return
 	}
 
 	position := -1
-	var err error
 	q.debugIteratedOrdered(func(item *queueItem) {
 		position++
 

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -215,6 +215,8 @@ type streamQueueReply struct {
 	ErrorString string
 }
 
+const gobStreamContentType = "application/x-gob-stream"
+
 func (q *Queue) handleDebugQueue(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method must be GET", http.StatusBadRequest)
@@ -222,12 +224,12 @@ func (q *Queue) handleDebugQueue(w http.ResponseWriter, r *http.Request) {
 	}
 
 	desiredContentType := r.Header.Get("Accept")
-	if desiredContentType != "application/x-gob-stream" {
+	if desiredContentType != gobStreamContentType {
 		http.Error(w, fmt.Sprintf("unsupported content type: %q", desiredContentType), http.StatusBadRequest)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/x-gob-stream")
+	w.Header().Set("Content-Type", gobStreamContentType)
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Transfer-Encoding", "chunked")

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -228,22 +228,9 @@ type pqueue []*queueItem
 func (pq pqueue) Len() int { return len(pq) }
 
 func (pq pqueue) Less(i, j int) bool {
-	// If we know x needs an update and y doesn't, then return true. Otherwise
-	// they are either equal priority or y is more urgent.
 	x := pq[i]
 	y := pq[j]
-	if x.indexed != y.indexed {
-		return !x.indexed
-	}
-
-	if xFail, yFail := x.indexState == indexStateFail, y.indexState == indexStateFail; xFail != yFail {
-		// if you failed to index, you are likely to fail again. So prefer
-		// non-failed.
-		return !xFail
-	}
-
-	// tie breaker is to prefer the item added to the queue first
-	return x.seq < y.seq
+	return lessQueueItem(x, y)
 }
 
 func (pq pqueue) Swap(i, j int) {
@@ -266,6 +253,24 @@ func (pq *pqueue) Pop() interface{} {
 	item.heapIdx = -1
 	*pq = old[0 : n-1]
 	return item
+}
+
+//
+func lessQueueItem(x, y *queueItem) bool {
+	// If we know x needs an update and y doesn't, then return true. Otherwise
+	// they are either equal priority or y is more urgent.
+	if x.indexed != y.indexed {
+		return !x.indexed
+	}
+
+	if xFail, yFail := x.indexState == indexStateFail, y.indexState == indexStateFail; xFail != yFail {
+		// if you failed to index, you are likely to fail again. So prefer
+		// non-failed.
+		return !xFail
+	}
+
+	// tie breaker is to prefer the item added to the queue first
+	return x.seq < y.seq
 }
 
 var (

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -180,7 +180,7 @@ func TestQueue_Integration_DebugQueue(t *testing.T) {
 	actualOutput := normalizeDebugOutput(string(raw))
 
 	expectedOutput := `
-Position        Name            ID              IsPending       Branches
+Position        Name            ID              IsOnQueue       Branches
 0               item-1          1               true            HEAD@stillQueued
 1               item-0          0               false           HEAD@popped
 `

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -120,6 +120,32 @@ func TestQueue_Bump(t *testing.T) {
 	}
 }
 
+func TestQueue_GobListSorted(t *testing.T) {
+	queue := &Queue{}
+
+	numRepositories := 100
+	repositories := make([]IndexOptions, numRepositories)
+
+	for i := 0; i < numRepositories; i++ {
+		repositories[i] = mkHEADIndexOptions(i, strconv.Itoa(i))
+	}
+
+	for _, r := range repositories {
+		queue.AddOrUpdate(r)
+	}
+
+	for _, test := range []struct {
+		name  string
+		items []IndexOptions
+	}{} {
+		t.Run(test.name, func(t *testing.T) {
+			queue := &Queue{}
+
+			queue.AddOrUpdate()
+		})
+	}
+}
+
 func mkHEADIndexOptions(id int, version string) IndexOptions {
 	return IndexOptions{
 		RepoID:   uint32(id),

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -159,14 +158,8 @@ func TestQueue_Integration_DebugQueue(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(queue.handleDebugQueue))
 	defer server.Close()
 
-	// setup: add the ?header=true query parameter to ensure that we fetch column headers
-	address, _ := url.Parse(server.URL)
-	params := address.Query()
-	params.Set("header", "true")
-	address.RawQuery = params.Encode()
-
 	// test: send a request to the queue's debug endpoint
-	response, err := http.Get(address.String())
+	response, err := http.Get(server.URL)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}


### PR DESCRIPTION
While debugging an issue, @stefanhengl and I both found it quite difficult to understand what the contents of the zoekt index queue were, and where in the queue a given repository might be. 

This PR implements two things:

- A new `/debug/queue` route that exposes route that retrieves every queue entry in sorted order
- A new `zoekt-sourcegraph-indexserver debug queue` command that uses the above to produce the following output:
   - [![asciicast](https://asciinema.org/a/t1cGM3dF3USLcSa44RxZecwE1.svg)](https://asciinema.org/a/t1cGM3dF3USLcSa44RxZecwE1)
   - (note the brief change in the queue ordering after I make a new commit)

```
❯ zoekt-sourcegraph-indexserver debug queue --help                                                                                                   12:19:30
USAGE
  queue [flags]

FLAGS
  -header=true         print column headers
  -hostname localhost  the hostname of the zoekt-sourcegraph-indexserver instance to connect to
  -port 6072           the port of the zoekt-sourcegraph-indexserver instance to connect to
  -timeout 10s         max timeout for establishing a connection to the zoekt-sourcegraph-indexserver instance
```


