### PR TITLE
incremental-indexing: add rudimentary compaction strategy (fallback after n shards)

### DIFF
--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -37,6 +37,7 @@ func main() {
 		"this is used to find repositories for submodules. "+
 		"It also affects name if the indexed repository is under this directory.")
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
+	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", gitindex.DefaultDeltaShardNumberFallbackThreshold, "upper limit on the number of preexisting shards that can exist before attempting a delta build")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
@@ -79,14 +80,15 @@ func main() {
 	for dir, name := range gitRepos {
 		opts.RepositoryDescription.Name = name
 		gitOpts := gitindex.Options{
-			BranchPrefix:       *branchPrefix,
-			Incremental:        *incremental,
-			Submodules:         *submodules,
-			RepoCacheDir:       *repoCacheDir,
-			AllowMissingBranch: *allowMissing,
-			BuildOptions:       *opts,
-			Branches:           branches,
-			RepoDir:            dir,
+			BranchPrefix:                      *branchPrefix,
+			Incremental:                       *incremental,
+			Submodules:                        *submodules,
+			RepoCacheDir:                      *repoCacheDir,
+			AllowMissingBranch:                *allowMissing,
+			BuildOptions:                      *opts,
+			Branches:                          branches,
+			RepoDir:                           dir,
+			DeltaShardNumberFallbackThreshold: *deltaShardNumberFallbackThreshold,
 		}
 
 		if err := gitindex.IndexGitRepo(gitOpts); err != nil {

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -37,7 +37,7 @@ func main() {
 		"this is used to find repositories for submodules. "+
 		"It also affects name if the indexed repository is under this directory.")
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
-	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", gitindex.DefaultDeltaShardNumberFallbackThreshold, "upper limit on the number of preexisting shards that can exist before attempting a delta build")
+	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -76,6 +76,10 @@ type indexArgs struct {
 	// UseDelta is true if we want to use the new delta indexer. This should
 	// only be true for repositories we explicitly enable.
 	UseDelta bool
+
+	// DeltaShardNumberFallbackThreshold is an upper limit on the number of preexisting shards that can exist
+	// before attempting a delta build.
+	DeltaShardNumberFallbackThreshold uint64
 }
 
 // BuildOptions returns a build.Options represented by indexArgs. Note: it
@@ -312,6 +316,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 
 	if o.UseDelta {
 		args = append(args, "-delta")
+		args = append(args, "-delta_threshold", strconv.FormatUint(o.DeltaShardNumberFallbackThreshold, 10))
 	}
 
 	args = append(args, buildOptions.Args()...)

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -220,6 +220,7 @@ func TestIndex(t *testing.T) {
 					{Name: "release", Version: "12345678"},
 				},
 			},
+			DeltaShardNumberFallbackThreshold: 22,
 		},
 		mockRepositoryMetadata: &zoekt.Repository{
 			ID:   0,
@@ -244,7 +245,7 @@ func TestIndex(t *testing.T) {
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.public 0",
 			"git -C $TMPDIR/test%2Frepo.git config zoekt.repoid 0",
 			"zoekt-git-index -submodules=false -incremental -branches HEAD,dev,release " +
-				"-delta -file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
+				"-delta -delta_threshold 22 -file_limit 123 -parallelism 4 -index /data/index -require_ctags -large_file foo -large_file bar " +
 				"$TMPDIR/test%2Frepo.git",
 		},
 	}}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -481,6 +481,8 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		args.UseDelta = true
 	}
 
+	args.DeltaShardNumberFallbackThreshold = s.deltaShardNumberFallbackThreshold
+
 	reason := "forced"
 
 	if args.Incremental {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -733,7 +733,7 @@ func getEnvWithDefaultUint64(k string, defaultVal uint64) uint64 {
 	if v == "" {
 		return defaultVal
 	}
-	i, err := strconv.ParseUint(k, 10, 64)
+	i, err := strconv.ParseUint(v, 10, 64)
 	if err != nil {
 		log.Fatalf("error parsing ENV %s to uint64: %s", k, err)
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -27,7 +27,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/google/zoekt/gitindex"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/keegancsmith/tmpfriend"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -900,8 +899,12 @@ func newServer(conf rootConfig) (*Server, error) {
 		debug.Printf("using delta shard builds for: %s", joinStringSet(deltaBuildRepositoriesAllowList, ", "))
 	}
 
-	deltaShardNumberFallbackThreshold := getEnvWithDefaultUint64("DELTA_SHARD_NUMBER_FALLBACK_THRESHOLD", gitindex.DefaultDeltaShardNumberFallbackThreshold)
-	debug.Printf("setting delta shard fallback threshold to %d shard(s)", deltaShardNumberFallbackThreshold)
+	deltaShardNumberFallbackThreshold := getEnvWithDefaultUint64("DELTA_SHARD_NUMBER_FALLBACK_THRESHOLD", 150)
+	if deltaShardNumberFallbackThreshold > 0 {
+		debug.Printf("setting delta shard fallback threshold to %d shard(s)", deltaShardNumberFallbackThreshold)
+	} else {
+		debug.Printf("disabling delta build fallback behavior - delta builds will be performed regardless of the number of preexisting shards")
+	}
 
 	var sg Sourcegraph
 	if rootURL.IsAbs() {

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -274,8 +274,6 @@ func SetTemplatesFromOrigin(desc *zoekt.Repository, u *url.URL) error {
 	}
 }
 
-const DefaultDeltaShardNumberFallbackThreshold uint64 = 150
-
 // The Options structs controls details of the indexing process.
 type Options struct {
 	// The repository to be indexed.
@@ -307,8 +305,8 @@ type Options struct {
 	// that can exist before attempting another delta build. If the number of preexisting shards exceeds this threshold,
 	// then a normal build will be performed instead.
 	//
-	// If DeltaShardNumberFallbackThreshold is 0, then the default threshold defined by
-	// gitindex.DefaultDeltaShardNumberFallbackThreshold will be used instead.
+	// If DeltaShardNumberFallbackThreshold is 0, then this fallback behavior is disabled:
+	// a delta build will always be performed regardless of the number of preexisting shards.
 	DeltaShardNumberFallbackThreshold uint64
 }
 
@@ -593,20 +591,19 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 		return nil, nil, nil, nil, fmt.Errorf("no existing shards found for repository")
 	}
 
-	if options.DeltaShardNumberFallbackThreshold == 0 {
-		options.DeltaShardNumberFallbackThreshold = DefaultDeltaShardNumberFallbackThreshold
-	}
+	if options.DeltaShardNumberFallbackThreshold > 0 {
+		// HACK: For our interim compaction strategy, we force a full normal index once
+		// the number of shards on disk for this repository exceeds the provided threshold.
+		//
+		// This strategy obviously isn't optimal (as an example: we currently can't differentiate
+		// between "normal" and "delta" shards, so repositories like the gigarepo that generate a large number of shards per
+		// build would be disproportionately affected by this), but it'll allow us to continue experimenting on real workloads
+		// while we create a better compaction strategy).
 
-	// HACK: For our interim compaction strategy, we force a full normal index once
-	// the number of shards on disk for this repository exceeds the provided threshold.
-	//
-	// This strategy obviously isn't optimal (as an example: we currently can't differentiate
-	// between "normal" and "delta" shards, so repositories like the gigarepo that generate a large number of shards per
-	// build would be disproportionately affected by this), but it'll allow us to continue experimenting on real workloads
-	// while we create a better compaction strategy).
-	oldShards := options.BuildOptions.FindAllShards()
-	if uint64(len(oldShards)) > options.DeltaShardNumberFallbackThreshold {
-		return nil, nil, nil, nil, fmt.Errorf("number of existing shards (%d) > requested shard threshold (%d)", len(oldShards), options.DeltaShardNumberFallbackThreshold)
+		oldShards := options.BuildOptions.FindAllShards()
+		if uint64(len(oldShards)) > options.DeltaShardNumberFallbackThreshold {
+			return nil, nil, nil, nil, fmt.Errorf("number of existing shards (%d) > requested shard threshold (%d)", len(oldShards), options.DeltaShardNumberFallbackThreshold)
+		}
 	}
 
 	// Check to see if the set of branch names is consistent with what we last indexed.

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -118,8 +118,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{fruitV2},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{helloWorld, fruitV2},
@@ -143,8 +143,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{fruitV2InFolder},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{foo, fruitV2InFolder},
@@ -168,8 +168,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{foo},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{helloWorld, fruitV1, foo},
@@ -195,8 +195,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 						"main": []zoekt.Document{foo},
 					},
 
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{helloWorld, fruitV1},
@@ -226,8 +226,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 						"main": []zoekt.Document{fruitV1},
 					},
 
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{fruitV2, fruitV4},
@@ -255,8 +255,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 						"main": []zoekt.Document{fruitV1},
 					},
 
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{fruitV1WithNewName, fruitV2},
@@ -282,8 +282,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 						"dev":  []zoekt.Document{fruitV3},
 					},
 
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{fruitV2, fruitV3},
@@ -304,16 +304,16 @@ func TestIndexDeltaBasic(t *testing.T) {
 				},
 				{
 					name: "first no-op (normal build -> delta build)",
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{fruitV1, foo, helloWorld},
 				},
 				{
 					name: "second no-op (delta build -> delta build)",
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedDocuments: []zoekt.Document{fruitV1, foo, helloWorld},
@@ -329,8 +329,8 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{helloWorld},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedFallbackToNormalBuild: true,
@@ -357,9 +357,9 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"release": []zoekt.Document{fruitV4},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.Branches = []string{"HEAD", "release", "dev"} // a bit of a hack to override it this way, but it gets the job done
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.Branches = []string{"HEAD", "release", "dev"} // a bit of a hack to override it this way, but it gets the job done
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedFallbackToNormalBuild: true,
@@ -384,12 +384,61 @@ func TestIndexDeltaBasic(t *testing.T) {
 					addedDocuments: branchToDocumentMap{
 						"main": []zoekt.Document{sourcegraphIgnoreWithContent},
 					},
-					optFn: func(t *testing.T, options *Options) {
-						options.BuildOptions.IsDelta = true
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
 					},
 
 					expectedFallbackToNormalBuild: true,
 					expectedDocuments:             []zoekt.Document{sourcegraphIgnoreWithContent},
+				},
+			},
+		},
+		{
+			name:     "should fallback to a full, normal build if the repository has more than the specified threshold of shards",
+			branches: []string{"main"},
+			steps: []step{
+				{
+					name: "setup: first shard",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{foo},
+					},
+
+					expectedDocuments: []zoekt.Document{foo},
+				},
+				{
+					name: "setup: second shard (delta)",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV1},
+					},
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{foo, fruitV1},
+				},
+				{
+					name: "setup: third shard (delta)",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{helloWorld},
+					},
+					optFn: func(t *testing.T, o *Options) {
+						o.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []zoekt.Document{foo, fruitV1, helloWorld},
+				},
+				{
+					name: "attempt another delta build after we already blew past the shard threshold",
+					addedDocuments: branchToDocumentMap{
+						"main": []zoekt.Document{fruitV2InFolder},
+					},
+					optFn: func(t *testing.T, o *Options) {
+						o.DeltaShardNumberFallbackThreshold = 2
+						o.BuildOptions.IsDelta = true
+					},
+
+					expectedFallbackToNormalBuild: true,
+					expectedDocuments:             []zoekt.Document{foo, fruitV1, helloWorld, fruitV2InFolder},
 				},
 			},
 		},


### PR DESCRIPTION
This PR implements a rudimentary compaction strategy for incremental-indexing: simply fallback to a normal build if the  number of preexisting shards exceeds some pre-configured threshold (defined by the `DELTA_SHARD_NUMBER_FALLBACK_THRESHOLD` environment variable).  

This strategy obviously isn't ideal for a number of reasons:

- immediately falling back to a full, normal build can cause a huge variation in indexing times (minutes instead of milliseconds)
- using a fixed threshold doesn't allow us to make nuanced decisions about when to perform compaction (taking into account factors like commit rate, etc.) 
- in this implementation, repositories that have a large number of base shards (like the gigarepo that has ~50 shards on dogfood) would experience a disproportionate number of fallbacks (compared to smaller repositories) 

Despite these drawbacks, using this stop-gap compaction strategy will allow us to safely enable incremental-indexing on huge monorepos with high commit rates (gigarepo):

- an upper bound on the number of delta shards bounds the worst-case memory impact on search-perf 
- we get an error-recovery mechanism for free (since we re-index every file when we fallback + delete all the old shards)

This will allow us to get better data about how incremental-indexing perfoms, which will help inform what our long-term compaction strategy should be. 