### PR TITLE
indexserver: introduce indexMutex

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_mutex.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_mutex.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// indexMutex is the concurrency control we have for operations that operate
+// on the index directory. We have two broad operations: global and repository
+// specific. A global operation is like a write lock on the whole directory. A
+// repository operation ensure we don't have multiple operations happening for
+// the same repository.
+type indexMutex struct {
+	// indexMu protects state in index directory. global takes write lock, repo
+	// takes read lock.
+	indexMu sync.RWMutex
+
+	// runningMu protects running. You need to first be holding indexMu.
+	runningMu sync.Mutex
+
+	// running maps by name since that is what we key by on disk. Once we start
+	// keying by repo ID on disk, we should switch to uint32.
+	running map[string]struct{}
+}
+
+func (m *indexMutex) With(repoName string, f func()) bool {
+	m.indexMu.RLock()
+	defer m.indexMu.RUnlock()
+
+	// init running; check and set running[repoName]
+	m.runningMu.Lock()
+	if m.running == nil {
+		m.running = map[string]struct{}{}
+	}
+	_, alreadyRunning := m.running[repoName]
+	m.running[repoName] = struct{}{}
+	m.runningMu.Unlock()
+
+	if alreadyRunning {
+		metricIndexMutexAlreadyRunning.Inc()
+		return false
+	}
+
+	// release running[repoName]
+	defer func() {
+		m.runningMu.Lock()
+		delete(m.running, repoName)
+		m.runningMu.Unlock()
+	}()
+
+	metricIndexMutexRepo.Inc()
+	defer metricIndexMutexRepo.Dec()
+
+	f()
+
+	return true
+}
+
+func (m *indexMutex) Global(f func()) {
+	metricIndexMutexGlobal.Inc()
+	defer metricIndexMutexGlobal.Dec()
+
+	m.indexMu.Lock()
+	defer m.indexMu.Unlock()
+
+	f()
+}
+
+var (
+	metricIndexMutexAlreadyRunning = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "index_mutex_already_running_total",
+		Help: "Total number of times we skipped processing a repository since an index was already running.",
+	})
+
+	metricIndexMutexGlobal = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_mutex_global",
+		Help: "The number of goroutines trying to or holding the global lock.",
+	})
+
+	metricIndexMutexRepo = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_mutex_repository",
+		Help: "The number of goroutines successfully holding a repo lock.",
+	})
+)


### PR DESCRIPTION
This struct abstracts away how we do locking on the index directory in a
process. Previously we had a very coarse sync.Mutex whenever kicking off
an operation which mutated the directory. We plan on introducing some
concurrency to allow multiple repositories to be indexed at once.
However, this requires us to distinguish from global locks vs locking
just for a repository. This is what indexMutex achieves.

We don't yet use "indexMutex.With" concurrently, but will in an upcoming
commit.

Additionally a slight bug is fixed on how we report indexing times.
Previously we included the time taken to acquire the index lock for
elapsed time. This means indexing might be reported to take a very long
time, but in reality we just are blocked on waiting for merge or cleanup
to finish.

Because of this bug included are a few very coarse metrics. We could go
much deeper like we do in sched.go. However, I believe this handles some
interesting cases so will leave that as follow-up work. Now when we have
the queue being very slow to process, this might point towards the
global lock being the issue.

Test Plan: go test -race