### PR TITLE
query: remove RepoBranches

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -78,18 +78,6 @@ func (d *indexData) simplify(in query.Q) query.Q {
 				}
 			}
 			return &query.Const{Value: false}
-		case *query.RepoBranches:
-			if len(d.repoMetaData) == 1 {
-				// Can simplify query now. compound too complicated since each repo
-				// may have different branches.
-				return r.Branches(d.repoMetaData[0].Name)
-			}
-			for _, md := range d.repoMetaData {
-				if _, ok := r.Set[md.Name]; ok {
-					return q
-				}
-			}
-			return &query.Const{Value: false}
 		case *query.RepoSet:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Set[repo.Name]

--- a/eval_test.go
+++ b/eval_test.go
@@ -289,23 +289,6 @@ func TestSimplifyRepoRegexp(t *testing.T) {
 	}
 }
 
-func TestSimplifyRepoBranch(t *testing.T) {
-	d := compoundReposShard(t, "foo", "bar")
-
-	some := &query.RepoBranches{Set: map[string][]string{"bar": {"branch1"}}}
-	none := &query.Repo{Regexp: regexp.MustCompile("banana")}
-
-	got := d.simplify(some)
-	if d := cmp.Diff(some, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
-	}
-
-	got = d.simplify(none)
-	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
-	}
-}
-
 func TestSimplifyBranchesRepos(t *testing.T) {
 	d := compoundReposShard(t, "foo", "bar")
 
@@ -324,24 +307,6 @@ func TestSimplifyBranchesRepos(t *testing.T) {
 
 	got = d.simplify(none)
 	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
-		t.Fatalf("-want, +got:\n%s", d)
-	}
-}
-
-func TestSimplifyRepoBranchSimple(t *testing.T) {
-	d := compoundReposShard(t, "foo")
-	q := &query.RepoBranches{Set: map[string][]string{"foo": {"HEAD", "b1"}, "bar": {"HEAD"}}}
-
-	want := &query.Or{[]query.Q{&query.Branch{
-		Pattern: "HEAD",
-		Exact:   true,
-	}, &query.Branch{
-		Pattern: "b1",
-		Exact:   true,
-	}}}
-
-	got := d.simplify(q)
-	if d := cmp.Diff(want, got); d != "" {
 		t.Fatalf("-want, +got:\n%s", d)
 	}
 }

--- a/matchtree.go
+++ b/matchtree.go
@@ -940,29 +940,6 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			},
 		}, nil
 
-	case *query.RepoBranches:
-		reposBranchesWant := make([]uint64, len(d.repoMetaData))
-		for repoIdx, r := range d.repoMetaData {
-			if branches, ok := s.Set[r.Name]; ok {
-				var mask uint64
-				for _, branch := range branches {
-					m, ok := d.branchIDs[repoIdx][branch]
-					if !ok {
-						continue
-					}
-					mask = mask | uint64(m)
-				}
-				reposBranchesWant[repoIdx] = mask
-			}
-		}
-		return &docMatchTree{
-			reason:  "RepoBranches",
-			numDocs: d.numDocs(),
-			predicate: func(docID uint32) bool {
-				return d.fileBranchMasks[docID]&reposBranchesWant[d.repos[docID]] != 0
-			},
-		}, nil
-
 	case *query.RepoSet:
 		reposWant := make([]bool, len(d.repoMetaData))
 		for repoIdx, r := range d.repoMetaData {

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -274,30 +274,6 @@ func TestRepo(t *testing.T) {
 	}
 }
 
-func TestRepoBranches(t *testing.T) {
-	d := &indexData{
-		repoMetaData:    []Repository{{Name: "foo"}, {Name: "bar"}},
-		fileBranchMasks: []uint64{1, 1, 1, 2, 1, 2, 1},
-		repos:           []uint16{0, 0, 1, 1, 1, 1, 1},
-		branchIDs:       []map[string]uint{{"HEAD": 1}, {"HEAD": 1, "b1": 2}},
-	}
-	mt, err := d.newMatchTree(&query.RepoBranches{Set: map[string][]string{"bar": {"b1", "b2"}}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := []uint32{3, 5}
-	for i := 0; i < len(want); i++ {
-		nextDoc := mt.nextDoc()
-		if nextDoc != want[i] {
-			t.Fatalf("want %d, got %d", want[i], nextDoc)
-		}
-		mt.prepare(nextDoc)
-	}
-	if mt.nextDoc() != maxUInt32 {
-		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
-	}
-}
-
 func TestBranchesRepos(t *testing.T) {
 	d := &indexData{
 		repoMetaData: []Repository{

--- a/query/marshal.go
+++ b/query/marshal.go
@@ -117,42 +117,6 @@ func repoBranchesEncode(repoBranches map[string][]string) ([]byte, error) {
 // repoBranches slice, so it is safe to share this slice.
 var head = []string{"HEAD"}
 
-// repoBranchesDecode implements an efficient decoder for RepoBranches.
-func repoBranchesDecode(b []byte) (map[string][]string, error) {
-	// binaryReader returns strings pointing into b to avoid allocations. We
-	// don't own b, so we create a copy of it.
-	r := binaryReader{b: append([]byte{}, b...)}
-
-	// Version
-	if v := r.byt(); v != 1 {
-		return nil, fmt.Errorf("unsupported RepoBranches encoding version %d", v)
-	}
-
-	// Length
-	l := r.uvarint()
-	repoBranches := make(map[string][]string, l)
-
-	for i := 0; i < l; i++ {
-		name := r.str()
-
-		branchesLen := int(r.byt())
-
-		// Special case "HEAD"
-		if branchesLen == 0 {
-			repoBranches[name] = head
-			continue
-		}
-
-		branches := make([]string, branchesLen)
-		for j := 0; j < branchesLen; j++ {
-			branches[j] = r.str()
-		}
-		repoBranches[name] = branches
-	}
-
-	return repoBranches, r.err
-}
-
 func branchesReposEncode(brs []BranchRepos) ([]byte, error) {
 	var b bytes.Buffer
 	var enc [binary.MaxVarintLen64]byte

--- a/query/marshal_test.go
+++ b/query/marshal_test.go
@@ -38,44 +38,6 @@ func BenchmarkRepoBranches_Encode(b *testing.B) {
 	}
 }
 
-func BenchmarkRepoBranches_Decode(b *testing.B) {
-	repoBranches := genRepoBranches(5_500_000)
-
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(repoBranches); err != nil {
-		b.Fatal(err)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for n := 0; n < b.N; n++ {
-		// We need to include gob.NewDecoder cost to avoid measuring encoding.
-		var repoBranches RepoBranches
-		if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&repoBranches); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func TestRepoBranches_Marshal(t *testing.T) {
-	want := genRepoBranches(1000)
-
-	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(want); err != nil {
-		t.Fatal(err)
-	}
-
-	var got RepoBranches
-	if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got); err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(want, &got); diff != "" {
-		t.Fatalf("mismatch (-want +got):\n%s", diff)
-	}
-}
-
 func BenchmarkBranchesRepos_Encode(b *testing.B) {
 	brs := genBranchesRepos(5_500_000)
 
@@ -140,29 +102,23 @@ func TestBranchesRepos_Marshal(t *testing.T) {
 // Generating 5.5M repos slows down the benchmark setup time, so we cache things.
 var genCache = map[string]interface{}{}
 
-func genRepoBranches(n int) *RepoBranches {
-	key := fmt.Sprintf("RepoBranches:%d", n)
-	val, ok := genCache[key]
-	if ok {
-		return val.(*RepoBranches)
-	}
-
+func genRepoBranches(n int) map[string][]string {
 	genName := func(n int) string {
 		bs := make([]byte, 8)
 		binary.LittleEndian.PutUint64(bs, uint64(n))
 		return fmt.Sprintf("%x", sha256.Sum256(bs))[:10]
 	}
 
-	repoBranches := &RepoBranches{Set: map[string][]string{}}
+	repoBranches := map[string][]string{}
 	orgIndex := 0
 	repoIndex := 0
 
 	for i := 0; i < n; i++ {
 		org := genName(orgIndex)
 		name := "github.com/" + org + "/" + genName(orgIndex*2+repoIndex)
-		repoBranches.Set[name] = []string{"HEAD"}
+		repoBranches[name] = []string{"HEAD"}
 		if repoIndex%50 == 0 {
-			repoBranches.Set[name] = append(repoBranches.Set[name], "more", "branches")
+			repoBranches[name] = append(repoBranches[name], "more", "branches")
 		}
 
 		if i%1000 == 0 {
@@ -173,7 +129,6 @@ func genRepoBranches(n int) *RepoBranches {
 		repoIndex++
 	}
 
-	genCache[key] = repoBranches
 	return repoBranches
 }
 
@@ -184,7 +139,7 @@ func genBranchesRepos(n int) *BranchesRepos {
 		return val.(*BranchesRepos)
 	}
 
-	set := genRepoBranches(n).Set
+	set := genRepoBranches(n)
 	br := map[string]*roaring.Bitmap{}
 	id := uint32(1)
 

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -138,7 +138,6 @@ func RegisterGob() {
 		gob.Register(&query.Not{})
 		gob.Register(&query.Or{})
 		gob.Register(&query.Regexp{})
-		gob.Register(&query.RepoBranches{})
 		gob.Register(&query.RepoRegexp{})
 		gob.Register(&query.RepoSet{})
 		gob.Register(&query.Repo{})

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -348,11 +348,6 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 				}
 				return false
 			})
-		case *query.RepoBranches:
-			setSize = len(setQuery.Set)
-			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
-				return len(setQuery.Set[repo.Name]) > 0
-			})
 		default:
 			continue
 		}
@@ -408,22 +403,6 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 			// Every repo wants the same branches, so we can replace RepoBranches
 			// with a list of branch queries.
 			and.Children[i] = &query.Branch{Pattern: c.List[0].Branch, Exact: true}
-			return filtered, query.Simplify(and)
-
-		case *query.RepoBranches:
-			// We can only replace if all the repos want the same branches.
-			want := c.Set[filtered[0].repos[0].Name]
-			for _, s := range filtered {
-				for _, repo := range s.repos {
-					if !strSliceEqual(want, c.Set[repo.Name]) {
-						return filtered, and
-					}
-				}
-			}
-
-			// Every repo wants the same branches, so we can replace RepoBranches
-			// with a list of branch queries.
-			and.Children[i] = c.Branches(filtered[0].repos[0].Name)
 			return filtered, query.Simplify(and)
 		}
 

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -241,13 +241,11 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 		t.Fatalf("no reposet: got %d results, want %d", len(res.Files), n)
 	}
 
-	repoBranchesSet := &query.RepoBranches{Set: make(map[string][]string)}
 	branchesRepos := &query.BranchesRepos{List: []query.BranchRepos{
 		{Branch: "HEAD", Repos: roaring.New()},
 	}}
 
 	for _, name := range repoSetNames {
-		repoBranchesSet.Set[name] = []string{"HEAD"}
 		branchesRepos.List[0].Repos.Add(hash(name))
 	}
 
@@ -258,10 +256,6 @@ func TestFilteringShardsByRepoSet(t *testing.T) {
 		query.NewAnd(set, sub),
 		// Test with the same reposet again
 		query.NewAnd(set, sub),
-
-		query.NewAnd(repoBranchesSet, sub),
-		// Test with the same repoBranches again
-		query.NewAnd(repoBranchesSet, sub),
 
 		query.NewAnd(branchesRepos, sub),
 		// Test with the same repoBranches with IDs again


### PR DESCRIPTION
This was a query type only used by Sourcegraph. It was superceded by BranchesRepos, so can be removed. It is no longer used in sourcegraph/sourcegraph.

Test Plan: go test ./...
