### PR TITLE
stats: keep track of the size of the memory-mapped part of the index 

### DIFF
--- a/api.go
+++ b/api.go
@@ -414,6 +414,9 @@ type RepoStats struct {
 	// IndexBytes is the amount of RAM used for index overhead.
 	IndexBytes int64
 
+	// IndexMmappedBytes is the amount of memory mmapped by the index.
+	IndexMmappedBytes int64
+
 	// ContentBytes is the amount of RAM used for raw content.
 	ContentBytes int64
 
@@ -446,6 +449,7 @@ func (s *RepoStats) Add(o *RepoStats) {
 	// shards.
 	s.Shards += o.Shards
 	s.IndexBytes += o.IndexBytes
+	s.IndexMmappedBytes += o.IndexMmappedBytes
 	s.Documents += o.Documents
 	s.ContentBytes += o.ContentBytes
 

--- a/index_test.go
+++ b/index_test.go
@@ -1142,7 +1142,7 @@ func TestListRepos(t *testing.T) {
 			Stats: RepoStats{
 				Shards:                     1,
 				Documents:                  4,
-				IndexBytes:                 300,
+				IndexBytes:                 261,
 				ContentBytes:               68,
 				NewLinesCount:              4,
 				DefaultBranchNewLinesCount: 2,

--- a/index_test.go
+++ b/index_test.go
@@ -1153,7 +1153,7 @@ func TestListRepos(t *testing.T) {
 		}
 
 		if os.Getenv("ZOEKT_ENABLE_NGRAM_BS") != "" {
-			want.Stats.IndexBytes = 228
+			want.Stats.IndexBytes = 189
 		}
 
 		if diff := cmp.Diff(want, res); diff != "" {

--- a/index_test.go
+++ b/index_test.go
@@ -1092,6 +1092,7 @@ func TestListRepos(t *testing.T) {
 					cmpopts.EquateEmpty(),
 					cmpopts.IgnoreFields(RepoListEntry{}, "IndexMetadata"),
 					cmpopts.IgnoreFields(RepoStats{}, "IndexBytes"),
+					cmpopts.IgnoreFields(RepoStats{}, "IndexMmappedBytes"),
 					cmpopts.IgnoreFields(Repository{}, "SubRepoMap"),
 					cmpopts.IgnoreFields(Repository{}, "priority"),
 				}
@@ -1143,6 +1144,7 @@ func TestListRepos(t *testing.T) {
 				Shards:                     1,
 				Documents:                  4,
 				IndexBytes:                 261,
+				IndexMmappedBytes:          49,
 				ContentBytes:               68,
 				NewLinesCount:              4,
 				DefaultBranchNewLinesCount: 2,
@@ -2209,6 +2211,7 @@ func TestStats(t *testing.T) {
 		cmpopts.IgnoreFields(RepoListEntry{}, "Repository"),
 		cmpopts.IgnoreFields(RepoListEntry{}, "IndexMetadata"),
 		cmpopts.IgnoreFields(RepoStats{}, "IndexBytes"),
+		cmpopts.IgnoreFields(RepoStats{}, "IndexMmappedBytes"),
 	}
 
 	repoListEntries := func(b *IndexBuilder) []RepoListEntry {

--- a/indexdata.go
+++ b/indexdata.go
@@ -299,23 +299,36 @@ func (d *indexData) String() string {
 func (d *indexData) memoryUse() int {
 	sz := 0
 	for _, a := range [][]uint32{
-		d.newlinesIndex, d.docSectionsIndex,
-		d.boundaries, d.fileNameIndex,
-		d.fileEndRunes, d.fileNameEndRunes,
-		d.fileEndSymbol, d.symbols.symKindIndex,
+		d.symbols.symKindIndex,
+		d.newlinesIndex,
+		d.docSectionsIndex,
+		d.boundaries,
+		d.fileEndRunes,
+		d.fileNameIndex,
+		d.fileEndSymbol,
+		d.fileNameEndRunes,
 		d.subRepos,
 	} {
 		sz += 4 * len(a)
 	}
-	sz += d.runeOffsets.sizeBytes()
-	sz += d.fileNameRuneOffsets.sizeBytes()
-	sz += len(d.languages)
-	sz += len(d.checksums)
-	sz += 2 * len(d.repos)
-	sz += 8 * len(d.runeDocSections)
-	sz += 8 * len(d.fileBranchMasks)
+
+	// All []byte fields are mmap-ed.
+
 	sz += d.ngrams.SizeBytes()
+	sz += 8 * len(d.runeDocSections)
+	sz += d.runeOffsets.sizeBytes()
 	sz += 12 * len(d.fileNameNgrams) // these slices reference mmap-ed memory
+	sz += d.fileNameRuneOffsets.sizeBytes()
+	sz += 8 * len(d.fileBranchMasks)
+	// branchNames
+	// branchIDs
+	// repoMetaData
+	// subRepoPaths
+	// repoListEntry
+	sz += 2 * len(d.repos)
+	sz += len(d.rawConfigMasks)
+	// bloomContents
+	// bloomNames
 	return sz
 }
 

--- a/indexdata.go
+++ b/indexdata.go
@@ -341,6 +341,8 @@ func (d *indexData) memoryUse() (ram, mmapped int) {
 	ram += 12 * len(d.fileNameNgrams) // these slices reference mmap-ed memory
 	ram += d.fileNameRuneOffsets.sizeBytes()
 	ram += 8 * len(d.fileBranchMasks)
+	// Small enough so we don't bother. Listed here for completeness: all fields of indexData
+	// are supposed to be taken into account.
 	// branchNames
 	// branchIDs
 	// repoMetaData

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -380,6 +380,7 @@ func TestShardedSearcher_List(t *testing.T) {
 		Shards:                     2,
 		Documents:                  1,
 		IndexBytes:                 196,
+		IndexMmappedBytes:          22,
 		ContentBytes:               13,
 		NewLinesCount:              1,
 		DefaultBranchNewLinesCount: 1,

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -379,7 +379,6 @@ func TestShardedSearcher_List(t *testing.T) {
 	stats := zoekt.RepoStats{
 		Shards:                     2,
 		Documents:                  1,
-		IndexBytes:                 196,
 		IndexMmappedBytes:          22,
 		ContentBytes:               13,
 		NewLinesCount:              1,

--- a/web/templates.go
+++ b/web/templates.go
@@ -381,6 +381,9 @@ document.onkeydown=function(e){
     {{.Stats.Documents}} documents ({{HumanUnit .Stats.ContentBytes}})
     from {{.Stats.Repos}} repositories.
     </p>
+    <p>
+    Memory-mapped {{HumanUnit .Stats.IndexMmappedBytes}} bytes.
+    </p>
   </div>
 
   <nav class="navbar navbar-default navbar-bottom">


### PR DESCRIPTION
Updates #321

See the linked issue for context.

1. It's not clear whether we need to know how much data is mmapped and whether it should influence e.g.
our recommendations regarding the expected amount of resources provisioned to zoekt, but at least it
was instructive to find out (we mmap around 45% of the total indexData memory). The downsides are
the API change to indexData.memoryUse() and the increased amount of time this method takes.
Please comment if you don't think we need this info. My opinion: while I'm not sure we do, it doesn't hurt much.
2. Most tests are ignoring IndexBytes field, and rightfully so. I've tried to remove IndexBytes from such tests.
The ones that do not ignore it are left to catch a possible regression.