### PR TITLE
Fix constant evaluation of empty repo set

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -614,7 +614,7 @@ func evalConstants(q Q) Q {
 		}
 	case *RepoSet:
 		if len(s.Set) == 0 {
-			return &Const{true}
+			return &Const{false}
 		}
 	}
 	return q


### PR DESCRIPTION
An empty repo set will never match anything, so can be evaluated to a
constant false. Previously, this would evaluate to true, which broke
Sourcegraph's `repohasfile:` filter.

Unblocks https://github.com/sourcegraph/sourcegraph/pull/37637