### PR TITLE
Split `lineBounds` out into its own method

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -274,20 +274,20 @@ func (nls newlines) lineBounds(lineNumber int) (start, end uint32) {
 	startIdx := lineNumber - 2
 	endIdx := lineNumber - 1
 
-	if startIdx >= 0 && startIdx < len(nls.locs) {
-		start = nls.locs[startIdx] + 1
-	} else if startIdx < 0 {
+	if startIdx < 0 {
 		start = 0
 	} else if startIdx >= len(nls.locs) {
 		start = nls.fileSize
+	} else {
+		start = nls.locs[startIdx] + 1
 	}
 
-	if endIdx >= 0 && endIdx < len(nls.locs) {
-		end = nls.locs[endIdx]
-	} else if endIdx < 0 {
+	if endIdx < 0 {
 		end = 0
 	} else if endIdx >= len(nls.locs) {
 		end = nls.fileSize
+	} else {
+		end = nls.locs[endIdx]
 	}
 
 	return start, end

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -294,7 +294,7 @@ func (nls newlines) lineBounds(lineNumber int) (start, end uint32) {
 }
 
 // getLines returns a slice of data containing the lines [low, high).
-// low is 1-based and inclusive. high is exclusive.
+// low is 1-based and inclusive. high is 1-based and exclusive.
 func (nls newlines) getLines(data []byte, low, high int) []byte {
 	if low >= high {
 		return nil

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -21,39 +21,45 @@ func getNewlines(data []byte) newlines {
 }
 
 func TestGetLines(t *testing.T) {
-	data := []byte(`one
-two
-three
-four`)
-
-	newLines := getNewlines(data)
-	lines := bytes.Split(data, []byte{'\n'}) // TODO does split group consecutive sep?
-	wantGetLines := func(low, high int) []byte {
-		low--
-		high--
-		if low < 0 {
-			low = 0
-		}
-		if low >= len(lines) {
-			return nil
-		}
-		if high <= 0 {
-			return nil
-		}
-		if high > len(lines) {
-			high = len(lines)
-		}
-		return bytes.Join(lines[low:high], []byte{'\n'})
+	contents := [][]byte{
+		[]byte("one\ntwo\nthree\nfour"),
+		[]byte("one\ntwo\nthree\nfour\n"),
+		[]byte("one"),
+		[]byte(""),
 	}
 
-	for low := -1; low <= len(lines)+2; low++ {
-		for high := low; high <= len(lines)+2; high++ {
-			want := wantGetLines(low, high)
-			got := newLines.getLines(data, low, high)
-			if d := cmp.Diff(string(want), string(got)); d != "" {
-				t.Fatal(d)
+	for _, content := range contents {
+		t.Run("", func(t *testing.T) {
+			newLines := getNewlines(content)
+			lines := bytes.Split(content, []byte{'\n'}) // TODO does split group consecutive sep?
+			wantGetLines := func(low, high int) []byte {
+				low--
+				high--
+				if low < 0 {
+					low = 0
+				}
+				if low >= len(lines) {
+					return nil
+				}
+				if high <= 0 {
+					return nil
+				}
+				if high > len(lines) {
+					high = len(lines)
+				}
+				return bytes.Join(lines[low:high], []byte{'\n'})
 			}
-		}
+
+			for low := -1; low <= len(lines)+2; low++ {
+				for high := low; high <= len(lines)+2; high++ {
+					want := wantGetLines(low, high)
+					got := newLines.getLines(content, low, high)
+					if d := cmp.Diff(string(want), string(got)); d != "" {
+						t.Fatal(d)
+					}
+				}
+			}
+		})
 	}
 }
 
@@ -108,6 +114,10 @@ func TestAtOffset(t *testing.T) {
 		data:       []byte("\n\n"),
 		offset:     3,
 		lineNumber: 3, lineStart: 2, lineEnd: 2,
+	}, {
+		data:       []byte("line with no newlines"),
+		offset:     3,
+		lineNumber: 1, lineStart: 0, lineEnd: 21,
 	}}
 
 	for _, tt := range cases {

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -126,3 +126,57 @@ func TestAtOffset(t *testing.T) {
 		})
 	}
 }
+
+func TestLineBounds(t *testing.T) {
+	cases := []struct {
+		data       []byte
+		lineNumber int
+		start      uint32
+		end        uint32
+	}{{
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		lineNumber: 1,
+		start:      0, end: 6,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		lineNumber: 2,
+		start:      7, end: 14,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		lineNumber: 0,
+		start:      0, end: 0,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		lineNumber: -1,
+		start:      0, end: 0,
+	}, {
+		data:       []byte("0.2.4.\n7.9.11.\n"),
+		lineNumber: 202002,
+		start:      15, end: 15,
+	}, {
+		data:       []byte("\n\n"),
+		lineNumber: 1,
+		start:      0, end: 0,
+	}, {
+		data:       []byte("\n\n"),
+		lineNumber: 2,
+		start:      1, end: 1,
+	}, {
+		data:       []byte("\n\n"),
+		lineNumber: 3,
+		start:      2, end: 2,
+	}}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			nls := getNewlines(tt.data)
+			gotStart, gotEnd := nls.lineBounds(tt.lineNumber)
+			if gotStart != tt.start {
+				t.Fatalf("expected line start %d, got %d", tt.start, gotStart)
+			}
+			if gotEnd != tt.end {
+				t.Fatalf("expected line end %d, got %d", tt.end, gotEnd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Building off #363, this splits `lineBounds` out of `atOffset` and `getLines` to reduce some of the logic duplication and so that we can fetch the boundaries of a single line from a line number rather than just a byte offset. This is another piece of information I will need to enable multiline matches. 

I added a unit test for this new method, and all existing unit tests for `lineBounds` and `getLines` still pass. 