### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -196,11 +196,7 @@ func retryTest(t *testing.T, f func(fatalf func(format string, args ...interface
 }
 
 func TestLargeFileOption(t *testing.T) {
-	dir, err := ioutil.TempDir("", "large_files_test")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	sizeMax := 1000
 	opts := Options{
@@ -252,11 +248,7 @@ func TestLargeFileOption(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := Options{
 		IndexDir: dir,
@@ -349,11 +341,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDeleteOldShards(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := Options{
 		IndexDir: dir,
@@ -436,11 +424,7 @@ func TestDeleteOldShards(t *testing.T) {
 }
 
 func TestPartialSuccess(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := Options{
 		IndexDir:    dir,
@@ -550,11 +534,7 @@ func TestFileRank(t *testing.T) {
 }
 
 func TestEmptyContent(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := Options{
 		IndexDir: dir,

--- a/cmd/zoekt-archive-index/e2e_test.go
+++ b/cmd/zoekt-archive-index/e2e_test.go
@@ -96,11 +96,7 @@ func TestIndexIncrementally(t *testing.T) {
 }
 
 func testIndexIncrementally(t *testing.T, format string) {
-	indexdir, err := ioutil.TempDir("", "TestIndexArg-index")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(indexdir)
+	indexdir := t.TempDir()
 	archive, err := ioutil.TempFile("", "TestIndexArg-archive")
 	if err != nil {
 		t.Fatalf("TempFile: %v", err)

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -114,11 +114,7 @@ func TestCleanup(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "TestCleanup")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			// Create index files
 			var fs []shard
@@ -221,11 +217,7 @@ func TestRemoveIncompleteShards(t *testing.T) {
 	}
 	sort.Strings(shards)
 
-	dir, err := ioutil.TempDir("", "TestRemoveIncompleteShards")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	for _, shard := range append(shards, incomplete...) {
 		_, err := os.Create(filepath.Join(dir, shard))

--- a/gitindex/clone_test.go
+++ b/gitindex/clone_test.go
@@ -15,8 +15,6 @@
 package gitindex
 
 import (
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -24,11 +22,7 @@ import (
 )
 
 func TestSetRemote(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	script := `mkdir orig
 cd orig
 git init

--- a/gitindex/delete_test.go
+++ b/gitindex/delete_test.go
@@ -1,20 +1,14 @@
 package gitindex
 
 import (
-	"io/ioutil"
 	"net/url"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 )
 
 func TestDeleteRepos(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Error("createSubmoduleRepo", err)

--- a/gitindex/ignore_test.go
+++ b/gitindex/ignore_test.go
@@ -3,7 +3,6 @@ package gitindex
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,21 +49,13 @@ git update-ref refs/meta/config HEAD
 }
 
 func TestIgnore(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSourcegraphignoreRepo(dir); err != nil {
 		t.Fatalf("createSourcegraphignoreRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,11 +36,7 @@ import (
 )
 
 func TestIndexEmptyRepo(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	cmd := exec.Command("git", "init", "-b", "master", "repo")
 	cmd.Dir = tmp

--- a/gitindex/repocache_test.go
+++ b/gitindex/repocache_test.go
@@ -15,9 +15,7 @@
 package gitindex
 
 import (
-	"io/ioutil"
 	"net/url"
-	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -36,11 +34,7 @@ func TestListReposNonExistent(t *testing.T) {
 }
 
 func TestListRepos(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	if err := createSubmoduleRepo(tmp); err != nil {
 		t.Fatalf("createSubmoduleRepo %v", err)
 	}

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -99,11 +98,7 @@ EOF
 }
 
 func TestFindGitRepos(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Error("createSubmoduleRepo", err)
@@ -138,11 +133,7 @@ func TestFindGitRepos(t *testing.T) {
 }
 
 func TestTreeToFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Fatalf("TempDir: %v", err)
@@ -195,21 +186,13 @@ func TestTreeToFiles(t *testing.T) {
 }
 
 func TestSubmoduleIndex(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Fatalf("createSubmoduleRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,
@@ -307,21 +290,13 @@ EOF
 }
 
 func TestSearchSymlinkByContent(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSymlinkRepo(dir); err != nil {
 		t.Fatalf("createSubmoduleRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,
@@ -372,20 +347,12 @@ func TestSearchSymlinkByContent(t *testing.T) {
 }
 
 func TestAllowMissingBranch(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Fatalf("createSubmoduleRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,
@@ -445,21 +412,13 @@ git update-ref refs/meta/config HEAD
 }
 
 func TestBranchWildcard(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createMultibranchRepo(dir); err != nil {
 		t.Fatalf("createMultibranchRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,
@@ -499,21 +458,13 @@ func TestBranchWildcard(t *testing.T) {
 }
 
 func TestSkipSubmodules(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
 		t.Fatalf("createMultibranchRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,
@@ -539,21 +490,13 @@ func TestSkipSubmodules(t *testing.T) {
 }
 
 func TestFullAndShortRefNames(t *testing.T) {
-	dir, err := ioutil.TempDir("", "git")
-	if err != nil {
-		t.Fatalf("TempDir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := createMultibranchRepo(dir); err != nil {
 		t.Fatalf("createMultibranchRepo: %v", err)
 	}
 
-	indexDir, err := ioutil.TempDir("", "index-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.RemoveAll(indexDir)
+	indexDir := t.TempDir()
 
 	buildOpts := build.Options{
 		IndexDir: indexDir,

--- a/shards/watcher_test.go
+++ b/shards/watcher_test.go
@@ -47,11 +47,7 @@ func advanceFS() {
 }
 
 func TestDirWatcherUnloadOnce(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logger := &loggingLoader{
 		loads: make(chan string, 10),
@@ -114,10 +110,7 @@ func TestDirWatcherUnloadOnce(t *testing.T) {
 }
 
 func TestDirWatcherLoadEmpty(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	logger := &loggingLoader{
 		loads: make(chan string, 10),
@@ -178,10 +171,7 @@ func TestVersionFromPath(t *testing.T) {
 }
 
 func TestDirWatcherLoadLatest(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	logger := &loggingLoader{
 		loads: make(chan string, 10),


### PR DESCRIPTION
A testing cleanup.

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir