### PR TITLE
Avoid allocating filename when checking if a document is tombstoned

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -231,12 +231,8 @@ nextFileMatch:
 			}
 
 			// Skip documents that are tombstoned
-			// TODO: This FileTombstones implementation (looking up by filenames) creates a lot of small allocations
-			// (string filenames) and can have poor cache performance. This should be addressed before we officially
-			// roll this out.
 			if len(repoMetadata.FileTombstones) > 0 {
-				fileName := string(d.fileName(nextDoc))
-				if _, tombstoned := repoMetadata.FileTombstones[fileName]; tombstoned {
+				if _, tombstoned := repoMetadata.FileTombstones[string(d.fileName(nextDoc))]; tombstoned {
 					continue
 				}
 			}


### PR DESCRIPTION
Got prompted this by a static check [SA6001](https://staticcheck.io/docs/checks#SA6001)

The compiler recognises m[string(b)] and can use the value of the byte slice directly when performing a map lookup without needing to allocate the string

### Test Plan
- Everything still passes in eval_test.go