### PR TITLE
debug: new pages for List and listIndexed

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -569,19 +569,20 @@ func createEmptyShard(args *indexArgs) error {
 
 // addDebugHandlers adds handlers specific to indexserver.
 func (s *Server) addDebugHandlers(mux *http.ServeMux) {
+	mux.Handle("/", http.HandlerFunc(s.handleReIndex))
 	mux.Handle("/debug/indexed", http.HandlerFunc(s.handleDebugIndexed))
 	mux.Handle("/debug/list", http.HandlerFunc(s.handleDebugList))
 	mux.Handle("/debug/queue", http.HandlerFunc(s.queue.handleDebugQueue))
-	mux.Handle("/debug/reindex", http.HandlerFunc(s.handleReIndex))
 }
 
 var repoTmpl = template.Must(template.New("name").Parse(`
 <html><body>
-<a href="/debug/requests">Traces</a><br>
+<a href="debug">Debug</a><br>
+<a href="debug/requests">Traces</a><br>
 {{.IndexMsg}}<br />
 <br />
 <h3>Re-index repository</h3>
-<form action="/debug/reindex" method="post">
+<form action="." method="post">
 {{range .Repos}}
 <button type="submit" name="repo" value="{{ .ID }}" />{{ .Name }}</button><br />
 {{end}}
@@ -944,7 +945,6 @@ func startServer(conf rootConfig) error {
 				{Href: "debug/list?indexed=true", Text: "Assigned (all)", Description: "includes repositories which this instance temporarily holds during re-balancing"},
 				{Href: "debug/list?indexed=false", Text: "Assigned (this instance)"},
 				{Href: "debug/queue", Text: "Queue"},
-				{Href: "debug/reindex", Text: "Re-index"},
 			}...)
 			s.addDebugHandlers(mux)
 			debug.Printf("serving HTTP on %s", conf.listen)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -618,11 +618,7 @@ func (s *Server) handleReIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
-	withIndexed := false
-	indexedStr := r.URL.Query().Get("indexed")
-	if b, err := strconv.ParseBool(indexedStr); err != nil {
-		withIndexed = b
-	}
+	withIndexed, _ := strconv.ParseBool(r.URL.Query().Get("indexed"))
 
 	var indexed []uint32
 	if withIndexed {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -624,7 +624,10 @@ func (s *Server) handleReIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
-	withIndexed, _ := strconv.ParseBool(r.URL.Query().Get("indexed"))
+	withIndexed := true
+	if b, err := strconv.ParseBool(r.URL.Query().Get("indexed")); err == nil {
+		withIndexed = b
+	}
 
 	var indexed []uint32
 	if withIndexed {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -635,15 +635,18 @@ func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	repoName := ""
+	s.queue.mu.Lock()
+	defer s.queue.mu.Unlock()
+
+	name := ""
 	for _, id := range repos.IDs {
 		if item := s.queue.get(id); item != nil {
-			repoName = item.opts.Name
+			name = item.opts.Name
 		} else {
-			repoName = ""
+			name = ""
 		}
 
-		_, err := fmt.Fprintf(w, "%d\t%s\n", id, repoName)
+		_, err := fmt.Fprintf(w, "%d\t%s\n", id, name)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -654,15 +657,18 @@ func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDebugIndexed(w http.ResponseWriter, r *http.Request) {
 	indexed := listIndexed(s.IndexDir)
 
-	repoName := ""
+	s.queue.mu.Lock()
+	defer s.queue.mu.Unlock()
+
+	name := ""
 	for _, id := range indexed {
 		if item := s.queue.get(id); item != nil {
-			repoName = item.opts.Name
+			name = item.opts.Name
 		} else {
-			repoName = ""
+			name = ""
 		}
 
-		_, err := fmt.Fprintf(w, "%d\t%s\n", id, repoName)
+		_, err := fmt.Fprintf(w, "%d\t%s\n", id, name)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -663,7 +663,7 @@ func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
 			debug.Printf("handleDebugList: %s\n", err.Error())
 		}
 	}
-	defer s.queue.mu.Unlock()
+	s.queue.mu.Unlock()
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -1,20 +1,56 @@
 package debugserver
 
 import (
+	"html/template"
 	"net/http"
 	"net/http/pprof"
 	"sync"
 
-	"github.com/google/zoekt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/trace"
+
+	"github.com/google/zoekt"
 )
 
 var registerOnce sync.Once
 
-func AddHandlers(mux *http.ServeMux, enablePprof bool) {
+var debugTmpl = template.Must(template.New("name").Parse(`
+<html>
+	<head>
+		<style>
+			.profile-name{
+				display:inline-block;
+				width:12rem;
+			}
+		</style>
+	</head>
+
+	<body>
+		<a class="profile-name" href="vars">Vars</a><br>
+		{{if .EnablePprof}}<a class="profile-name" href="debug/pprof/">PProf</a>{{else}}PProf disabled{{end}}<br>
+		<a class="profile-name" href="metrics">Metrics</a><br>
+		<a class="profile-name" href="debug/requests">Requests</a><br>
+		<a class="profile-name" href="debug/events">Events</a><br>
+
+		{{/* links which are specific to webserver or indexserver */}}
+		{{range .DebugPages}}<a class="profile-name" href={{.Href}}>{{.Text}}</a>{{.Description}}<br>{{end}}
+
+		<br>
+		<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>
+		<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
+	</body>
+</html>
+`))
+
+type DebugPage struct {
+	Href        string
+	Text        string
+	Description string
+}
+
+func AddHandlers(mux *http.ServeMux, enablePprof bool, p ...DebugPage) {
 	registerOnce.Do(register)
 
 	trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
@@ -22,18 +58,13 @@ func AddHandlers(mux *http.ServeMux, enablePprof bool) {
 	}
 
 	index := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`
-				<a href="vars">Vars</a><br>
-				<a href="debug/pprof/">PProf</a><br>
-				<a href="metrics">Metrics</a><br>
-				<a href="debug/requests">Requests</a><br>
-				<a href="debug/events">Events</a><br>
-			`))
-		_, _ = w.Write([]byte(`
-				<br>
-				<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>
-				<form method="post" action="freeosmemory" style="display: inline;"><input type="submit" value="Free OS Memory"></form>
-			`))
+		_ = debugTmpl.Execute(w, struct {
+			DebugPages  []DebugPage
+			EnablePprof bool
+		}{
+			DebugPages:  p,
+			EnablePprof: enablePprof,
+		})
 	})
 	mux.Handle("/debug", index)
 	mux.Handle("/vars", http.HandlerFunc(expvarHandler))

--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -21,24 +21,23 @@ var debugTmpl = template.Must(template.New("name").Parse(`
 	<head>
 		<title>/debug</title>
 		<style>
-			.profile-name{
+			.debug-page{
 				display:inline-block;
 				width:12rem;
 			}
 		</style>
 	</head>
-
 	<body>
 		/debug<br>
 		<br>
-		<a class="profile-name" href="vars">Vars</a><br>
-		{{if .EnablePprof}}<a class="profile-name" href="debug/pprof/">PProf</a>{{else}}PProf disabled{{end}}<br>
-		<a class="profile-name" href="metrics">Metrics</a><br>
-		<a class="profile-name" href="debug/requests">Requests</a><br>
-		<a class="profile-name" href="debug/events">Events</a><br>
+		<a class="debug-page" href="vars">Vars</a><br>
+		{{if .EnablePprof}}<a class="debug-page" href="debug/pprof/">PProf</a>{{else}}PProf disabled{{end}}<br>
+		<a class="debug-page" href="metrics">Metrics</a><br>
+		<a class="debug-page" href="debug/requests">Requests</a><br>
+		<a class="debug-page" href="debug/events">Events</a><br>
 
 		{{/* links which are specific to webserver or indexserver */}}
-		{{range .DebugPages}}<a class="profile-name" href={{.Href}}>{{.Text}}</a>{{.Description}}<br>{{end}}
+		{{range .DebugPages}}<a class="debug-page" href={{.Href}}>{{.Text}}</a>{{.Description}}<br>{{end}}
 
 		<br>
 		<form method="post" action="gc" style="display: inline;"><input type="submit" value="GC"></form>

--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -19,6 +19,7 @@ var registerOnce sync.Once
 var debugTmpl = template.Must(template.New("name").Parse(`
 <html>
 	<head>
+		<title>/debug</title>
 		<style>
 			.profile-name{
 				display:inline-block;
@@ -28,6 +29,8 @@ var debugTmpl = template.Must(template.New("name").Parse(`
 	</head>
 
 	<body>
+		/debug<br>
+		<br>
 		<a class="profile-name" href="vars">Vars</a><br>
 		{{if .EnablePprof}}<a class="profile-name" href="debug/pprof/">PProf</a>{{else}}PProf disabled{{end}}<br>
 		<a class="profile-name" href="metrics">Metrics</a><br>


### PR DESCRIPTION
This adds new debug pages which were previously only exposed as CLI debug commands.

/debug/list
/debug/indexed?indexed=<TRUE, false>

<img width="1103" alt="Screenshot 2022-05-19 at 14 35 56" src="https://user-images.githubusercontent.com/26413131/169294669-f2d00f41-bfaf-4c52-aa8c-443a81097e06.png">

Other changes:

- We only show the PProf link if PProf is enabled
- Add link to "Queue" on the debug landing page