### PR TITLE
Create `newlines` type

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -242,7 +242,12 @@ func (p *contentProvider) fillContentMatches(ms []*candidateMatch, numContextLin
 }
 
 type newlines struct {
-	locs     []uint32
+	// locs is the sorted set of byte offsets of the newlines in the file
+	locs []uint32
+
+	// fileSize is just the number of bytes in the file. It is stored
+	// on this struct so we can safely know the length of the last line
+	// in the file since not all files end in a newline.
 	fileSize uint32
 }
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -64,14 +64,14 @@ func (p *contentProvider) docSections() []DocumentSection {
 	return p._sects
 }
 
-func (p *contentProvider) newlines() []uint32 {
+func (p *contentProvider) newlines() newlines {
 	if p._nl == nil {
 		var sz uint32
 		p._nl, sz, p.err = p.id.readNewlines(p.idx, p._nlBuf)
 		p._nlBuf = p._nl
 		p.stats.ContentBytesLoaded += int64(sz)
 	}
-	return p._nl
+	return newlines{locs: p._nl, fileSize: p.fileSize}
 }
 
 func (p *contentProvider) data(fileName bool) []byte {
@@ -167,7 +167,7 @@ func (p *contentProvider) fillContentMatches(ms []*candidateMatch, numContextLin
 	var result []LineMatch
 	for len(ms) > 0 {
 		m := ms[0]
-		num, lineStart, lineEnd := m.line(p.newlines(), p.fileSize)
+		num, lineStart, lineEnd := p.newlines().atOffset(m.byteOffset)
 
 		var lineCands []*candidateMatch
 
@@ -215,8 +215,8 @@ func (p *contentProvider) fillContentMatches(ms []*candidateMatch, numContextLin
 		finalMatch.Line = data[lineStart:lineEnd]
 
 		if numContextLines > 0 {
-			finalMatch.Before = getLines(data, p.newlines(), num-numContextLines, num)
-			finalMatch.After = getLines(data, p.newlines(), num+1, num+1+numContextLines)
+			finalMatch.Before = p.newlines().getLines(data, num-numContextLines, num)
+			finalMatch.After = p.newlines().getLines(data, num+1, num+1+numContextLines)
 		}
 
 		for _, m := range lineCands {
@@ -241,14 +241,39 @@ func (p *contentProvider) fillContentMatches(ms []*candidateMatch, numContextLin
 	return result
 }
 
+type newlines struct {
+	locs     []uint32
+	fileSize uint32
+}
+
+// atOffset takes a byte offset and returns the 1-based line number of the line
+// containing the offset as well as the start and end offsets of that line.
+func (nls newlines) atOffset(offset uint32) (lineNumber, lineStart, lineEnd int) {
+	idx := sort.Search(len(nls.locs), func(n int) bool {
+		return nls.locs[n] >= offset
+	})
+
+	end := int(nls.fileSize)
+	if idx < len(nls.locs) {
+		end = int(nls.locs[idx])
+	}
+
+	start := 0
+	if idx > 0 {
+		start = int(nls.locs[idx-1] + 1)
+	}
+
+	return idx + 1, start, end
+}
+
 // getLines returns a slice of data containing the lines [low, high).
 // low is 1-based and inclusive. high is exclusive.
-func getLines(data []byte, newLines []uint32, low, high int) []byte {
+func (nls newlines) getLines(data []byte, low, high int) []byte {
 	// newlines[0] is the start of the 2nd line in data.
 	// So adjust low and high to be based on newLines.
 	low -= 2
 	high -= 2
-	if low >= high || high < 0 || low >= len(newLines) || len(newLines) == 0 {
+	if low >= high || high < 0 || low >= len(nls.locs) || len(nls.locs) == 0 {
 		return nil
 	}
 
@@ -256,13 +281,13 @@ func getLines(data []byte, newLines []uint32, low, high int) []byte {
 	if low < 0 {
 		startIndex = 0
 	} else {
-		startIndex = newLines[low] + 1
+		startIndex = nls.locs[low] + 1
 	}
 
-	if high >= len(newLines) {
+	if high >= len(nls.locs) {
 		return data[startIndex:]
 	}
-	return data[startIndex:newLines[high]]
+	return data[startIndex:nls.locs[high]]
 }
 
 const (

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -251,8 +251,11 @@ type newlines struct {
 	fileSize uint32
 }
 
-// atOffset takes a byte offset and returns the 1-based line number of the line
-// containing the offset as well as the start and end offsets of that line.
+// atOffset returns the line containing the offset. If the offset lands on
+// the newline ending line M, we return M.  The line is characterized
+// by its linenumber (base-1, byte index of line start, byte index of
+// line end). The line end is the index of a newline, or the filesize
+// (if matching the last line of the file.)
 func (nls newlines) atOffset(offset uint32) (lineNumber, lineStart, lineEnd int) {
 	idx := sort.Search(len(nls.locs), func(n int) bool {
 		return nls.locs[n] >= offset

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -13,12 +13,17 @@ two
 three
 four`)
 
-	var newLines []uint32
+	var locs []uint32
 	for i, c := range data {
 		if c == '\n' {
-			newLines = append(newLines, uint32(i))
+			locs = append(locs, uint32(i))
 		}
 	}
+	newLines := newlines{
+		locs:     locs,
+		fileSize: uint32(len(data)),
+	}
+
 	lines := bytes.Split(data, []byte{'\n'}) // TODO does split group consecutive sep?
 	wantGetLines := func(low, high int) []byte {
 		low--
@@ -41,7 +46,7 @@ four`)
 	for low := -1; low <= len(lines)+2; low++ {
 		for high := low; high <= len(lines)+2; high++ {
 			want := wantGetLines(low, high)
-			got := getLines(data, newLines, low, high)
+			got := newLines.getLines(data, low, high)
 			if d := cmp.Diff(string(want), string(got)); d != "" {
 				t.Fatal(d)
 			}

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -7,23 +7,26 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGetLines(t *testing.T) {
-	data := []byte(`one
-two
-three
-four`)
-
+func getNewlines(data []byte) newlines {
 	var locs []uint32
 	for i, c := range data {
 		if c == '\n' {
 			locs = append(locs, uint32(i))
 		}
 	}
-	newLines := newlines{
+	return newlines{
 		locs:     locs,
 		fileSize: uint32(len(data)),
 	}
+}
 
+func TestGetLines(t *testing.T) {
+	data := []byte(`one
+two
+three
+four`)
+
+	newLines := getNewlines(data)
 	lines := bytes.Split(data, []byte{'\n'}) // TODO does split group consecutive sep?
 	wantGetLines := func(low, high int) []byte {
 		low--

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -56,3 +56,73 @@ four`)
 		}
 	}
 }
+
+func TestAtOffset(t *testing.T) {
+	cases := []struct {
+		data       []byte
+		offset     uint32
+		lineNumber int
+		lineStart  int
+		lineEnd    int
+	}{{
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     0,
+		lineNumber: 1, lineStart: 0, lineEnd: 6,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     6,
+		lineNumber: 1, lineStart: 0, lineEnd: 6,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     2,
+		lineNumber: 1, lineStart: 0, lineEnd: 6,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     2,
+		lineNumber: 1, lineStart: 0, lineEnd: 6,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     7,
+		lineNumber: 2, lineStart: 7, lineEnd: 14,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     11,
+		lineNumber: 2, lineStart: 7, lineEnd: 14,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		offset:     15,
+		lineNumber: 3, lineStart: 15, lineEnd: 15,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11."),
+		offset:     7,
+		lineNumber: 2, lineStart: 7, lineEnd: 14,
+	}, {
+		data:       []byte("\n\n"),
+		offset:     0,
+		lineNumber: 1, lineStart: 0, lineEnd: 0,
+	}, {
+		data:       []byte("\n\n"),
+		offset:     1,
+		lineNumber: 2, lineStart: 1, lineEnd: 1,
+	}, {
+		data:       []byte("\n\n"),
+		offset:     3,
+		lineNumber: 3, lineStart: 2, lineEnd: 2,
+	}}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			nls := getNewlines(tt.data)
+			gotLineNumber, gotLineStart, gotLineEnd := nls.atOffset(tt.offset)
+			if gotLineNumber != tt.lineNumber {
+				t.Fatalf("expected line number %d, got %d", tt.lineNumber, gotLineNumber)
+			}
+			if gotLineStart != tt.lineStart {
+				t.Fatalf("expected line start %d, got %d", tt.lineStart, gotLineStart)
+			}
+			if gotLineEnd != tt.lineEnd {
+				t.Fatalf("expected line end %d, got %d", tt.lineEnd, gotLineEnd)
+			}
+		})
+	}
+}

--- a/matchiter.go
+++ b/matchiter.go
@@ -17,7 +17,6 @@ package zoekt
 import (
 	"bytes"
 	"fmt"
-	"sort"
 )
 
 // candidateMatch is a candidate match for a substring.
@@ -57,29 +56,6 @@ func (m *candidateMatch) matchContent(content []byte) bool {
 		m.byteMatchSz = uint32(sz)
 		return ok
 	}
-}
-
-// line returns the line holding the match. If the match starts with
-// the newline ending line M, we return M.  The line is characterized
-// by its linenumber (base-1, byte index of line start, byte index of
-// line end).  The line end is the index of a newline, or the filesize
-// (if matching the last line of the file.)
-func (m *candidateMatch) line(newlines []uint32, fileSize uint32) (lineNum, lineStart, lineEnd int) {
-	idx := sort.Search(len(newlines), func(n int) bool {
-		return newlines[n] >= m.byteOffset
-	})
-
-	end := int(fileSize)
-	if idx < len(newlines) {
-		end = int(newlines[idx])
-	}
-
-	start := 0
-	if idx > 0 {
-		start = int(newlines[idx-1] + 1)
-	}
-
-	return idx + 1, start, end
 }
 
 // matchIterator is a docIterator that produces candidateMatches for a given document

--- a/matchtree.go
+++ b/matchtree.go
@@ -558,7 +558,7 @@ func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matc
 	lines := make([]lineRange, 0, len(t.children[fewestChildren].(*substrMatchTree).current))
 	prev := -1
 	for _, candidate := range t.children[fewestChildren].(*substrMatchTree).current {
-		line, byteStart, byteEnd := candidate.line(cp.newlines(), cp.fileSize)
+		line, byteStart, byteEnd := cp.newlines().atOffset(candidate.byteOffset)
 		if line == prev {
 			continue
 		}


### PR DESCRIPTION
As I'm working towards supporting multiline results in Zoekt, one of the recurring needs was the ability to get the line number at the end of the match. Currently, `candidateMatch.line()` assumes that the candidate match only spans a single line and returns the line containing the beginning of the match. This is fine for single-line matches, but not for multi-line matches. 

This PR creates a new `newlines` type that is returned from `(*contentProvider).newlines()`. The type defines two new methods:
- `(newlines).atOffset()`, which replaces the functionality of `candidateMatch.line()`, and 
- `(newlines).getLines()`, which replaces the functionality of the standalone `getLines()` 

This will let me reuse the `atOffset` method for calculating the line info for the end of the candidate match. As a bonus, I think it organizes the newline-related code a bit better. 