### PR TITLE
disable bloom filters by default

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -105,8 +105,8 @@ func TestBloomSkip(t *testing.T) {
 		{false, 1},
 		{true, 0},
 	} {
-		if tc.skip {
-			os.Setenv("ZOEKT_DISABLE_BLOOM", "1")
+		if !tc.skip {
+			os.Setenv("ZOEKT_ENABLE_BLOOM", "1")
 		}
 		b := testIndexBuilder(t, nil,
 			Document{Name: "f1", Content: []byte("reader derre errea")},
@@ -116,7 +116,7 @@ func TestBloomSkip(t *testing.T) {
 			t.Errorf("bloom disabled=%v filtered out %v shards, want %v",
 				tc.skip, res.Stats.ShardsSkippedFilter, tc.want)
 		}
-		os.Unsetenv("ZOEKT_DISABLE_BLOOM")
+		os.Unsetenv("ZOEKT_ENABLE_BLOOM")
 	}
 }
 

--- a/read.go
+++ b/read.go
@@ -294,7 +294,7 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	if os.Getenv("ZOEKT_DISABLE_BLOOM") == "" {
+	if os.Getenv("ZOEKT_ENABLE_BLOOM") != "" {
 		d.bloomContents, err = d.readBloom(toc.contentBloom)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We experimentally disabled bloom filters in production and didn't notice
a measureable difference in performance. However, bloom filters do cost
memory both at indexing and serving time. This commit is the first step
to removing them. The plan is to disable by default. If we have no
negative feedback / metrics then in a month or two we can remove bloom
filters being generated.

Previously we had the feature flag ZOEKT_DISABLE_BLOOM. This has now
been renamed to ZOEKT_ENABLE_BLOOM and inverted.

Test Plan: go test