### PR TITLE
Convert regexp capture groups to non-capture groups

### DIFF
--- a/query/parse.go
+++ b/query/parse.go
@@ -231,6 +231,15 @@ func regexpQuery(text string, content, file bool) (Q, error) {
 		return nil, err
 	}
 
+	if hasCapture(r) {
+		re, err := ConvertCapture(r)
+		if err == nil {
+			r = re
+		} else {
+			log.Printf("WARN: ConvertCapture error: %s", err)
+		}
+	}
+
 	if r.Op == syntax.OpLiteral {
 		expr = &Substring{
 			Pattern:  string(r.Rune),

--- a/query/parse.go
+++ b/query/parse.go
@@ -231,14 +231,7 @@ func regexpQuery(text string, content, file bool) (Q, error) {
 		return nil, err
 	}
 
-	if hasCapture(r) {
-		re, err := ConvertCapture(r)
-		if err == nil {
-			r = re
-		} else {
-			log.Printf("WARN: ConvertCapture error: %s", err)
-		}
-	}
+	r = optimizeRegexp(r)
 
 	if r.Op == syntax.OpLiteral {
 		expr = &Substring{

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -64,7 +64,7 @@ func TestParseQuery(t *testing.T) {
 		{"abccase:yes", &Substring{Pattern: "abccase:yes"}},
 		{"file:abc", &Substring{Pattern: "abc", FileName: true}},
 		{"branch:pqr", &Branch{Pattern: "pqr"}},
-		{"((x) )", &Substring{Pattern: "x"}},
+		{"((x|y) )", &Regexp{Regexp: mustParseRE("[xy]")}},
 		{"file:helpers\\.go byte", NewAnd(
 			&Substring{Pattern: "helpers.go", FileName: true},
 			&Substring{Pattern: "byte"})},

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -46,11 +46,11 @@ func TestParseQuery(t *testing.T) {
 			NewAnd(&Substring{Pattern: "ppp"}, &Substring{Pattern: "qqq"}),
 			NewAnd(&Substring{Pattern: "rrr"}, &Substring{Pattern: "sss"}))},
 		{"((x) ora b(z(d)))", NewAnd(
-			&Regexp{Regexp: mustParseRE("(x)")},
+			&Substring{Pattern: "x"},
 			&Substring{Pattern: "ora"},
-			&Regexp{Regexp: mustParseRE("b(z(d))")})},
+			&Substring{Pattern: "bzd"})},
 		{"( )", &Const{Value: true}},
-		{"(abc)(de)", &Regexp{Regexp: mustParseRE("(abc)(de)")}},
+		{"(abc)(de)", &Substring{Pattern: "abcde"}},
 		{"sub-pixel", &Substring{Pattern: "sub-pixel"}},
 		{"abc", &Substring{Pattern: "abc"}},
 		{"ABC", &Substring{Pattern: "ABC", CaseSensitive: true}},
@@ -64,7 +64,7 @@ func TestParseQuery(t *testing.T) {
 		{"abccase:yes", &Substring{Pattern: "abccase:yes"}},
 		{"file:abc", &Substring{Pattern: "abc", FileName: true}},
 		{"branch:pqr", &Branch{Pattern: "pqr"}},
-		{"((x) )", &Regexp{Regexp: mustParseRE("(x)")}},
+		{"((x) )", &Substring{Pattern: "x"}},
 		{"file:helpers\\.go byte", NewAnd(
 			&Substring{Pattern: "helpers.go", FileName: true},
 			&Substring{Pattern: "byte"})},
@@ -81,7 +81,7 @@ func TestParseQuery(t *testing.T) {
 		{"file:\"\"", &Const{true}},
 		{"abc.*def", &Regexp{Regexp: mustParseRE("abc.*def")}},
 		{"abc\\.\\*def", &Substring{Pattern: "abc.*def"}},
-		{"(abc)", &Regexp{Regexp: mustParseRE("(abc)")}},
+		{"(abc)", &Substring{Pattern: "abc"}},
 
 		{"c:abc", &Substring{Pattern: "abc", Content: true}},
 		{"content:abc", &Substring{Pattern: "abc", Content: true}},
@@ -91,7 +91,7 @@ func TestParseQuery(t *testing.T) {
 		{"sym:pqr", &Symbol{&Substring{Pattern: "pqr"}}},
 		{"sym:Pqr", &Symbol{&Substring{Pattern: "Pqr", CaseSensitive: true}}},
 		{"sym:.*", &Symbol{&Regexp{Regexp: mustParseRE(".*")}}},
-		{"sym:a(b|d)e", &Symbol{&Regexp{Regexp: mustParseRE("a(b|d)e")}}},
+		{"sym:a(b|d)e", &Symbol{&Regexp{Regexp: mustParseRE("a[bd]e")}}},
 
 		// case
 		{"abc case:yes", &Substring{Pattern: "abc", CaseSensitive: true}},

--- a/query/regexp.go
+++ b/query/regexp.go
@@ -43,13 +43,11 @@ func LowerRegexp(r *syntax.Regexp) *syntax.Regexp {
 	return &newRE
 }
 
-// Optimize Regexp.
-// Convert capturing groups to non-capturing groups.
+// optimizeRegexp converts capturing groups to non-capturing groups.
 // Returns original input if an error is encountered
 func optimizeRegexp(re *syntax.Regexp) *syntax.Regexp {
 	r := convertCapture(re)
-	r = r.Simplify()
-	return r
+	return r.Simplify()
 }
 
 func convertCapture(re *syntax.Regexp) *syntax.Regexp {

--- a/query/regexp.go
+++ b/query/regexp.go
@@ -51,26 +51,27 @@ func optimizeRegexp(re *syntax.Regexp) *syntax.Regexp {
 }
 
 func convertCapture(re *syntax.Regexp) *syntax.Regexp {
-	if hasCapture(re) {
-		// Make a copy so in unlikely event of an error the original can be used as a fallback
-		r, err := syntax.Parse(re.String(), regexpFlags)
-		if err != nil {
-			log.Printf("failed to copy regexp `%s`: %v", re, err)
-			return re
-		}
-
-		r = uncapture(r)
-
-		// Parse again for new structure to take effect
-		r, err = syntax.Parse(r.String(), regexpFlags)
-		if err != nil {
-			log.Printf("failed to parse regexp after uncapture `%s`: %v", r, err)
-			return re
-		}
-
-		return r
+	if !hasCapture(re) {
+		return re
 	}
-	return re
+
+	// Make a copy so in unlikely event of an error the original can be used as a fallback
+	r, err := syntax.Parse(re.String(), regexpFlags)
+	if err != nil {
+		log.Printf("failed to copy regexp `%s`: %v", re, err)
+		return re
+	}
+
+	r = uncapture(r)
+
+	// Parse again for new structure to take effect
+	r, err = syntax.Parse(r.String(), regexpFlags)
+	if err != nil {
+		log.Printf("failed to parse regexp after uncapture `%s`: %v", r, err)
+		return re
+	}
+
+	return r
 }
 
 func hasCapture(r *syntax.Regexp) bool {

--- a/query/regexp.go
+++ b/query/regexp.go
@@ -91,7 +91,9 @@ func hasCapture(r *syntax.Regexp) bool {
 func uncapture(r *syntax.Regexp) *syntax.Regexp {
 	if r.Op == syntax.OpCapture {
 		// Captures only have one subexpression
-		return uncapture(r.Sub[0])
+		r.Op = syntax.OpConcat
+		r.Cap = 0
+		r.Name = ""
 	}
 
 	for i, s := range r.Sub {

--- a/query/regexp_test.go
+++ b/query/regexp_test.go
@@ -65,3 +65,20 @@ func TestLowerRegexp(t *testing.T) {
 		t.Errorf("got mutated original %s want %s", re.String(), in)
 	}
 }
+
+func TestConvertCapture(t *testing.T) {
+	in := "(hello)world"
+	re := mustParseRE(in)
+
+	got, err := ConvertCapture(re)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := mustParseRE("(?:hello)world")
+	if !got.Equal(want) {
+		printRegexp(t, got, 0)
+		printRegexp(t, want, 0)
+		t.Errorf("got %s, want %s", got, want)
+	}
+}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -562,6 +562,15 @@ func BenchmarkShardedSearch(b *testing.B) {
 	needleSub := &query.Substring{Pattern: "needle"}
 	haystackSub := &query.Substring{Pattern: "haystack"}
 	helloworldSub := &query.Substring{Pattern: "helloworld"}
+	haystackCap, err := query.Parse("hay(s(t))(a)ck")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	haystackNonCap, err := query.Parse("hay(?:s(?:t))(?:a)ck")
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	setAnd := func(q query.Q) func() query.Q {
 		return func() query.Q {
@@ -589,6 +598,8 @@ func BenchmarkShardedSearch(b *testing.B) {
 		{"substring all results", func() query.Q { return haystackSub }, len(repos) * filesPerRepo},
 		{"substring no results", func() query.Q { return helloworldSub }, 0},
 		{"substring some results", func() query.Q { return needleSub }, len(repos)},
+		{"regexp all results capture", func() query.Q { return haystackCap }, len(repos) * filesPerRepo},
+		{"regexp all results non-capture", func() query.Q { return haystackNonCap }, len(repos) * filesPerRepo},
 
 		{"substring all results and repo set", setAnd(haystackSub), len(repoSetIDs) * filesPerRepo},
 		{"substring some results and repo set", setAnd(needleSub), len(repoSetIDs)},

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -598,6 +598,7 @@ func BenchmarkShardedSearch(b *testing.B) {
 		{"substring all results", func() query.Q { return haystackSub }, len(repos) * filesPerRepo},
 		{"substring no results", func() query.Q { return helloworldSub }, 0},
 		{"substring some results", func() query.Q { return needleSub }, len(repos)},
+
 		{"regexp all results capture", func() query.Q { return haystackCap }, len(repos) * filesPerRepo},
 		{"regexp all results non-capture", func() query.Q { return haystackNonCap }, len(repos) * filesPerRepo},
 


### PR DESCRIPTION
Progress on https://github.com/sourcegraph/sourcegraph/issues/34826

When a regexp query is parsed if it contains capture groups the regexp is rewritten to use non-capture groups.
In addition to the speed benefit described in the above issue this also allows certain regexp to be rewritten as Substring queries. e.g. The Regexp query `ba(na)na` becomes `ba(?:na)na` which can be simplified to the literal `banana` and used as a Substring query.

### Test Plan
Tested locally:
- Added `TestConvertCapture` to verify correct behaviour converting from capture to non-capture group
- Updated `TestParseQuery` cases where a Regexp query is now converted to a Substring query
- Benchmarks `^BenchmarkShardedSearch$/regexp` comparing performance of parsing the same query but using capture and non-capture groups to measure the overhead of converting the capture group case to non-capture
Here is a comparison of running the benchmark without (old time) and with (new time) the optimisation
```
name                                             old time/op    new time/op    delta
ShardedSearch/regexp_all_results_capture-16         1.26s ±14%     0.96s ± 7%  -23.83%  (p=0.008 n=5+5)
ShardedSearch/regexp_all_results_non-capture-16     934ms ± 5%     941ms ± 1%     ~     (p=0.690 n=5+5)

name                                             old alloc/op   new alloc/op   delta
ShardedSearch/regexp_all_results_capture-16        3.77GB ± 0%    3.01GB ± 0%  -20.30%  (p=0.008 n=5+5)
ShardedSearch/regexp_all_results_non-capture-16    3.01GB ± 0%    3.01GB ± 0%     ~     (p=1.000 n=5+5)

name                                             old allocs/op  new allocs/op  delta
ShardedSearch/regexp_all_results_capture-16         33.7M ± 0%     26.2M ± 0%  -22.14%  (p=0.016 n=5+4)
ShardedSearch/regexp_all_results_non-capture-16     26.2M ± 0%     26.2M ± 0%     ~     (p=0.857 n=5+5)
```

Additionally I ran `zoekt-webserver` verifying correct behaviour with different regexp queries trying to detect any edge cases. As a safeguard the code modifies a copy of the original regexp such that in the extremely unlikely event of an edge case which results in an error the code can fallback and use the original regexp query