### PR TITLE
debug: add debug score for line matches

### DIFF
--- a/api.go
+++ b/api.go
@@ -89,7 +89,9 @@ type LineMatch struct {
 
 	// The higher the better. Only ranks the quality of the match
 	// within the file, does not take rank of file into account
-	Score         float64
+	Score      float64
+	DebugScore string
+
 	LineFragments []LineFragmentMatch
 }
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -16,8 +16,10 @@ package zoekt
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"unicode/utf8"
 )
 
@@ -130,7 +132,7 @@ func (p *contentProvider) findOffset(filename bool, r uint32) uint32 {
 	return byteOff
 }
 
-func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int, language string) []LineMatch {
+func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int, language string, debug bool) []LineMatch {
 	var result []LineMatch
 	if ms[0].fileName {
 		// There is only "line" in a filename.
@@ -155,7 +157,7 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int,
 
 	sects := p.docSections()
 	for i, m := range result {
-		result[i].Score = p.matchScore(sects, &m, language)
+		result[i].Score, result[i].DebugScore = p.matchScore(sects, &m, language, debug)
 	}
 
 	return result
@@ -296,19 +298,35 @@ func findSection(secs []DocumentSection, off, sz uint32) (int, bool) {
 	return 0, false
 }
 
-func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, language string) float64 {
-	var maxScore float64
+func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, language string, debug bool) (float64, string) {
+	type debugScore struct {
+		score float64
+		what  string
+	}
+
+	score := &debugScore{}
+	maxScore := &debugScore{}
+
+	addScore := func(what string, s float64) {
+		if debug {
+			score.what += fmt.Sprintf("%s:%f, ", what, s)
+		}
+		score.score += s
+	}
+
 	for _, f := range m.LineFragments {
 		startBoundary := f.LineOffset < len(m.Line) && (f.LineOffset == 0 || byteClass(m.Line[f.LineOffset-1]) != byteClass(m.Line[f.LineOffset]))
 
 		end := int(f.LineOffset) + f.MatchLength
 		endBoundary := end > 0 && (end == len(m.Line) || byteClass(m.Line[end-1]) != byteClass(m.Line[end]))
 
-		score := 0.0
+		score.score = 0
+		score.what = ""
+
 		if startBoundary && endBoundary {
-			score = scoreWordMatch
+			addScore("WordMatch", scoreWordMatch)
 		} else if startBoundary || endBoundary {
-			score = scorePartialWordMatch
+			addScore("PartialWordMatch", scorePartialWordMatch)
 		}
 
 		if m.FileName {
@@ -316,22 +334,22 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 			startMatch := sep+1 == f.LineOffset
 			endMatch := len(m.Line) == f.LineOffset+f.MatchLength
 			if startMatch && endMatch {
-				score += scoreBase
+				addScore("Base", scoreBase)
 			} else if startMatch || endMatch {
-				score += (scoreBase + scorePartialBase) / 2
+				addScore("EdgeBase", (scoreBase+scorePartialBase)/2)
 			} else if sep < f.LineOffset {
-				score += scorePartialBase
+				addScore("InnerBase", scorePartialBase)
 			}
 		} else if secIdx, ok := findSection(secs, f.Offset, uint32(f.MatchLength)); ok {
 			sec := secs[secIdx]
 			startMatch := sec.Start == f.Offset
 			endMatch := sec.End == f.Offset+uint32(f.MatchLength)
 			if startMatch && endMatch {
-				score += scoreSymbol
+				addScore("Symbol", scoreSymbol)
 			} else if startMatch || endMatch {
-				score += (scoreSymbol + scorePartialSymbol) / 2
+				addScore("EdgeSymbol", (scoreSymbol+scorePartialSymbol)/2)
 			} else {
-				score += scorePartialSymbol
+				addScore("InnerSymbol", scorePartialSymbol)
 			}
 
 			si := f.SymbolInfo
@@ -342,15 +360,16 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 			}
 			if si != nil {
 				// the LineFragment may not be on a symbol, then si will be nil.
-				score += scoreKind(language, si.Kind)
+				addScore(fmt.Sprintf("kind:%s:%s", language, si.Kind), scoreKind(language, si.Kind))
 			}
 		}
 
-		if score > maxScore {
-			maxScore = score
+		if score.score > maxScore.score {
+			maxScore.score = score.score
+			maxScore.what = score.what
 		}
 	}
-	return maxScore
+	return maxScore.score, strings.TrimRight(maxScore.what, ", ")
 }
 
 // scoreKind boosts a match based on the combination of language and kind. The

--- a/eval.go
+++ b/eval.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 
 	enry_data "github.com/go-enry/go-enry/v2/data"
-	"github.com/google/zoekt/query"
 	"github.com/grafana/regexp"
+
+	"github.com/google/zoekt/query"
 )
 
 const maxUInt16 = 0xffff
@@ -337,7 +338,7 @@ nextFileMatch:
 					byteMatchSz:   uint32(len(nm)),
 				})
 		}
-		fileMatch.LineMatches = cp.fillMatches(finalCands, opts.NumContextLines, fileMatch.Language)
+		fileMatch.LineMatches = cp.fillMatches(finalCands, opts.NumContextLines, fileMatch.Language, opts.DebugScore)
 
 		maxFileScore := 0.0
 		for i := range fileMatch.LineMatches {

--- a/web/api.go
+++ b/web/api.go
@@ -73,7 +73,8 @@ type Match struct {
 	After     string `json:",omitempty"`
 
 	// Don't expose to caller of JSON API
-	Score float64 `json:"-"`
+	Score      float64 `json:"-"`
+	ScoreDebug string  `json:"-"`
 }
 
 // Fragment holds data of a single contiguous match within in a line

--- a/web/snippets.go
+++ b/web/snippets.go
@@ -124,7 +124,9 @@ func (s *Server) formatResults(result *zoekt.SearchResult, query string, localPr
 				FileName: f.FileName,
 				LineNum:  m.LineNumber,
 				URL:      fMatch.URL + fragment,
-				Score:    m.Score,
+
+				Score:      m.Score,
+				ScoreDebug: m.DebugScore,
 			}
 
 			md.Before = string(m.Before)

--- a/web/templates.go
+++ b/web/templates.go
@@ -241,7 +241,7 @@ document.onkeydown=function(e){
         {{range .Matches}}
         <tr>
           <td style="background-color: rgba(238, 238, 255, 0.6);">
-            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}} {{if $showScoreDebug}}<i>(score:{{.Score}})</i>{{end}}</pre>
+            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}} {{if $showScoreDebug}}<i>(score:{{.Score}} <-- {{.ScoreDebug}})</i>{{end}}</pre>
           </td>
         </tr>
         {{end}}


### PR DESCRIPTION
We enrich the score of a line match with more detailed information of how it was
calculated. This is similar to what we already do on the level of file matches.