### PR TITLE
indexserver: tombstone duplicate repos from compound shards in the cleanup cycle

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -321,7 +321,7 @@ func getTombstonedRepos(dir string) map[uint32]shard {
 				RepoName:      repo.Name,
 				Path:          p,
 				ModTime:       repo.LatestCommitDate,
-				RepoTombstone: true,
+				RepoTombstone: repo.Tombstone,
 			}
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -173,6 +173,14 @@ func cleanup(indexDir string, repos []uint32, now time.Time, shardMerging bool) 
 
 	// feature flag: place file TOMBSTONE_DUPLICATES in IndexDir
 	if _, err := os.Stat(filepath.Join(indexDir, "TOMBSTONE_DUPLICATES")); err == nil && shardMerging {
+		// This breaks an invariant of cleanup() where we guarantee that right
+		// after a cleanup the index state is consistent with the repos parameter.
+		// If the duplicates are tombstoned, the same repoID may seem both
+		// alive and tombstoned, depending on which compound shard you look into.
+		// However, introducing duplicates in the first place breaks another invariant
+		// (of having no duplicates), so
+		// 1. This is bad, but we are fixing an even worse situation.
+		// 2. This code should be removed as soon as the situation is fixed.
 		tombstoneDuplicates(indexDir)
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -275,7 +275,6 @@ func tombstoneDuplicates(indexDir string) {
 		}
 		if latest != 0 {
 			shards[0], shards[latest] = shards[latest], shards[0]
-			latest = 0
 		}
 
 		if err := zoekt.UnsetTombstone(shards[0].Path, repoID); err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -393,8 +393,8 @@ func TestCleanupCompoundShards(t *testing.T) {
 
 	cleanup(dir, repos, now, true)
 
-	index := getShards(dir, alive)
-	trash := getShards(filepath.Join(dir, ".trash"), alive)
+	index := getShards(dir)
+	trash := getShards(filepath.Join(dir, ".trash"))
 
 	if len(trash) != 0 {
 		t.Fatalf("expected empty trash, got %+v", trash)
@@ -474,8 +474,8 @@ func TestTombstoneDuplicateShards(t *testing.T) {
 
 	cleanup(dir, repos, now, true)
 
-	index := getShards(dir, alive)
-	trash := getShards(filepath.Join(dir, ".trash"), alive)
+	index := getShards(dir)
+	trash := getShards(filepath.Join(dir, ".trash"))
 
 	if len(trash) != 0 {
 		t.Fatalf("expected empty trash, got %+v", trash)

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/build"
 )
@@ -446,18 +447,19 @@ func TestTombstoneDuplicateShards(t *testing.T) {
 	old := now.Add(-2 * time.Hour)
 
 	cs1 := createCompoundShard(t, dir, []uint32{1, 2, 3}, func(*zoekt.Repository) {})
-	// Hide it from being removed by Builder.Finish() called when creating cs2.
+
+	// Hack part 1: hide repos from being tombstoned by Builder.Finish() when creating cs2.
 	for i := 1; i <= 3; i++ {
 		if err := zoekt.SetTombstone(cs1, uint32(i)); err != nil {
 			t.Fatal(err)
 		}
 	}
+
 	cs2 := createCompoundShard(t, dir, []uint32{1, 2}, func(*zoekt.Repository) {})
+
+	// Hack part 2: remove tombstones to create duplicates.
 	for i := 1; i <= 3; i++ {
 		if err := zoekt.UnsetTombstone(cs1, uint32(i)); err != nil {
-			t.Fatal(err)
-		}
-		if err := zoekt.UnsetTombstone(cs2, uint32(i)); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -810,7 +810,7 @@ func (s *Server) forceIndex(id uint32) (string, error) {
 }
 
 func listIndexed(indexDir string) []uint32 {
-	index := getShards(indexDir, alive)
+	index := getShards(indexDir)
 	metricNumIndexed.Set(float64(len(index)))
 	repoIDs := make([]uint32, 0, len(index))
 	for id := range index {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -810,7 +810,7 @@ func (s *Server) forceIndex(id uint32) (string, error) {
 }
 
 func listIndexed(indexDir string) []uint32 {
-	index := getShards(indexDir)
+	index := getShards(indexDir, alive)
 	metricNumIndexed.Set(float64(len(index)))
 	repoIDs := make([]uint32, 0, len(index))
 	for id := range index {

--- a/cmd/zoekt-sourcegraph-indexserver/meta_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta_test.go
@@ -62,7 +62,7 @@ func TestMergeMeta(t *testing.T) {
 	// create a compound shard. Use a new indexdir to avoid the need to cleanup
 	// old shards.
 	dir = t.TempDir()
-	tmpFn, dstFn, err := merge(dir, repoFns)
+	tmpFn, dstFn, err := merge(t, dir, repoFns)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,9 @@ func TestMergeMeta(t *testing.T) {
 	}
 }
 
-func merge(dstDir string, names []string) (string, string, error) {
+func merge(t *testing.T, dstDir string, names []string) (string, string, error) {
+	t.Helper()
+
 	var files []zoekt.IndexFile
 	for _, fn := range names {
 		f, err := os.Open(fn)

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -375,7 +375,7 @@ func (sf sourcegraphFake) List(ctx context.Context, indexed []uint32) (*Sourcegr
 		}
 		for _, opt := range opts {
 			if opt.Error != "" {
-				sf.Log.Printf("WARN: ignoring GetIndexOptions error for %s: %v", opt.Name, err)
+				sf.Log.Printf("WARN: ignoring GetIndexOptions error for %s: %v", opt.Name, opt.Error)
 				continue
 			}
 			f(opt.IndexOptions)


### PR DESCRIPTION
Intended usage:
0. Merge #382 before this PR. This should, hopefully, stop further duplicates.
1. Enable the feature flag on a couple of instances by placing a file named TOMBSTONE_DUPLICATES in the index dir. Check that everything is all right. Expected outcome: on the next call to cleanup(), all duplicates but one are tombstoned. After a subsequent call to vacuum(), there are no more duplicates. A possible undesired outcome: compound shards are starting to break and reassemble.
2. If Step 1 goes as expected, either enable feature flag on all instances or make the change in this PR unconditional.
3. After the duplicates are removed and are stopped from appearing again, revert this PR.


Fixes #320

### Test Plan

* Unit test (included)
* Manual testing
* Feature flag to be extra safe