### PR TITLE
all: remove curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go install -ldflags "-X github.com/google/zoekt.Version=$VERSION" ./cmd/...
 FROM alpine:3.15.0 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git ca-certificates bind-tools tini jansson curl
+    apk add --no-cache git ca-certificates bind-tools tini jansson
 
 COPY install-ctags-alpine.sh .
 RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/google/zoekt.Version=$VERSION" ./cmd/...
 
-FROM alpine:3.15.0 AS zoekt
+FROM alpine:3.15.4 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git ca-certificates bind-tools tini jansson

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.4
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson && \

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git jansson curl && \
+    apk add --no-cache ca-certificates bind-tools tini git jansson && \
     apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0'
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0
+FROM alpine:3.15.4
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
    apk add --no-cache ca-certificates bind-tools tini

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,8 +1,7 @@
 FROM alpine:3.15.0
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-   apk add --no-cache ca-certificates bind-tools tini curl && \
-   apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0'
+   apk add --no-cache ca-certificates bind-tools tini
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph

--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -79,23 +79,23 @@ func debugCmd() *ffcli.Command {
 		Name:       "debug",
 		ShortUsage: "debug <subcommand>",
 		ShortHelp:  "a set of commands for debugging and testing",
-		LongHelp: `CURL
+		LongHelp: `
   Zoekt-sourcegraph-indexserver exposes debug information on the /debug landing page.
-  You can use the following curl commands to access this information from the command line.
+  You can use the following wget commands to access this information from the command line.
 
-  curl http://localhost:6072/debug/indexed
+  wget -q -O - http://localhost:6072/debug/indexed
     list the repositories that are INDEXED by this instance.
 
-  curl http://localhost:6072/debug/list[?indexed=TRUE/false]
+  wget -q -O - http://localhost:6072/debug/list[?indexed=TRUE/false]
     list the repositories that are OWNED by this instance. If indexed=true (default), the list may contain repositories
     that this instance holds temporarily, for example during rebalancing.
 
-  curl http://localhost:6072/debug/merge
+  wget -q -O - http://localhost:6072/debug/merge
     start a full merge operation in the index directory. You can check the status with
-    "curl http://localhost:6072/metrics -sS | grep index_shard_merging_running". It is only possible
+    "wget -q -O - http://localhost:6072/metrics -sS | grep index_shard_merging_running". It is only possible
     to trigger one merge operation at a time.
 
-  curl http://localhost:6072/debug/queue
+  wget -q -O - http://localhost:6072/debug/queue
     list the repositories in the indexing queue, sorted by descending priority.
 
     COLUMN HEADERS


### PR DESCRIPTION
We only have curl for debugging. We can just use wget which comes with busybox.

Test Plan: ran wget manually to ensure it works. Also built both images locally and had clean scans from snyk.

```shellsession
docker build -t zoekt .
docker scan zoekt
docker build -t zoekt-indexserver . -f Dockerfile.indexserver 
docker scan zoekt-indexserver
docker build -t zoekt-webserver . -f Dockerfile.webserver
docker scan zoekt-webserver
```