### PR TITLE
docker: change our default GOGC to 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ COPY --from=builder /go/bin/* /usr/local/bin/
 
 # zoekt-webserver has a large stable heap size (10s of gigs), and as such the
 # default GOGC=100 could be better tuned. https://dave.cheney.net/tag/gogc
-ENV GOGC=50
+# In go1.18 the GC changed significantly and from experimentation we tuned it
+# down from 50 to 25.
+ENV GOGC=25
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -24,6 +24,8 @@ COPY --from=zoekt \
 
 # zoekt indexing has a large stable heap size (gigs), and as such the default
 # GOGC=100 could be better tuned. https://dave.cheney.net/tag/gogc
-ENV GOGC=50
+# In go1.18 the GC changed significantly and from experimentation we tuned it
+# down from 50 to 25.
+ENV GOGC=25
 
 ENTRYPOINT ["/sbin/tini", "--", "zoekt-sourcegraph-indexserver"]

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -18,7 +18,9 @@ COPY --from=zoekt /usr/local/bin/zoekt-webserver /usr/local/bin/
 
 # zoekt-webserver has a large stable heap size (10s of gigs), and as such the
 # default GOGC=100 could be better tuned. https://dave.cheney.net/tag/gogc
-ENV GOGC=50
+# In go1.18 the GC changed significantly and from experimentation we tuned it
+# down from 50 to 25.
+ENV GOGC=25
 
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD zoekt-webserver -index $DATA_DIR -pprof -rpc


### PR DESCRIPTION
We had a regression in go1.18 in our memory usage. From experimentation we have found a value of 25 gave us the same stable size from before 1.18.

Note: we set GOGC for all containers, but really we only should be doing this for webserver. However, I don't want to bundle that change into this one.

Test Plan: we have validated this on sourcegraph.com over the last few weeks.
