### PR TITLE
queue.go: correctly update dateAddedToQueue field when item is reinserted via Bump()

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -124,6 +124,8 @@ func (q *Queue) Bump(ids []uint32) []uint32 {
 		} else if item.heapIdx < 0 {
 			q.seq++
 			item.seq = q.seq
+			item.dateAddedToQueue = time.Now()
+
 			heap.Push(&q.pq, item)
 			metricQueueLen.Set(float64(len(q.pq)))
 			metricQueueCap.Set(float64(len(q.items)))


### PR DESCRIPTION
Follow up to https://github.com/sourcegraph/zoekt/pull/324 which didn't account for this case.