### PR TITLE
stats: fixed wrong size reporting for repos from compound shards 

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -171,22 +171,21 @@ func TestSearch_ShardRepoMaxMatchCountOpt(t *testing.T) {
 	})
 }
 
-// compoundReposShard returns a compound shard where each repo has 1 document.
 func compoundReposShard(t *testing.T, names ...string) *indexData {
 	t.Helper()
-	b := newIndexBuilder()
-	b.indexFormatVersion = NextIndexFormatVersion
+
+	repos := make([]*Repository, 0, len(names))
+	docs := make([][]Document, 0, len(names))
 	for _, name := range names {
-		if err := b.setRepository(&Repository{ID: hash(name), Name: name}); err != nil {
-			t.Fatal(err)
+		repos = append(repos, &Repository{ID: hash(name), Name: name})
+		ds := []Document{
+			Document{Name: name + ".txt", Content: []byte(name + " content")},
+			Document{Name: name + ".2.txt", Content: []byte(name + " content 2")},
 		}
-		if err := b.AddFile(name+".txt", []byte(name+" content")); err != nil {
-			t.Fatal(err)
-		}
-		if err := b.AddFile(name+".2.txt", []byte(name+" content 2")); err != nil {
-			t.Fatal(err)
-		}
+		docs = append(docs, ds)
 	}
+
+	b := testIndexBuilderCompound(t, repos, docs)
 	s := searcherForTest(t, b)
 	return s.(*indexData)
 }

--- a/index_test.go
+++ b/index_test.go
@@ -61,6 +61,32 @@ func testIndexBuilder(t *testing.T, repo *Repository, docs ...Document) *IndexBu
 	return b
 }
 
+func testIndexBuilderCompound(t *testing.T, repos []*Repository, docs [][]Document) *IndexBuilder {
+	t.Helper()
+
+	b := newIndexBuilder()
+	b.indexFormatVersion = NextIndexFormatVersion
+	b.contentBloom.bits = b.contentBloom.bits[:bloomSizeTest]
+	b.nameBloom.bits = b.nameBloom.bits[:bloomSizeTest]
+
+	if len(repos) != len(docs) {
+		t.Fatalf("testIndexBuilderCompound: repos must be the same length as docs, got: len(repos)=%d len(docs)=%d", len(repos), len(docs))
+	}
+
+	for i, repo := range repos {
+		if err := b.setRepository(repo); err != nil {
+			t.Fatal(err)
+		}
+		for j, d := range docs[i] {
+			if err := b.Add(d); err != nil {
+				t.Fatalf("Add %d %d: %v", i, j, err)
+			}
+		}
+	}
+
+	return b
+}
+
 func TestBoundary(t *testing.T) {
 	b := testIndexBuilder(t, nil,
 		Document{Name: "f1", Content: []byte("x the")},
@@ -2175,4 +2201,119 @@ func TestSearchTypeLanguage(t *testing.T) {
 	b.featureVersion = 11 // force fallback
 	res = searchForTest(t, b, &query.Language{Language: "C++"})
 	wantSingleMatch(res, "hello.h")
+}
+
+func TestStats(t *testing.T) {
+	ignored := []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(RepoListEntry{}, "Repository"),
+		cmpopts.IgnoreFields(RepoListEntry{}, "IndexMetadata"),
+	}
+
+	repoListEntries := func(b *IndexBuilder) []RepoListEntry {
+		searcher := searcherForTest(t, b)
+		indexdata := searcher.(*indexData)
+		return indexdata.repoListEntry
+	}
+
+	t.Run("one empty repo", func(t *testing.T) {
+		b := testIndexBuilder(t, nil)
+		got := repoListEntries(b)
+		want := []RepoListEntry{
+			RepoListEntry{
+				Stats: RepoStats{
+					Repos:                      0,
+					Shards:                     1,
+					Documents:                  0,
+					IndexBytes:                 20,
+					ContentBytes:               0,
+					NewLinesCount:              0,
+					DefaultBranchNewLinesCount: 0,
+					OtherBranchesNewLinesCount: 0,
+				},
+			},
+		}
+
+		if diff := cmp.Diff(want, got, ignored...); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+
+	})
+
+	t.Run("one simple shard", func(t *testing.T) {
+		b := testIndexBuilder(t, nil,
+			Document{Name: "doc 0", Content: []byte("content 0")},
+			Document{Name: "doc 1", Content: []byte("content 1")},
+		)
+		got := repoListEntries(b)
+		want := []RepoListEntry{
+			RepoListEntry{
+				Stats: RepoStats{
+					Repos:                      0,
+					Shards:                     1,
+					Documents:                  2,
+					IndexBytes:                 224,
+					ContentBytes:               28,
+					NewLinesCount:              0,
+					DefaultBranchNewLinesCount: 0,
+					OtherBranchesNewLinesCount: 0,
+				},
+			},
+		}
+
+		if diff := cmp.Diff(want, got, ignored...); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+
+	})
+
+	t.Run("one compound shard", func(t *testing.T) {
+		b := testIndexBuilderCompound(t,
+			[]*Repository{
+				&Repository{Name: "repo 0"},
+				&Repository{Name: "repo 1"},
+			},
+			[][]Document{
+				[]Document{
+					Document{Name: "doc 0", Content: []byte("content 0")},
+					Document{Name: "doc 1", Content: []byte("content 1")},
+				},
+				[]Document{
+					Document{Name: "doc 2", Content: []byte("content 2")},
+					Document{Name: "doc 3", Content: []byte("content 3")},
+				},
+			},
+		)
+		got := repoListEntries(b)
+		want := []RepoListEntry{
+			RepoListEntry{
+				Stats: RepoStats{
+					Repos:                      0,
+					Shards:                     1,
+					Documents:                  2,
+					IndexBytes:                 180,
+					ContentBytes:               28,
+					NewLinesCount:              0,
+					DefaultBranchNewLinesCount: 0,
+					OtherBranchesNewLinesCount: 0,
+				},
+			},
+			RepoListEntry{
+				Stats: RepoStats{
+					Repos:                      0,
+					Shards:                     1,
+					Documents:                  2,
+					IndexBytes:                 180,
+					ContentBytes:               28,
+					NewLinesCount:              0,
+					DefaultBranchNewLinesCount: 0,
+					OtherBranchesNewLinesCount: 0,
+				},
+			},
+		}
+
+		if diff := cmp.Diff(want, got, ignored...); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+	})
 }


### PR DESCRIPTION
The boundaries slice keeps the offsets at which text contents of files start within a shard,
one entry per file and one sentinel entry in the end. Therefore, for simple shards the last
entry in this slice can be used to determine the total size of the files in the shard.
The accurate calculation (boundaries[len(boundaries) - 1] - boundaries[0]) is simplified
by the relativeIndex() trick, so boundaries[0] equals 0, and the expression we were using to
calculate the file size was boundaries[len(boundaries) - 1].

Later we added support for compound shards where different files in a shard can belong to
different repos, although files from a single repo always occupy a contiguous subrange in
all data structures where direct indexing by file number makes sense. If the files span the
subrange of indexes [l, r) the correct expression for their total size is boundaries[r] - boundaries[l].
However, the old code had a mistake where we used, by analogy with the simple shard case,
the one-term expression boundaries[r]. This resulted in overestimation of the total repo sizes for
repos that ended up in compound shards.

Updates #321 