### PR TITLE
indexserver: add health checker

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/checks.go
+++ b/cmd/zoekt-sourcegraph-indexserver/checks.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/google/zoekt/internal/check"
+)
+
+func canConnectToFrontendInternal(sg Sourcegraph) check.Check {
+	return check.Check{
+		Name:        "can_connect_to_sourcegraph_frontend_internal",
+		Description: "Zoekt can reach the internal API of Sourcegraph frontend",
+		Run: func(ctx context.Context) (string, error) {
+			cl, ok := sg.(*sourcegraphClient)
+			if !ok {
+				// This can only happen if we run indexserver without a Sourcegraph instance.
+				return "", fmt.Errorf("not a sourcegraphClient")
+			}
+
+			u := cl.Root.ResolveReference(&url.URL{Path: "/.internal/ping"})
+			req, err := retryablehttp.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if err != nil {
+				return "", err
+			}
+
+			resp, err := cl.doRequest(req)
+			if err != nil {
+				return "", err
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != 200 {
+				return "", fmt.Errorf("url=%s status=%d", u.String(), resp.StatusCode)
+			}
+
+			b, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return "", err
+			}
+
+			return string(b), nil
+		},
+	}
+}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,0 +1,155 @@
+package check
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strconv"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+type RunFunc func(ctx context.Context) (string, error)
+
+type Check struct {
+	Name        string
+	Description string
+
+	Run RunFunc
+
+	LastRun           time.Time
+	CachedCheckErr    error
+	CachedCheckOutput string
+}
+
+func (c *Check) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name              string    `json:"name"`
+		Description       string    `json:"description"`
+		LastRun           time.Time `json:"last_run"`
+		CachedCheckErr    string    `json:"cached_check_err"`
+		CachedCheckOutput string    `json:"cached_check_output"`
+	}{
+		Name:              c.Name,
+		Description:       c.Description,
+		LastRun:           c.LastRun,
+		CachedCheckErr:    errString(c.CachedCheckErr),
+		CachedCheckOutput: c.CachedCheckOutput,
+	})
+}
+
+type HealthChecker struct {
+	mu     sync.Mutex
+	Checks []Check
+}
+
+func (c *HealthChecker) MarshalJSON() ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return json.Marshal(c.Checks)
+}
+
+func (c *HealthChecker) Run() {
+	for {
+		time.Sleep(60 * time.Second)
+		c.doRun()
+	}
+}
+
+func (c *HealthChecker) doRun() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	sem := semaphore.NewWeighted(int64(runtime.GOMAXPROCS(0)))
+	wg := sync.WaitGroup{}
+
+	next := c.Checks[:0]
+
+	for _, check := range c.Checks {
+		err := sem.Acquire(ctx, 1)
+		if err != nil {
+			return
+		}
+		wg.Add(1)
+		go func(check Check) {
+			defer sem.Release(1)
+			defer wg.Done()
+
+			check.CachedCheckOutput, check.CachedCheckErr = check.Run(ctx)
+			check.LastRun = time.Now().UTC()
+
+			c.mu.Lock()
+			next = append(next, check)
+			c.mu.Unlock()
+		}(check)
+	}
+	wg.Wait()
+}
+
+func (c *HealthChecker) Print(w http.ResponseWriter) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	bw := bytes.Buffer{}
+	tw := tabwriter.NewWriter(&bw, 16, 8, 4, ' ', 0)
+
+	_, err := fmt.Fprintf(tw, "status\tname\tdescription\toutput\terr\tlast_run\n")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("writing column headers: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	for _, check := range c.Checks {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			func() string {
+				if check.LastRun.IsZero() {
+					return "PENDING"
+				}
+				if check.CachedCheckErr == nil {
+					return "OK"
+				}
+				return "FAIL"
+			}(),
+			check.Name,
+			check.Description,
+			check.CachedCheckOutput,
+			errString(check.CachedCheckErr),
+			timestampString(check.LastRun),
+		)
+	}
+
+	err = tw.Flush()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("flushing tabwriter: %s", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Length", strconv.Itoa(bw.Len()))
+
+	if _, err := io.Copy(w, &bw); err != nil {
+		http.Error(w, fmt.Sprintf("copying output to response writer: %s", err), http.StatusInternalServerError)
+		return
+	}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func timestampString(t time.Time) string {
+	if t.IsZero() {
+		return "never"
+	}
+	return t.Format(time.RFC3339)
+}


### PR DESCRIPTION
This is still WIP. We can use the PR to discuss the design.

Design:
- each service 
  - defines its own checks (see checks.go), adds them to a HealthChecker and calls HealthChecker.Run() at startup.
  - exposes an endpoint `debug/check` that serves plain text (default) as well as JSON, depending on the header `Accept`.
- the health checker runs all checks in the background and caches the latest results and errors
- In a first version, frontend can simply render the text version of each service.

The "check" package should eventually live outside Zoekt, for example in `sourcegraph/check`.

![image](https://user-images.githubusercontent.com/26413131/175573197-a59e0077-aec6-4a96-a7d3-754603c878c0.png)

### Test Plan
start sourcegraph with Zoekt pointing to this branch
```
curl http://localhost:6072/debug/check -Ss
```
