### PR TITLE
queue.go: add prometheus metric for tracking the amount of time a repository spent in the queue

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -65,10 +65,15 @@ func (q *Queue) Pop() (opts IndexOptions, ok bool) {
 
 	item := heap.Pop(&q.pq).(*queueItem)
 	opts = item.opts
-	item.dateAddedToQueue = time.Unix(0, 0)
 
 	metricQueueLen.Set(float64(len(q.pq)))
 	metricQueueCap.Set(float64(len(q.items)))
+
+	name := repoNameForMetric(opts.Name)
+	age := time.Since(item.dateAddedToQueue)
+	metricQueueAge.WithLabelValues(name).Observe(age.Seconds())
+
+	item.dateAddedToQueue = time.Unix(0, 0)
 
 	q.mu.Unlock()
 	return opts, true
@@ -391,4 +396,25 @@ var (
 		Name: "index_queue_cap",
 		Help: "The number of repositories tracked by the index queue, including popped items. Should be the same as index_num_assigned.",
 	})
+	metricQueueAge = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "index_queue_age_seconds",
+		Help: "A histogram of the amount of time a popped repository spent sitting in the queue beforehand.",
+		Buckets: []float64{
+			60,     // 1m
+			300,    // 5m
+			1200,   // 20m
+			2400,   // 40m
+			3600,   // 1h
+			10800,  // 3h
+			18000,  // 5h
+			36000,  // 10h
+			43200,  // 12h
+			54000,  // 15h
+			72000,  // 20h
+			86400,  // 24h
+			108000, // 30h
+			126000, // 35h
+			172800, // 48h
+		},
+	}, []string{"name"}) // name=name of the repository that was just popped from the queue
 )


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C023ELQLV7F/p1650037236875689?thread_ts=1649941550.692219&cid=C023ELQLV7F

On sourcegraph.com, we see evidence indicating repositories are spending large amounts of time (20+ hours) in the indexing queue. Adding a new Prometheus metric that tracks this field will allow us to create Grafana dashboards. Both of these can help enable us to dig into this issue further. 