### PR TITLE
indexserver: increase resolution of index_repo_seconds metric

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -23,7 +23,7 @@ import (
 
 // indexTimeout defines how long the indexserver waits before
 // killing an indexing job.
-const indexTimeout = 1 * time.Hour // an index should never take longer than an hour.
+const indexTimeout = 1*time.Hour + 30*time.Minute // an index should never take longer than an hour and a half
 
 // IndexOptions are the options that Sourcegraph can set via it's search
 // configuration endpoint.

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -21,6 +21,10 @@ import (
 	"github.com/google/zoekt/build"
 )
 
+// indexTimeout defines how long the indexserver waits before
+// killing an indexing job.
+const indexTimeout = 1 * time.Hour // an index should never take longer than an hour.
+
 // IndexOptions are the options that Sourcegraph can set via it's search
 // configuration endpoint.
 type IndexOptions struct {
@@ -162,8 +166,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs) error {
 
 	buildOptions := o.BuildOptions()
 
-	// An index should never take longer than an hour.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), indexTimeout)
 	defer cancel()
 
 	gitDir, err := tmpGitDir(o.Name)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -64,9 +64,12 @@ var (
 	})
 
 	metricIndexDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "index_repo_seconds",
-		Help:    "A histogram of latencies for indexing a repository.",
-		Buckets: prometheus.ExponentialBucketsRange((100 * time.Millisecond).Seconds(), (5*time.Minute + indexTimeout).Seconds(), 15),
+		Name: "index_repo_seconds",
+		Help: "A histogram of latencies for indexing a repository.",
+		Buckets: prometheus.ExponentialBucketsRange(
+			(100 * time.Millisecond).Seconds(),
+			(40*time.Minute + indexTimeout).Seconds(), // add an extra 40 minutes to account for the time it takes to clone the repo
+			20),
 	}, []string{
 		"state", // state is an indexState
 		"name",  // name of the repository that was indexed

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -66,7 +66,7 @@ var (
 	metricIndexDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "index_repo_seconds",
 		Help:    "A histogram of latencies for indexing a repository.",
-		Buckets: prometheus.ExponentialBuckets(.1, 10, 7), // 100ms -> 27min
+		Buckets: prometheus.ExponentialBucketsRange((100 * time.Millisecond).Seconds(), (5*time.Minute + indexTimeout).Seconds(), 15),
 	}, []string{
 		"state", // state is an indexState
 		"name",  // name of the repository that was indexed


### PR DESCRIPTION
Our maximum index job duration is an hour (jobs will be killed after this). However, our Prometheus metric for this has buckets for durations longer than a day! These are unnecessary. 

This change:
- caps the maximum bucket to be only 5mins larger than our maximum allowed duration (allowing for jobs that aren't killed as soon as we reach the 1 hour mark)
- raises the number of buckets in the 100ms -> 1h5m) range so that we can get more accurate metrics 