### PR TITLE
introduce ability to skip indexing symbols metadata for certain repositories

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -481,16 +481,15 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	}
 
 	repositoryName := args.Name
-	repositoryID := args.BuildOptions().RepositoryDescription.ID
 	if _, ok := s.deltaBuildRepositoriesAllowList[repositoryName]; ok {
-		debug.Printf("delta build: Server.Index: marking %q (ID %d) for delta build", repositoryName, repositoryID)
+		tr.LazyPrintf("marking this repository for delta build")
 		args.UseDelta = true
 	}
 
 	args.DeltaShardNumberFallbackThreshold = s.deltaShardNumberFallbackThreshold
 
 	if _, ok := s.repositoriesSkipSymbolsCalculationAllowList[repositoryName]; ok {
-		debug.Printf("Server.Index: skipping symbols calculation for %q (ID %d)", repositoryName, repositoryID)
+		tr.LazyPrintf("skipping symbols calculation")
 		args.Symbols = false
 	}
 


### PR DESCRIPTION
On k8s.sgdev.org, we're repeatedly failing to index the gigarepo. 

`zoekt-git-index` keeps getting OOMKilled after ~10 minutes. I then modified the command to run `zoekt-git-index` without the `symbols` flag, and the job made it past the 10 minute mark (indicating that ctags was responsible for the early memory blow up). Ideally we'd fix the underling issue preventing ctags from working with the gigarepo, but for now I want to unblock us from getting more data on how incremental-indexing performs against this repo. 

---

This PR introduces the `SKIP_SYMBOLS_REPOS_ALLOWLIST` environment variable. Symbols metadata calculations are explicitly disabled for any repositories contained in this comma separated list (e.x.: `SKIP_SYMBOLS_REPOS_ALLOWLIST: gigarepo,gigarepo-incremental-indexing,...`). 

