### PR TITLE
ci: add shfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,18 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@1.1.0
-
+  
+  shfmt:
+    name: shfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-shfmt@v1.0.2
+        with:
+          filter_mode: "nofilter"
+          fail_on_error: "true"
+          shfmt_flags: "-i 2 -ci -bn"
+          
   # We build a shared docker image called "zoekt". This is not pushed, but is
   # used for creating the indexserver and webserver images.
   docker:

--- a/bench.sh
+++ b/bench.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
- echo            "Running benchmarks..."
+echo "Running benchmarks..."

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ echo            "Running benchmarks..."

--- a/bench.sh
+++ b/bench.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running benchmarks..."


### PR DESCRIPTION
This PR adds [shfmt](https://github.com/mvdan/sh#shfmt), a shell script formatter, as a CI step that will run on all pull requests. If your change includes a script that doesn't conform to our style guide, a comment will be posted on your PR that highlights the changes that need to be made.

I setup shfmt to use flags that conform to Google's style guide. This is the same style that we use in github.com/sourcegraph/sourcegraph. 