### PR TITLE
Upgrade pcre2 package

### DIFF
--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -2,7 +2,7 @@ FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson curl && \
-    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0'
+    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0'
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph


### PR DESCRIPTION
This patches CVE-2022-1586 in order to facilitate customer deployments that may block deploying versions with high/critical CVEs. The details of the CVE are undergoing reanalysis so I'm patching out of precaution.