### PR TITLE
Add ability to filter out archived repositories

### DIFF
--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -166,6 +166,7 @@ func main() {
 			"zoekt.name":           name,
 			"zoekt.gerrit-project": k,
 			"zoekt.gerrit-host":    rootURL.String(),
+			"zoekt.archived":       marshalBool(v.State == "READ_ONLY"),
 		}
 
 		for _, wl := range v.WebLinks {
@@ -214,4 +215,11 @@ func deleteStaleRepos(destDir string, filter *gitindex.Filter, repos map[string]
 		log.Fatalf("deleteRepos: %v", err)
 	}
 	return nil
+}
+
+func marshalBool(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
 }

--- a/cmd/zoekt-mirror-github/main.go
+++ b/cmd/zoekt-mirror-github/main.go
@@ -295,6 +295,12 @@ func cloneRepos(destDir string, repos []*github.Repository) error {
 		if err != nil {
 			return err
 		}
+
+		archived := false
+		if r.Archived != nil {
+			archived = *r.Archived
+		}
+
 		config := map[string]string{
 			"zoekt.web-url-type": "github",
 			"zoekt.web-url":      *r.HTMLURL,
@@ -304,6 +310,8 @@ func cloneRepos(destDir string, repos []*github.Repository) error {
 			"zoekt.github-watchers":    itoa(r.WatchersCount),
 			"zoekt.github-subscribers": itoa(r.SubscribersCount),
 			"zoekt.github-forks":       itoa(r.ForksCount),
+
+			"zoekt.archived": marshalBool(archived),
 		}
 		dest, err := gitindex.CloneRepo(destDir, *r.FullName, *r.CloneURL, config)
 		if err != nil {
@@ -316,4 +324,11 @@ func cloneRepos(destDir string, repos []*github.Repository) error {
 	}
 
 	return nil
+}
+
+func marshalBool(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
 }

--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -174,6 +174,8 @@ func fetchProjects(destDir, token string, projects []*gitlab.Project) {
 
 			"zoekt.gitlab-stars": strconv.Itoa(p.StarCount),
 			"zoekt.gitlab-forks": strconv.Itoa(p.ForksCount),
+
+			"zoekt.archived": marshalBool(p.Archived),
 		}
 
 		cloneURL := p.HTTPURLToRepo
@@ -186,4 +188,11 @@ func fetchProjects(destDir, token string, projects []*gitlab.Project) {
 			fmt.Println(dest)
 		}
 	}
+}
+
+func marshalBool(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
 }

--- a/query/parse.go
+++ b/query/parse.go
@@ -125,6 +125,15 @@ func parseExpr(in []byte) (Q, int, error) {
 		}
 
 		expr = &Repo{r}
+	case tokArchived:
+		switch text {
+		case "yes":
+			expr = RawConfig(RcOnlyArchived)
+		case "no":
+			expr = RawConfig(RcNoArchived)
+		default:
+			return nil, 0, fmt.Errorf("query: unknown archived argument %q, want {yes,no}", text)
+		}
 	case tokBranch:
 		expr = &Branch{Pattern: text}
 	case tokText, tokRegex:
@@ -364,9 +373,11 @@ const (
 	tokLang       = 12
 	tokSym        = 13
 	tokType       = 14
+	tokArchived   = 15
 )
 
 var tokNames = map[int]string{
+	tokArchived:   "Archived",
 	tokBranch:     "Branch",
 	tokCase:       "Case",
 	tokError:      "Error",
@@ -384,20 +395,21 @@ var tokNames = map[int]string{
 }
 
 var prefixes = map[string]int{
-	"b:":       tokBranch,
-	"branch:":  tokBranch,
-	"c:":       tokContent,
-	"case:":    tokCase,
-	"content:": tokContent,
-	"f:":       tokFile,
-	"file:":    tokFile,
-	"r:":       tokRepo,
-	"regex:":   tokRegex,
-	"repo:":    tokRepo,
-	"lang:":    tokLang,
-	"sym:":     tokSym,
-	"t:":       tokType,
-	"type:":    tokType,
+	"archived:": tokArchived,
+	"b:":        tokBranch,
+	"branch:":   tokBranch,
+	"c:":        tokContent,
+	"case:":     tokCase,
+	"content:":  tokContent,
+	"f:":        tokFile,
+	"file:":     tokFile,
+	"r:":        tokRepo,
+	"regex:":    tokRegex,
+	"repo:":     tokRepo,
+	"lang:":     tokLang,
+	"sym:":      tokSym,
+	"t:":        tokType,
+	"type:":     tokType,
 }
 
 var reservedWords = map[string]int{

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -65,6 +65,8 @@ func TestParseQuery(t *testing.T) {
 		{"file:abc", &Substring{Pattern: "abc", FileName: true}},
 		{"branch:pqr", &Branch{Pattern: "pqr"}},
 		{"((x|y) )", &Regexp{Regexp: mustParseRE("[xy]")}},
+		{"archived:yes", RawConfig(RcOnlyArchived)},
+		{"archived:no", RawConfig(RcNoArchived)},
 		{"file:helpers\\.go byte", NewAnd(
 			&Substring{Pattern: "helpers.go", FileName: true},
 			&Substring{Pattern: "byte"})},

--- a/web/templates.go
+++ b/web/templates.go
@@ -170,6 +170,7 @@ document.onkeydown=function(e){
           <dt><a href="search?q=-Path%5c+file+Stream">-Path\ file Stream</a></dt><dd>search "Stream", but exclude files containing "Path File"</dd>
           <dt><a href="search?q=sym:data">sym:data</a></span></dt><dd>search for symbol definitions containing "data"</dd>
           <dt><a href="search?q=phone+r:droid">phone r:droid</a></dt><dd>search for "phone" in repositories whose name contains "droid"</dd>
+          <dt><a href="search?q=phone+archived:no">phone archived:no</a></dt><dd>search for "phone" in repositories that are not archived</dd>
           <dt><a href="search?q=phone+b:master">phone b:master</a></dt><dd>for Git repos, find "phone" in files in branches whose name contains "master".</dd>
           <dt><a href="search?q=phone+b:HEAD">phone b:HEAD</a></dt><dd>for Git repos, find "phone" in the default ('HEAD') branch.</dd>
         </dl>


### PR DESCRIPTION
#### Changes

Two changes in this PR:

1. Store the archived status of mirrored repositories in zoekt-mirror-{gerrit,gitlab,github}
    - the archive status is stored in the `zoekt.archived` field of the git config of the cloned repository
    - this approach is in line with how the existing `zoekt-sourcegraph-indexserver` represents archived repositories
    - the other zoekt-mirror binaries are for upstreams that don't have the notion of an archived repository, so I have not changed them

2. Add a new query option, `archived:` which accepts `yes`, `no`. `archived:yes` will mean only results from archived repositories are returned. `archived:no` will mean results from archived repositories are excluded. 
    - this is achieved by constructing a query using the `RawConfig` query type

#### Testing

I've tested the changed zoekt-mirror binaries as follows:

* zoekt-mirror-gitlab
	* tested with `go run ./cmd/zoekt-mirror-gitlab -dest scratch/gitlab`, checked that `archived` is set appropriately (including with an archived repo)
* zoekt-mirror-github
	* tested with `go run ./cmd/zoekt-mirror-github -dest scratch/github --user jamespwilliams -name 'archive-test'`, checked that `archived` is set appropriately (including with an archived repo)
* zoekt-mirror-gerrit
	* tested with `go run ./cmd/zoekt-mirror-gerrit -name 'arch' -dest scratch/gerrit https://go-review.googlesource.com/` and checking that `zoekt.archived` is set in `config` of the repo

I tested the new query type by building indexes from the repositories mirrored during my testing above, and running the webserver using those indexes. I played around with the `archived` option and checked that results were correctly excluded where appropriate, which they were.

#### Relevant issues

https://github.com/sourcegraph/zoekt/issues/368