### PR TITLE
ranking: boost base filename matches

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -32,10 +32,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/regexp"
+
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/shards"
-	"github.com/grafana/regexp"
 )
 
 func TestBasic(t *testing.T) {
@@ -842,6 +843,27 @@ public class HelloWorld
 			wantLanguage: "Java",
 			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
+		},
+		{
+			fileName:     "a/b/c/config.go",
+			query:        &query.Substring{FileName: true, Pattern: "config"},
+			wantLanguage: "Go",
+			// 5500 (partial base at boundary) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 6410,
+		},
+		{
+			fileName:     "a/b/c/config.go",
+			query:        &query.Substring{FileName: true, Pattern: "config.go"},
+			wantLanguage: "Go",
+			// 7000 (full base match) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 7910,
+		},
+		{
+			fileName:     "a/config/c/d.go",
+			query:        &query.Substring{FileName: true, Pattern: "config"},
+			wantLanguage: "Go",
+			// 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 910,
 		},
 	}
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -267,6 +267,8 @@ const (
 	// TODO - how to scale this relative to rank?
 	scorePartialWordMatch   = 50.0
 	scoreWordMatch          = 500.0
+	scoreBase               = 7000
+	scorePartialBase        = 4000
 	scoreImportantThreshold = 2000.0
 	scoreSymbol             = 7000.0
 	scorePartialSymbol      = 4000.0
@@ -309,7 +311,18 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 			score = scorePartialWordMatch
 		}
 
-		if secIdx, ok := findSection(secs, f.Offset, uint32(f.MatchLength)); ok {
+		if m.FileName {
+			sep := bytes.LastIndexByte(m.Line, '/')
+			startMatch := sep+1 == f.LineOffset
+			endMatch := len(m.Line) == f.LineOffset+f.MatchLength
+			if startMatch && endMatch {
+				score += scoreBase
+			} else if startMatch || endMatch {
+				score += (scoreBase + scorePartialBase) / 2
+			} else if sep < f.LineOffset {
+				score += scorePartialBase
+			}
+		} else if secIdx, ok := findSection(secs, f.Offset, uint32(f.MatchLength)); ok {
 			sec := secs[secIdx]
 			startMatch := sec.Start == f.Offset
 			endMatch := sec.End == f.Offset+uint32(f.MatchLength)

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -267,8 +267,8 @@ const (
 	// TODO - how to scale this relative to rank?
 	scorePartialWordMatch   = 50.0
 	scoreWordMatch          = 500.0
-	scoreBase               = 7000
-	scorePartialBase        = 4000
+	scoreBase               = 7000.0
+	scorePartialBase        = 4000.0
 	scoreImportantThreshold = 2000.0
 	scoreSymbol             = 7000.0
 	scorePartialSymbol      = 4000.0


### PR DESCRIPTION
We boost matches of filenames if the match is within the boundaries of
the base of a filename. Full matches get a higher boost than partial
matches. The approach is identical to boosting of content matches that
match symbol section.

Additionally we fix a bug where we used sections belonging to the file
content to score filename matches.

Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>