### PR TITLE
indexeserver: better logging for sourcegraphClient

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/zoekt"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 func TestGetIndexOptions(t *testing.T) {
@@ -42,10 +42,7 @@ func TestGetIndexOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sg := &sourcegraphClient{
-		Root:   u,
-		Client: retryablehttp.NewClient(),
-	}
+	sg := newSourcegraphClient(u, "", 0)
 
 	cases := map[string]*IndexOptions{
 		`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -865,7 +865,7 @@ func newSourcegraphClient(rootURL *url.URL, hostname string, batchSize int) *sou
 	client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 		shouldRetry, checkErr := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
 
-		if resp.StatusCode == http.StatusInternalServerError {
+		if resp != nil && resp.StatusCode == http.StatusInternalServerError {
 			if b, e := io.ReadAll(resp.Body); e == nil {
 				checkErr = fmt.Errorf("%w: body=%q", checkErr, string(b))
 			}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -302,7 +302,7 @@ func (s *Server) Run() {
 
 			repos, err := s.Sourcegraph.List(context.Background(), listIndexed(s.IndexDir))
 			if err != nil {
-				log.Println(err)
+				log.Printf("error listing repos: %s", err)
 				continue
 			}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -952,7 +952,6 @@ func newServer(conf rootConfig) (*Server, error) {
 		}
 
 		sg = newSourcegraphClient(rootURL, conf.hostname, batchSize)
-
 	} else {
 		sg = sourcegraphFake{
 			RootDir: rootURL.String(),

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -88,6 +88,8 @@ func TestListRepoIDs(t *testing.T) {
 func TestListRepoIDs_Error(t *testing.T) {
 	msg := "deadbeaf deadbeaf"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// This is how Sourcegraph returns error messages to the caller.
 		http.Error(w, msg, http.StatusInternalServerError)
 	}))
 	defer ts.Close()

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/google/zoekt"
 )
@@ -25,11 +24,9 @@ func TestServer_defaultArgs(t *testing.T) {
 	}
 
 	s := &Server{
-		Sourcegraph: &sourcegraphClient{
-			Root: root,
-		},
-		IndexDir: "/testdata/index",
-		CPUCount: 6,
+		Sourcegraph: newSourcegraphClient(root, "", 0),
+		IndexDir:    "/testdata/index",
+		CPUCount:    6,
 	}
 	want := &indexArgs{
 		IndexOptions: IndexOptions{
@@ -70,11 +67,7 @@ func TestListRepoIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &sourcegraphClient{
-		Root:     u,
-		Hostname: "test-indexed-search-1",
-		Client:   retryablehttp.NewClient(),
-	}
+	s := newSourcegraphClient(u, "test-indexed-search-1", 0)
 
 	gotRepos, err := s.List(context.Background(), []uint32{1, 3})
 	if err != nil {
@@ -94,7 +87,6 @@ func TestListRepoIDs(t *testing.T) {
 
 func TestListRepoIDs_Error(t *testing.T) {
 	msg := "deadbeaf deadbeaf"
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusInternalServerError)
 	}))

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/zoekt"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"golang.org/x/net/trace"
+
+	"github.com/google/zoekt"
 )
 
 // SourcegraphListResult is the return value of Sourcegraph.List. It is its
@@ -102,7 +103,7 @@ type sourcegraphClient struct {
 func (s *sourcegraphClient) List(ctx context.Context, indexed []uint32) (*SourcegraphListResult, error) {
 	repos, err := s.listRepoIDs(ctx, indexed)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("listRepoIDs: %w", err)
 	}
 
 	batchSize := s.BatchSize


### PR DESCRIPTION
This improves the error messages for our sourcegraph client. The change is motivated by a recent customer issue.

Now we log the error returned by Sourcegraph if the List call returns with status code 500. We also wrap errors coming from Server.Sourcegraph.List(...), which should make it easier to filter the logs.