### PR TITLE
indexData: experimental ngram map via binary search

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -1124,6 +1124,10 @@ func TestListRepos(t *testing.T) {
 			},
 		}
 
+		if os.Getenv("ZOEKT_ENABLE_NGRAM_BS") != "" {
+			want.Stats.IndexBytes = 228
+		}
+
 		if diff := cmp.Diff(want, res); diff != "" {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}

--- a/indexdata.go
+++ b/indexdata.go
@@ -33,7 +33,7 @@ type indexData struct {
 
 	file IndexFile
 
-	ngrams combinedNgramOffset
+	ngrams ngramMap
 
 	newlinesStart uint32
 	newlinesIndex []uint32

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -15,6 +15,7 @@
 package zoekt
 
 import (
+	"encoding/binary"
 	"sort"
 )
 
@@ -355,4 +356,90 @@ func (a *asciiNgramOffset) DumpMap() map[ngram]simpleSection {
 
 func (a *asciiNgramOffset) SizeBytes() int {
 	return 4*len(a.entries) + 4*len(a.chunkOffsets)
+}
+
+// ngramMap is an transient type while we investigate the performance of
+// combinedNgramOffset (established) vs binarySearch (new).
+//
+// It is like an interface, but we do the drudgery so we still get a useful
+// zero value (instead of nil panics in tests).
+type ngramMap struct {
+	offsetMap combinedNgramOffset
+	bsMap     binarySearchNgram
+}
+
+func (m ngramMap) Get(gram ngram) simpleSection {
+	if m.offsetMap.asc != nil {
+		return m.offsetMap.Get(gram)
+	}
+	return m.bsMap.Get(gram)
+}
+
+func (m ngramMap) DumpMap() map[ngram]simpleSection {
+	if m.offsetMap.asc != nil {
+		return m.offsetMap.DumpMap()
+	}
+	return m.bsMap.DumpMap()
+}
+
+func (m ngramMap) SizeBytes() int {
+	if m.offsetMap.asc != nil {
+		return m.offsetMap.SizeBytes()
+	}
+	return 0 // binarySearch only uses mmaped data.
+}
+
+type binarySearchNgram struct {
+	// ngramText is the bytes at indexTOC.ngramText
+	//
+	// It is a sorted ngramSlice marshalled as list of bigendian uint64s.
+	ngramText []byte
+	// postingIndex is the index section of the compoundSection for the posting
+	// lists.
+	//
+	// It is a list of offsets in the a order corresponding with ngramText. It
+	// is marshalled as a list of bigendian uint32s.
+	postingOffsets []uint32
+	// postingDataSentinalOffset is where postingData ends in the index file.
+	// This is used to calculate the size of the last posting.
+	postingDataSentinalOffset uint32
+}
+
+func (b binarySearchNgram) Get(gram ngram) (ss simpleSection) {
+	getNGram := func(i int) ngram {
+		i *= ngramEncoding
+		return ngram(binary.BigEndian.Uint64(b.ngramText[i : i+ngramEncoding]))
+	}
+
+	size := len(b.ngramText) / ngramEncoding
+	if size == 0 {
+		return simpleSection{}
+	}
+	x := sort.Search(size, func(i int) bool { return gram <= getNGram(i) })
+	if x >= size || getNGram(x) != gram {
+		return simpleSection{}
+	}
+
+	if x+1 < size {
+		return simpleSection{
+			off: b.postingOffsets[x],
+			sz:  b.postingOffsets[x+1] - b.postingOffsets[x],
+		}
+	} else {
+		return simpleSection{
+			off: b.postingOffsets[x],
+			sz:  b.postingDataSentinalOffset - b.postingOffsets[x],
+		}
+	}
+}
+
+func (b binarySearchNgram) DumpMap() map[ngram]simpleSection {
+	m := map[ngram]simpleSection{}
+	ngramText := b.ngramText
+	for len(ngramText) > 0 {
+		gram := ngram(binary.BigEndian.Uint64(ngramText))
+		ngramText = ngramText[8:]
+		m[gram] = b.Get(gram)
+	}
+	return m
 }

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -400,9 +400,9 @@ type binarySearchNgram struct {
 	// It is a list of offsets in the a order corresponding with ngramText. It
 	// is marshalled as a list of bigendian uint32s.
 	postingOffsets []uint32
-	// postingDataSentinalOffset is where postingData ends in the index file.
+	// postingDataSentinelOffset is where postingData ends in the index file.
 	// This is used to calculate the size of the last posting.
-	postingDataSentinalOffset uint32
+	postingDataSentinelOffset uint32
 }
 
 func (b binarySearchNgram) Get(gram ngram) (ss simpleSection) {
@@ -428,17 +428,17 @@ func (b binarySearchNgram) Get(gram ngram) (ss simpleSection) {
 	} else {
 		return simpleSection{
 			off: b.postingOffsets[x],
-			sz:  b.postingDataSentinalOffset - b.postingOffsets[x],
+			sz:  b.postingDataSentinelOffset - b.postingOffsets[x],
 		}
 	}
 }
 
 func (b binarySearchNgram) DumpMap() map[ngram]simpleSection {
-	m := map[ngram]simpleSection{}
 	ngramText := b.ngramText
+	m := make(map[ngram]simpleSection, len(ngramText)/ngramEncoding)
 	for len(ngramText) > 0 {
 		gram := ngram(binary.BigEndian.Uint64(ngramText))
-		ngramText = ngramText[8:]
+		ngramText = ngramText[ngramEncoding:]
 		m[gram] = b.Get(gram)
 	}
 	return m

--- a/read.go
+++ b/read.go
@@ -489,7 +489,7 @@ func (d *indexData) readBinarySearchNgrams(toc *indexTOC) (binarySearchNgram, er
 	return binarySearchNgram{
 		ngramText:                 ngramText,
 		postingOffsets:            toc.postings.offsets,
-		postingDataSentinalOffset: toc.postings.data.off + toc.postings.data.sz,
+		postingDataSentinelOffset: toc.postings.data.off + toc.postings.data.sz,
 	}, nil
 }
 

--- a/read.go
+++ b/read.go
@@ -289,9 +289,18 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	d.ngrams, err = d.readNgrams(toc)
-	if err != nil {
-		return nil, err
+	if os.Getenv("ZOEKT_ENABLE_NGRAM_BS") != "" {
+		bsMap, err := d.readBinarySearchNgrams(toc)
+		if err != nil {
+			return nil, err
+		}
+		d.ngrams = ngramMap{bsMap: bsMap}
+	} else {
+		offsetMap, err := d.readNgrams(toc)
+		if err != nil {
+			return nil, err
+		}
+		d.ngrams = ngramMap{offsetMap: offsetMap}
 	}
 
 	if os.Getenv("ZOEKT_ENABLE_BLOOM") != "" {
@@ -469,6 +478,19 @@ func (d *indexData) readNgrams(toc *indexTOC) (combinedNgramOffset, error) {
 	}
 
 	return makeCombinedNgramOffset(ngrams, postingsIndex), nil
+}
+
+func (d *indexData) readBinarySearchNgrams(toc *indexTOC) (binarySearchNgram, error) {
+	ngramText, err := d.readSectionBlob(toc.ngramText)
+	if err != nil {
+		return binarySearchNgram{}, err
+	}
+
+	return binarySearchNgram{
+		ngramText:                 ngramText,
+		postingOffsets:            toc.postings.offsets,
+		postingDataSentinalOffset: toc.postings.data.off + toc.postings.data.sz,
+	}, nil
 }
 
 func (d *indexData) readFileNameNgrams(toc *indexTOC) (map[ngram][]byte, error) {


### PR DESCRIPTION
This is an experiment where instead of creating an in memory
representation of the ngram map, we instead lazily read and decode the
data in the search request path.

This uses the fact that we marshal on to disk the ngrams in a sorted
order, so we can binary search it. This requires no changes to how we
marshal, so can be done without re-indexing.

I expect this to be slower, but I am not sure how much slower. But it
will give us good evidence that investing in a better on disk map (ie a
btree or a perfect hash map) would be worthwhile.

It is gated behind the environment variable ZOEKT_ENABLE_NGRAM_BS. I
intend to turn it on in a dogfood cluster to see experimental impact. If
that goes well I'll roll it out to a fraction of our production cluster.

Test Plan: ZOEKT_ENABLE_NGRAM_BS=1 go test ./... and some manual testing
with and without it turned on.