### PR TITLE
indexserver: only log if someone else is running

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_mutex.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_mutex.go
@@ -25,6 +25,10 @@ type indexMutex struct {
 	running map[string]struct{}
 }
 
+// With runs f if no other f with the same repoName is running. If f runs true
+// is returned, otherwise false is returned.
+//
+// With blocks if f runs or the Global lock is held.
 func (m *indexMutex) With(repoName string, f func()) bool {
 	m.indexMu.RLock()
 	defer m.indexMu.RUnlock()
@@ -58,6 +62,8 @@ func (m *indexMutex) With(repoName string, f func()) bool {
 	return true
 }
 
+// Global runs f once the global lock is held. IE no other Global or With f's
+// will be running.
 func (m *indexMutex) Global(f func()) {
 	metricIndexMutexGlobal.Inc()
 	defer metricIndexMutexGlobal.Dec()

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -386,7 +386,7 @@ func (s *Server) processQueue() {
 
 		args := s.indexArgs(opts)
 
-		alreadyRunning := s.muIndexDir.With(opts.Name, func() {
+		ran := s.muIndexDir.With(opts.Name, func() {
 			// only record time taken once we hold the lock. This avoids us
 			// recording time taken while merging/cleanup runs.
 			start := time.Now()
@@ -410,7 +410,7 @@ func (s *Server) processQueue() {
 			s.queue.SetIndexed(opts, state)
 		})
 
-		if alreadyRunning {
+		if !ran {
 			// Someone else is processing the repository. We can just skip this job
 			// since the repository will be added back to the queue and we will
 			// converge to the correct behaviour.


### PR DESCRIPTION
We inverted the condition around alreadyRunning. Luckily the only
side-effect was extra debug logs. I noticed this while testing with
debug logs on.

Test Plan: Run with debug logs and notice the already running messages
disappear. Add in a sleep for 2 minutes in indexing then check already
running messages pop up.

```
  SRC_LOG_LEVEL=dbug go run ./cmd/zoekt-sourcegraph-indexserver \
    -listen 127.0.0.1:6072 \
    -index_concurrency 4 \
    -sourcegraph_url ~/src \
    -index /tmp/zoekt-test
```

plz-review-url: https://plz.review/review/6899