### PR TITLE
improve descriptions of entries on /debug endpoint

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -978,10 +978,10 @@ func startServer(conf rootConfig) error {
 		go func() {
 			mux := http.NewServeMux()
 			debugserver.AddHandlers(mux, true, []debugserver.DebugPage{
-				{Href: "debug/indexed", Text: "Indexed"},
-				{Href: "debug/list?indexed=true", Text: "Assigned (all)", Description: "includes repositories which this instance temporarily holds during re-balancing"},
-				{Href: "debug/list?indexed=false", Text: "Assigned (this instance)"},
-				{Href: "debug/queue", Text: "Queue"},
+				{Href: "debug/indexed", Text: "Indexed", Description: "list of all indexed repositories"},
+				{Href: "debug/list?indexed=false", Text: "Assigned (this instance)", Description: "list of all repositories that are assigned to this instance"},
+				{Href: "debug/list?indexed=true", Text: "Assigned (all)", Description: "same as above, but includes repositories which this instance temporarily holds during re-balancing"},
+				{Href: "debug/queue", Text: "Indexing Queue State", Description: "list of all repositories in the indexing queue, sorted by descending priority"},
 			}...)
 			s.addDebugHandlers(mux)
 			debug.Printf("serving HTTP on %s", conf.listen)


### PR DESCRIPTION
<img width="859" alt="Screen Shot 2022-06-02 at 8 58 53 AM" src="https://user-images.githubusercontent.com/9022011/171673680-caef70b6-c560-4e79-85fe-09dd14497abc.png">
