### PR TITLE
merging: lock index dir during merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install ctags
         run: ./install-ctags-alpine.sh
       - name: test
-        run: go test ./... -v
+        run: go test ./...
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: install ctags
         run: ./install-ctags-alpine.sh
       - name: test
-        run: go test ./...
+        run: go test ./... -v
 
   shellcheck:
     name: shellcheck

--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -7,12 +7,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
-
-	"github.com/google/zoekt/build"
 )
 
 func debugIndex() *ffcli.Command {
@@ -75,27 +72,6 @@ func debugMeta() *ffcli.Command {
 	}
 }
 
-func debugMerge() *ffcli.Command {
-	fs := flag.NewFlagSet("debug merge", flag.ExitOnError)
-	simulate := fs.Bool("simulate", false, "if set, merging will be simulated")
-	targetSize := fs.Int64("merge_target_size", getEnvWithDefaultInt64("SRC_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
-	index := fs.String("index", getEnvWithDefaultString("DATA_DIR", build.DefaultDir), "set index directory to use")
-	dbg := fs.Bool("debug", srcLogLevelIsDebug(), "turn on more verbose logging.")
-
-	return &ffcli.Command{
-		Name:       "merge",
-		FlagSet:    fs,
-		ShortUsage: "merge [flags] <dir>",
-		ShortHelp:  "run a full merge operation inside dir",
-		Exec: func(ctx context.Context, args []string) error {
-			if *dbg {
-				debug = log.New(os.Stderr, "", log.LstdFlags)
-			}
-			return doMerge(*index, *targetSize*1024*1024, *simulate)
-		},
-	}
-}
-
 func debugCmd() *ffcli.Command {
 	fs := flag.NewFlagSet("debug", flag.ExitOnError)
 
@@ -113,6 +89,11 @@ func debugCmd() *ffcli.Command {
   curl http://localhost:6072/debug/list[?indexed=TRUE/false]
     list the repositories that are OWNED by this instance. If indexed=true (default), the list may contain repositories
     that this instance holds temporarily, for example during rebalancing.
+
+  curl http://localhost:6072/debug/merge
+    start a full merge operation in the index directory. You can check the status with
+    "curl http://localhost:6072/metrics -sS | grep index_shard_merging_running". It is only possible
+    to trigger one merge operation at a time.
 
   curl http://localhost:6072/debug/queue
     list the repositories in the indexing queue, sorted by descending priority.
@@ -133,7 +114,6 @@ func debugCmd() *ffcli.Command {
 		FlagSet: fs,
 		Subcommands: []*ffcli.Command{
 			debugIndex(),
-			debugMerge(),
 			debugMeta(),
 			debugTrigrams(),
 		},

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -718,6 +718,7 @@ func (s *Server) handleDebugMerge(w http.ResponseWriter, _ *http.Request) {
 	go func() {
 		s.doMerge()
 	}()
+	w.Write([]byte("merging enqueued\n"))
 }
 
 func (s *Server) handleDebugIndexed(w http.ResponseWriter, r *http.Request) {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -358,10 +358,7 @@ func (s *Server) Run() {
 	go func() {
 		for range jitterTicker(s.MergeInterval, syscall.SIGUSR1) {
 			if s.shardMerging {
-				err := doMerge(s.IndexDir, s.TargetSizeBytes, false)
-				if err != nil {
-					log.Printf("error during merging: %s", err)
-				}
+				s.doMerge()
 			}
 		}
 	}()
@@ -598,6 +595,7 @@ func (s *Server) addDebugHandlers(mux *http.ServeMux) {
 
 	mux.Handle("/debug/indexed", http.HandlerFunc(s.handleDebugIndexed))
 	mux.Handle("/debug/list", http.HandlerFunc(s.handleDebugList))
+	mux.Handle("/debug/merge", http.HandlerFunc(s.handleDebugMerge))
 	mux.Handle("/debug/queue", http.HandlerFunc(s.queue.handleDebugQueue))
 }
 
@@ -704,6 +702,22 @@ func (s *Server) handleDebugList(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("copying output to response writer: %s", err), http.StatusInternalServerError)
 		return
 	}
+}
+
+// handleDebugMerge triggers a merge even if shard merging is not enabled. Users
+// can run this command during periods of low usage (evenings, weekends) to
+// trigger an initial merge run. In the steady-state, merges happen rarely, even
+// on busy instances, and users can rely on automatic merging instead.
+func (s *Server) handleDebugMerge(w http.ResponseWriter, _ *http.Request) {
+
+	// A merge operation can take very long, depending on the number merges and the
+	// target size of the compound shards. We run the merge in the background and
+	// return immediately to the user.
+	//
+	// We track the status of the merge with metricShardMergingRunning.
+	go func() {
+		s.doMerge()
+	}()
 }
 
 func (s *Server) handleDebugIndexed(w http.ResponseWriter, r *http.Request) {
@@ -978,7 +992,7 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.StringVar(&rc.root, "sourcegraph_url", os.Getenv("SRC_FRONTEND_INTERNAL"), "http://sourcegraph-frontend-internal or http://localhost:3090. If a path to a directory, we fake the Sourcegraph API and index all repos rooted under path.")
 	fs.DurationVar(&rc.interval, "interval", time.Minute, "sync with sourcegraph this often")
 	fs.DurationVar(&rc.vacuumInterval, "vacuum_interval", 24*time.Hour, "run vacuum this often")
-	fs.DurationVar(&rc.mergeInterval, "merge_interval", time.Hour, "run merge this often")
+	fs.DurationVar(&rc.mergeInterval, "merge_interval", 8*time.Hour, "run merge this often")
 	fs.Int64Var(&rc.targetSize, "merge_target_size", getEnvWithDefaultInt64("SRC_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
 	fs.Int64Var(&rc.minSize, "merge_min_size", getEnvWithDefaultInt64("SRC_MIN_SIZE", 1800), "the minimum size of a compound shard in MiB")
 	fs.Int64Var(&rc.indexConcurrency, "index_concurrency", getEnvWithDefaultInt64("SRC_INDEX_CONCURRENCY", 1), "the number of concurrent index jobs to run.")

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,10 +43,21 @@ func pickCandidates(shards []candidate, targetSizeBytes int64) compound {
 
 var mergeRunning atomic.Bool
 
+func defaultMergeCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("zoekt-merge-index", "merge")
+	cmd.Args = append(cmd.Args, args...)
+	return cmd
+}
+
 // doMerge drives the merge process. It holds the lock on s.indexDir for the
 // duration of 1 merge, which might be several minutes, depending on the target
 // size of the compound shard.
 func (s *Server) doMerge() {
+	s.merge(defaultMergeCmd)
+}
+
+// same as doMerge but with a configurable merge command.
+func (s *Server) merge(mergeCmd func(args ...string) *exec.Cmd) {
 
 	// Guard against the user triggering competing merge jobs with the debug
 	// command.
@@ -72,6 +82,7 @@ func (s *Server) doMerge() {
 
 		candidates, excluded := loadCandidates(s.IndexDir)
 		debug.Printf("loadCandidates: candidates=%d excluded=%d\n", len(candidates), excluded)
+
 		c := pickCandidates(candidates, s.TargetSizeBytes)
 		if len(c.shards) <= 1 {
 			debug.Printf("could not find enough shards to build a compound shard\n")
@@ -79,24 +90,26 @@ func (s *Server) doMerge() {
 		}
 		debug.Printf("start merging: shards=%d total_size=%.2fMiB\n", len(c.shards), float64(c.size)/(1024*1024))
 
+		var paths []string
+		for _, p := range c.shards {
+			paths = append(paths, p.path)
+		}
+
 		start := time.Now()
-		out, err := callMerge(c.shards)
+		out, err := mergeCmd(paths...).CombinedOutput()
 
 		metricShardMergingDuration.WithLabelValues(strconv.FormatBool(err != nil)).Observe(time.Since(start).Seconds())
 		if err != nil {
-			debug.Printf("callMerge: out=%s, err=%s\n", out, err)
+			debug.Printf("mergeCmd: out=%s, err=%s\n", out, err)
 			return false
 		}
 
-		// for len(c.shards)<=1, callMerge is a NOP. Hence, there is no need to log
-		// anything here.
-		if len(c.shards) > 1 {
-			newCompoundName := reCompound.Find(out)
-			now := time.Now()
-			for _, s := range c.shards {
-				_, _ = fmt.Fprintf(wc, "%s\t%s\t%s\t%s\n", now.UTC().Format(time.RFC3339), "merge", filepath.Base(s.path), string(newCompoundName))
-			}
+		newCompoundName := reCompound.Find(out)
+		now := time.Now()
+		for _, s := range c.shards {
+			_, _ = fmt.Fprintf(wc, "%s\t%s\t%s\t%s\n", now.UTC().Format(time.RFC3339), "merge", filepath.Base(s.path), string(newCompoundName))
 		}
+
 		return true
 	}
 
@@ -206,28 +219,4 @@ type compound struct {
 func (c *compound) add(cand candidate) {
 	c.shards = append(c.shards, cand)
 	c.size += cand.sizeBytes
-}
-
-// callMerge calls zoekt-merge-index and captures its output. callMerge is a NOP
-// if len(shards) <= 1.
-func callMerge(shards []candidate) ([]byte, error) {
-	if len(shards) <= 1 {
-		return nil, nil
-	}
-
-	cmd := exec.Command("zoekt-merge-index", "merge", "-")
-
-	wc, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-
-	go func() {
-		for _, s := range shards {
-			_, _ = io.WriteString(wc, fmt.Sprintf("%s\n", s.path))
-		}
-		_ = wc.Close()
-	}()
-
-	return cmd.CombinedOutput()
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -10,11 +9,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/zoekt"
 	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"go.uber.org/atomic"
 	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/google/zoekt"
 )
 
 var reCompound = regexp.MustCompile(`compound-.*\.zoekt`)
@@ -30,62 +31,79 @@ var metricShardMergingDuration = promauto.NewHistogramVec(prometheus.HistogramOp
 	Buckets: prometheus.LinearBuckets(30, 30, 10),
 }, []string{"error"})
 
-// doMerge drives the merge process.
-func doMerge(dir string, targetSizeBytes int64, simulate bool) error {
+func pickCandidates(shards []candidate, targetSizeBytes int64) compound {
+	c := compound{}
+	for _, shard := range shards {
+		c.add(shard)
+		if c.size >= targetSizeBytes {
+			return c
+		}
+	}
+	return compound{}
+}
+
+var mergeRunning atomic.Bool
+
+// doMerge drives the merge process. It holds the lock on s.indexDir for the
+// duration of 1 merge, which might be several minutes, depending on the target
+// size of the compound shard.
+func (s *Server) doMerge() {
+
+	// Guard against the user triggering competing merge jobs with the debug
+	// command.
+	if !mergeRunning.CAS(false, true) {
+		debug.Printf("merge already running\n")
+		return
+	}
+	defer mergeRunning.Store(false)
+
 	metricShardMergingRunning.Set(1)
 	defer metricShardMergingRunning.Set(0)
 
 	wc := &lumberjack.Logger{
-		Filename:   filepath.Join(dir, "zoekt-merge-log.tsv"),
+		Filename:   filepath.Join(s.IndexDir, "zoekt-merge-log.tsv"),
 		MaxSize:    100, // Megabyte
 		MaxBackups: 5,
 	}
 
-	if simulate {
-		debug.Println("simulating")
-	}
+	createOneCompoundShard := func() bool {
+		s.muIndexDir.Lock()
+		defer s.muIndexDir.Unlock()
 
-	shards, excluded := loadCandidates(dir)
-	debug.Printf("merging: found %d candidate shards, %d shards were excluded\n", len(shards), excluded)
-	if len(shards) == 0 {
-		return nil
-	}
+		candidates, excluded := loadCandidates(s.IndexDir)
+		debug.Printf("loadCandidates: candidates=%d excluded=%d\n", len(candidates), excluded)
+		c := pickCandidates(candidates, s.TargetSizeBytes)
+		if len(c.shards) <= 1 {
+			debug.Printf("could not find enough shards to build a compound shard\n")
+			return false
+		}
+		debug.Printf("start merging: shards=%d total_size=%.2fMiB\n", len(c.shards), float64(c.size)/(1024*1024))
 
-	compounds, _ := generateCompounds(shards, targetSizeBytes)
-	debug.Printf("merging: generated %d compounds\n", len(compounds))
-	if len(compounds) == 0 {
-		return nil
-	}
+		start := time.Now()
+		out, err := callMerge(c.shards)
 
-	var totalSizeBytes int64 = 0
-	totalShards := 0
-	for ix, comp := range compounds {
-		debug.Printf("compound %d: merging %d shards with total size %.2f MiB\n", ix, len(comp.shards), float64(comp.size)/(1024*1024))
-		if !simulate {
-			start := time.Now()
-			stdOut, stdErr, err := callMerge(comp.shards)
-			metricShardMergingDuration.WithLabelValues(strconv.FormatBool(err != nil)).Observe(time.Since(start).Seconds())
-			debug.Printf("callMerge: OUT: %s, ERR: %s\n", string(stdOut), string(stdErr))
-			if err != nil {
-				debug.Printf("error during merging compound %d, stdErr: %s, err: %s\n", ix, stdErr, err)
-				continue
-			}
-			// for len(comp.shards)<=1, callMerge is a NOP. Hence there is no need to log
-			// anything here.
-			if len(comp.shards) > 1 {
-				newCompoundName := reCompound.Find(stdErr)
-				now := time.Now()
-				for _, s := range comp.shards {
-					_, _ = fmt.Fprintf(wc, "%s\t%s\t%s\t%s\n", now.UTC().Format(time.RFC3339), "merge", filepath.Base(s.path), string(newCompoundName))
-				}
+		metricShardMergingDuration.WithLabelValues(strconv.FormatBool(err != nil)).Observe(time.Since(start).Seconds())
+		if err != nil {
+			debug.Printf("callMerge: out=%s, err=%s\n", out, err)
+			return false
+		}
+
+		// for len(c.shards)<=1, callMerge is a NOP. Hence, there is no need to log
+		// anything here.
+		if len(c.shards) > 1 {
+			newCompoundName := reCompound.Find(out)
+			now := time.Now()
+			for _, s := range c.shards {
+				_, _ = fmt.Fprintf(wc, "%s\t%s\t%s\t%s\n", now.UTC().Format(time.RFC3339), "merge", filepath.Base(s.path), string(newCompoundName))
 			}
 		}
-		totalShards += len(comp.shards)
-		totalSizeBytes += comp.size
+		return true
 	}
 
-	debug.Printf("total size: %.2f MiB, number of shards merged: %d\n", float64(totalSizeBytes)/(1024*1024), totalShards)
-	return nil
+	// We keep creating compound shards until we run out of shards to merge or until
+	// we encounter an error during merging.
+	for createOneCompoundShard() {
+	}
 }
 
 type candidate struct {
@@ -95,7 +113,7 @@ type candidate struct {
 	sizeBytes int64
 }
 
-// loadCandidates returns all shards eligable for merging.
+// loadCandidates returns all shards eligible for merging.
 func loadCandidates(dir string) ([]candidate, int) {
 	excluded := 0
 
@@ -190,39 +208,18 @@ func (c *compound) add(cand candidate) {
 	c.size += cand.sizeBytes
 }
 
-// generateCompounds groups simple shards into compound shards without performing
-// the actual merge. Shards that are not contained in any of the compound shards
-// are returned in the second argument.
-func generateCompounds(shards []candidate, targetSizeBytes int64) ([]compound, []candidate) {
-	compounds := make([]compound, 0)
-	cur := compound{}
-	for _, s := range shards {
-		cur.add(s)
-		if cur.size > targetSizeBytes {
-			compounds = append(compounds, cur)
-			cur = compound{}
-		}
-	}
-	return compounds, cur.shards
-}
-
 // callMerge calls zoekt-merge-index and captures its output. callMerge is a NOP
 // if len(shards) <= 1.
-func callMerge(shards []candidate) ([]byte, []byte, error) {
+func callMerge(shards []candidate) ([]byte, error) {
 	if len(shards) <= 1 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	cmd := exec.Command("zoekt-merge-index", "merge", "-")
 
-	outBuf := &bytes.Buffer{}
-	errBuf := &bytes.Buffer{}
-	cmd.Stdout = outBuf
-	cmd.Stderr = errBuf
-
 	wc, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	go func() {
@@ -232,6 +229,5 @@ func callMerge(shards []candidate) ([]byte, []byte, error) {
 		_ = wc.Close()
 	}()
 
-	err = cmd.Run()
-	return outBuf.Bytes(), errBuf.Bytes(), err
+	return cmd.CombinedOutput()
 }

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,7 +142,21 @@ func TestDoMerge(t *testing.T) {
 			}
 
 			s := &Server{IndexDir: dir, TargetSizeBytes: tc.targetSizeBytes}
+
+			// temp hack to find out why this test is failing on CI.
+			b := bytes.Buffer{}
+			old := debug
+			defer func() {
+				debug = old
+			}()
+			debug = log.New(&b, "TestDoMerge: ", log.LstdFlags)
 			s.doMerge()
+			t.Log(b.String())
+
+			fs, _ := filepath.Glob(filepath.Join(dir, "*"))
+			for _, f := range fs {
+				t.Log(filepath.Base(f))
+			}
 
 			checkCount(dir, "compound-*", tc.wantCompound)
 			checkCount(dir, "*_v16.00000.zoekt", tc.wantSimple)

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -1,12 +1,11 @@
 package main
 
 import (
-	"math/rand"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"testing/quick"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
@@ -42,73 +41,6 @@ func TestHasMultipleShards(t *testing.T) {
 	}
 }
 
-// genTestCompounds is a helper that generates compounds from n shards with sizes
-// in (0, targetSize].
-func genTestCompounds(t *testing.T, n uint8, targetSize int64) ([]compound, []candidate, int64) {
-	t.Helper()
-
-	candidates := make([]candidate, 0, n)
-	var totalSize int64
-	var i uint8
-	for i = 0; i < n; i++ {
-		thisSize := rand.Int63n(targetSize) + 1
-		candidates = append(candidates, candidate{"", thisSize})
-		totalSize += thisSize
-	}
-
-	compounds, excluded := generateCompounds(candidates, targetSize)
-	return compounds, excluded, totalSize
-}
-
-func TestEitherMergedOrExcluded(t *testing.T) {
-	// n is uint8 to keep the slices reasonably small and the tests performant.
-	f := func(n uint8) bool {
-		compounds, excluded, wantTotalSize := genTestCompounds(t, n, 10)
-		shardCount := len(excluded)
-		var gotTotalSize int64
-		for _, c := range compounds {
-			shardCount += len(c.shards)
-			gotTotalSize += c.size
-		}
-		for _, c := range excluded {
-			gotTotalSize += c.sizeBytes
-		}
-		if shardCount != int(n) {
-			t.Logf("shards: want %d, got %d", int(n), shardCount)
-			return false
-		}
-		if gotTotalSize != wantTotalSize {
-			t.Logf("total size: want %d, got %d", wantTotalSize, gotTotalSize)
-			return false
-		}
-		return true
-	}
-
-	if err := quick.Check(f, nil); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestCompoundsHaveSizeAboveTargetSize(t *testing.T) {
-	f := func(n uint8, targetSize int64) bool {
-		if targetSize <= 0 {
-			return true
-		}
-
-		compounds, _, _ := genTestCompounds(t, n, targetSize)
-		for _, c := range compounds {
-			if c.size < targetSize {
-				return false
-			}
-		}
-		return true
-	}
-
-	if err := quick.Check(f, nil); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestDoNotDeleteSingleShards(t *testing.T) {
 	dir := t.TempDir()
 
@@ -129,13 +61,120 @@ func TestDoNotDeleteSingleShards(t *testing.T) {
 		t.Errorf("Finish: %v", err)
 	}
 
-	err = doMerge(dir, 2000*1024*1024, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s := &Server{IndexDir: dir, TargetSizeBytes: 2000 * 1024 * 1024}
+	s.doMerge()
 
 	_, err = os.Stat(filepath.Join(dir, "test-repo_v16.00000.zoekt"))
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDoMerge(t *testing.T) {
+
+	// A fixed set of shards gives us reliable shard sizes which makes it easy to
+	// define a cutoff with targetSizeBytes.
+	m := []string{
+		"../../testdata/shards/repo_v16.00000.zoekt",
+		"../../testdata/shards/repo2_v16.00000.zoekt",
+		"../../testdata/shards/ctagsrepo_v16.00000.zoekt",
+	}
+
+	testCases := []struct {
+		name            string
+		targetSizeBytes int64
+		wantCompound    int
+		wantSimple      int
+	}{
+		{
+			name:            "3 shards",
+			targetSizeBytes: 6 * 1024,
+			wantCompound:    1,
+			wantSimple:      0,
+		},
+		{
+			name:            "2 shards",
+			targetSizeBytes: 4 * 1024,
+			wantCompound:    1,
+			wantSimple:      1,
+		},
+		{
+			// This is a pathological case where the target size of a compound shard is
+			// smaller than the size of a simple shard. In realistic scenarios,
+			// targetSizeBytes should be 100x or more of a typical shard size.
+			name:            "target size too small",
+			targetSizeBytes: 2 * 1024,
+			wantCompound:    0,
+			wantSimple:      3,
+		},
+		{
+			name:            "target size too big",
+			targetSizeBytes: 10 * 1024,
+			wantCompound:    0,
+			wantSimple:      3,
+		},
+		{
+			name:            "target size 0",
+			targetSizeBytes: 0,
+			wantCompound:    0,
+			wantSimple:      3,
+		},
+	}
+
+	checkCount := func(dir string, pattern string, want int) {
+		have, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(have) != want {
+			t.Fatalf("want %d, have %d", want, len(have))
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_, err := copyTestShards(dir, m)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := &Server{IndexDir: dir, TargetSizeBytes: tc.targetSizeBytes}
+			s.doMerge()
+
+			checkCount(dir, "compound-*", tc.wantCompound)
+			checkCount(dir, "*_v16.00000.zoekt", tc.wantSimple)
+		})
+	}
+
+}
+
+func copyTestShards(dstDir string, srcShards []string) ([]string, error) {
+	var tmpShards []string
+	for _, s := range srcShards {
+		dst := filepath.Join(dstDir, filepath.Base(s))
+		tmpShards = append(tmpShards, dst)
+		if err := copyFile(s, dst); err != nil {
+			return nil, err
+		}
+	}
+	return tmpShards, nil
+}
+
+func copyFile(src, dst string) (err error) {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+	return d.Close()
 }


### PR DESCRIPTION
fixes: #319 

This updates mainly `doMerge`, which drives the merge process. Previously we didn't lock the index dir which can potentially lead to race conditions with indexing and cleanup. 

Changes:
- lock index dir during merging. We release the lock after each compound shard we create
- set default merge interval from 1h to 8h
- recompute candidates before each merge, because candidates might change between two merges
- remove simulation mode
- the debug command is now curl-based and respects the lock

There is a use case of the debug command I haven't thought about before. Customers can use it to trigger an inital merge during less busy hours even if shard merging is disabled.

### Test plan
- new unit tests
- manual testing
  - I ran a local instance of indexserver with shard merging enabled 

  ```
  SRC_ENABLE_SHARD_MERGING=true go run . --merge_target_size 40 --merge_min_size 5 --merge_interval 10s -- 
  sourcegraph_url <local/dir> --debug
  ```

  - I inspected the index dir and the merge logs.
  - I triggered a couple of merge jobs with `curl http://localhost:6072/debug/merge` and confirmed that only 1 merge operation can run at a time.
