### PR TITLE
indexserver: allow specifying branches to index for sourcegraphFake

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"golang.org/x/net/trace"
 
@@ -463,19 +464,53 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 		Priority: float("SG_PRIORITY"),
 	}
 
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = dir
-	if b, err := cmd.Output(); err != nil {
+	branches, err := sf.getBranches(name)
+	if err != nil {
 		return opts, err
-	} else {
-		head := string(bytes.TrimSpace(b))
-		opts.Branches = []zoekt.RepositoryBranch{{
-			Name:    "HEAD",
-			Version: head,
-		}}
 	}
+	opts.Branches = branches
 
 	return opts, nil
+}
+
+func (sf sourcegraphFake) getBranches(name string) ([]zoekt.RepositoryBranch, error) {
+	dir := filepath.Join(sf.RootDir, filepath.FromSlash(name))
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	sec := cfg.Raw.Section("zoekt")
+	branches := sec.Options.GetAll("branch")
+	if len(branches) == 0 {
+		branches = append(branches, "HEAD")
+	}
+
+	rBranches := make([]zoekt.RepositoryBranch, 0, len(branches))
+	for _, branch := range branches {
+		cmd := exec.Command("git", "rev-parse", branch)
+		cmd.Dir = dir
+		if b, err := cmd.Output(); err != nil {
+			sf.Log.Printf("WARN: Could not get branch %s/%s", name, branch)
+		} else {
+			version := string(bytes.TrimSpace(b))
+			rBranches = append(rBranches, zoekt.RepositoryBranch{
+				Name:    branch,
+				Version: version,
+			})
+		}
+	}
+
+	if len(rBranches) == 0 {
+		return nil, fmt.Errorf("WARN: Could not get any branch revisions for repo %s", name)
+	}
+
+	return rBranches, nil
 }
 
 func (sf sourcegraphFake) id(name string) uint32 {


### PR DESCRIPTION
Currently sourcegraphFake is hardcoded to index `HEAD`.
This PR allows specifying multiple branch names using the Git Config key `zoekt.branch` to inform sourcegraphFake which branches to index. If no branches are specified it will fallback to `HEAD`
e.g. 
```
git config --add zoekt.branch master
git config --add zoekt.branch j/sgfake-branch-config
```

### Test Plan
- Manual testing
  -  No branches specified i.e. `zoekt.branch` does not exist
     - Result: `HEAD` indexed
  - Single branch specified
     - `git config --add zoekt.branch master`
     - Result: `master` branch indexed
  - Multiple branches specified
     - `git config --add zoekt.branch master`
     - `git config --add zoekt.branch j/sgfake-branch-config`
     - Result: `master` & `j/sgfake-branch-config` indexed
  - Non-existent branch specified
     - `git config --add zoekt.branch j/non-existent`
     - Result: Index failed. warning printed `WARN: Could not get branch zoekt/j/non-existent`
  - Existing & non-existent branches specified
     - `git config --add zoekt.branch j/sgfake-branch-config`
     - `git config --add zoekt.branch j/non-existent`
     - Result: ` j/sgfake-branch-config` indexed; warning printed `WARN: Could not get branch zoekt/j/non-existent`

#### Notes
- I think failing in the case when only non-existent branches are specified is acceptable (versus trying to fallback to `HEAD`) as it more clearly informs the user that the config is in an incorrect state. It can be easily changed if people think the logged warning is enough and the fallback would be more preferable