### PR TITLE
wip: Create delta shard using diff between on disk index and upstream

### DIFF
--- a/cmd/zoekt-index-diff/diff.go
+++ b/cmd/zoekt-index-diff/diff.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/zoekt"
+	"github.com/sourcegraph/go-diff/diff"
+)
+
+// parseDiffHuskNew parses diff husk into new file contents
+// As we use -U<large number> each file is only a single husk
+func parseDiffHuskNew(h *diff.Hunk) []byte {
+	content := h.Body[:0]
+	hunk := h.Body
+	for len(hunk) > 0 {
+		newLine := bytes.IndexByte(hunk, '\n')
+		switch hunk[0] {
+		case ' ', '+':
+			if newLine < 0 {
+				content = append(content, hunk[1:]...)
+				hunk = nil
+			} else {
+				content = append(content, hunk[1:newLine+1]...)
+				hunk = hunk[newLine+1:]
+			}
+		case '-':
+			if newLine < 0 {
+				hunk = nil
+			} else {
+				hunk = hunk[newLine+1:]
+			}
+
+		}
+	}
+	return content
+}
+
+// patseDiffHuskOrig parses diff husk into original file contents
+func parseDiffHuskOrig(h *diff.Hunk) []byte {
+	content := h.Body[:0]
+	hunk := h.Body
+	for len(hunk) > 0 {
+		newLine := bytes.IndexByte(hunk, '\n')
+		switch hunk[0] {
+		case ' ', '-':
+			if newLine < 0 {
+				content = append(content, hunk[1:]...)
+				hunk = nil
+			} else {
+				content = append(content, hunk[1:newLine+1]...)
+				hunk = hunk[newLine+1:]
+			}
+		case '+':
+			if newLine < 0 {
+				hunk = nil
+			} else {
+				hunk = hunk[newLine+1:]
+			}
+
+		}
+	}
+	return content
+}
+
+// parseGitHashFromDiff returns the old and new file blob hashes
+func parseGitHashFromDiff(f *diff.FileDiff) (plumbing.Hash, plumbing.Hash) {
+	// TODO(jac): An upstream change to more easily expose this would be nice
+	for _, v := range f.Extended {
+		// index ABCD..EF12 100644
+		if strings.HasPrefix(v, "index") {
+			// ABCD..EF12
+			i := strings.Split(v, " ")[1]
+			// [ABCD, EF12]
+			indices := strings.Split(i, "..")
+			return plumbing.NewHash(indices[0]), plumbing.NewHash(indices[1])
+		}
+	}
+
+	log.Panicf("Could not read file blob hashes for %s", f.NewName)
+	// unreachable
+	var x plumbing.Hash
+	return x, x
+}
+
+// computeGitHash computes the git file blob hash of a document
+func computeGitHash(doc zoekt.Document) plumbing.Hash {
+	return plumbing.ComputeHash(plumbing.BlobObject, doc.Content)
+}

--- a/cmd/zoekt-index-diff/diff_test.go
+++ b/cmd/zoekt-index-diff/diff_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/zoekt"
+	"github.com/sourcegraph/go-diff/diff"
+)
+
+func Test_ParseDiffHunkNew(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   diff.Hunk
+		want string
+	}{
+		{
+			name: "no changes - no newline at end", // shouldn't happen in reality
+			in: diff.Hunk{
+				Body: []byte(" Hello\n World"),
+			},
+			want: "Hello\nWorld",
+		},
+		{
+			name: "no changes - newline at end", // shouldn't happen in reality
+			in: diff.Hunk{
+				Body: []byte(" Hello\n World\n"),
+			},
+			want: "Hello\nWorld\n",
+		},
+		{
+			name: "only additions",
+			in: diff.Hunk{
+				Body: []byte(` Hello
++Wonderful
+ World
++!`),
+			},
+			want: `Hello
+Wonderful
+World
+!`,
+		},
+		{
+			name: "additions and removals",
+			in: diff.Hunk{
+				Body: []byte(`-Hello
++Goodbye
+ World`),
+			},
+			want: `Goodbye
+World`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffHuskNew(&tt.in)
+			if string(got) != tt.want {
+				t.Errorf("Incorrect diff parse want:\n%s\ngot:\n%s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func Test_ParseDiffHunkOrig(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   diff.Hunk
+		want string
+	}{
+		{
+			name: "no changes - no newline at end", // shouldn't happen in reality
+			in: diff.Hunk{
+				Body: []byte(" Hello\n World"),
+			},
+			want: "Hello\nWorld",
+		},
+		{
+			name: "no changes - newline at end", // shouldn't happen in reality
+			in: diff.Hunk{
+				Body: []byte(" Hello\n World\n"),
+			},
+			want: "Hello\nWorld\n",
+		},
+		{
+			name: "only additions",
+			in: diff.Hunk{
+				Body: []byte(` Hello
++Wonderful
+ World
++!`),
+			},
+			want: `Hello
+World
+`,
+		},
+		{
+			name: "additions and removals",
+			in: diff.Hunk{
+				Body: []byte(`-Hello
++Goodbye
+ World`),
+			},
+			want: `Hello
+World`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffHuskOrig(&tt.in)
+			if string(got) != tt.want {
+				t.Errorf("Incorrect diff parse want:\n%s\ngot:\n%s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func Test_ComputeGitHash(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   zoekt.Document
+		want plumbing.Hash
+	}{
+		{
+			name: "file without newline at end",
+			in: zoekt.Document{
+				Name:    "a.txt",
+				Content: []byte("Hello, World!"),
+			},
+			want: plumbing.NewHash("b45ef6fec89518d314f546fd6c3025367b721684"),
+		},
+		{
+			name: "file with newline at end",
+			in: zoekt.Document{
+				Name:    "b.txt",
+				Content: []byte("Hello, World!\n"),
+			},
+			want: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plumbing.ComputeHash(plumbing.BlobObject, tt.in.Content)
+			if got != tt.want {
+				t.Errorf("Hash mismatch got %s, wanted %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_ParseGitHashFromDiff(t *testing.T) {
+	var tests = []struct {
+		name string
+		in   diff.FileDiff
+		want [2]string
+	}{
+		{
+			name: "",
+			in:   diff.FileDiff{Extended: []string{"diff --git go.mod go.mod", "index 0862d4714f9faf7b1b2c2ff3645c18d3925a2c3a..d479a7d884e72e4bfe326e054474b7720bec7cae 100644"}},
+			want: [2]string{"0862d4714f9faf7b1b2c2ff3645c18d3925a2c3a", "d479a7d884e72e4bfe326e054474b7720bec7cae"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOld, gotNew := parseGitHashFromDiff(&tt.in)
+			if gotOld.String() != tt.want[0] {
+				t.Errorf("Hash mismatch got %s, wanted %s", gotOld, tt.want)
+			}
+			if gotNew.String() != tt.want[1] {
+				t.Errorf("Hash mismatch got %s, wanted %s", gotNew, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/zoekt-index-diff/index.go
+++ b/cmd/zoekt-index-diff/index.go
@@ -100,6 +100,8 @@ func fileModified(branch string, f *diff.FileDiff, b *build.Builder, d *zoekt.Do
 		} else {
 			doc.Branches = br
 		}
+	} else {
+		log.Fatalf("Could not find document for old version of changed file %s", f.NewName)
 	}
 
 	// Add new version of file

--- a/cmd/zoekt-index-diff/index.go
+++ b/cmd/zoekt-index-diff/index.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"log"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/zoekt"
+	"github.com/google/zoekt/build"
+	"github.com/sourcegraph/go-diff/diff"
+)
+
+func getBranchSetFromShard(bOpts build.Options) []zoekt.RepositoryBranch {
+	repo, ok, err := bOpts.FindRepositoryMetadata()
+	if !ok {
+		log.Fatalf("Could not read branches from disk: %v", err)
+	}
+	return repo.Branches
+}
+
+func existingShardPaths(bOpts build.Options) []string {
+	shards := bOpts.FindAllShards()
+	return shards
+}
+
+func removeBranch(branch string, branches []string) []string {
+	for i, b := range branches {
+		if branch == b {
+			return append(branches[:i], branches[i+1:]...)
+		}
+	}
+	return nil
+}
+
+func index(r io.Reader, branch string, sha string, bOpts build.Options) error {
+	dr := diff.NewMultiFileDiffReader(r)
+
+	d, err := zoekt.NewDocReader(existingShardPaths(bOpts))
+	if err != nil {
+		log.Fatalf("")
+	}
+	defer d.Close()
+	// Debugging
+	// d.ListDocs()
+	// return nil
+
+	b, err := build.NewBuilder(bOpts)
+	if err != nil {
+		return err
+	}
+	defer b.Finish()
+
+	for {
+		f, err := dr.ReadFile()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if f.NewName == "/dev/null" {
+			// File path removed
+			fileRemoved(branch, f, b, d)
+		} else if f.OrigName == "/dev/null" {
+			// File path added
+			fileAdded(branch, f, b, d)
+		} else {
+			// File content modified
+			fileModified(branch, f, b, d)
+		}
+
+	}
+
+	err = b.Finish()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fileModified(branch string, f *diff.FileDiff, b *build.Builder, d *zoekt.DocReader) {
+	c := parseDiffHuskNew(f.Hunks[0])
+	oldHash, newHash := parseGitHashFromDiff(f)
+	b.MarkFileAsChangedOrRemoved(f.NewName)
+
+	docs := d.ReadDocs(f.NewName)
+	hashes := make(map[plumbing.Hash]*zoekt.Document, len(docs))
+	for _, doc := range docs {
+		hashes[computeGitHash(doc)] = &doc
+	}
+
+	// Remove old version of file
+	if doc, ok := hashes[oldHash]; ok {
+		br := removeBranch(branch, doc.Branches)
+		// Either old doc was unique, remove it. Or just remove from branches of doc
+		if len(br) == 0 {
+			delete(hashes, oldHash)
+		} else {
+			doc.Branches = br
+		}
+	}
+
+	// Add new version of file
+	if doc, ok := hashes[newHash]; ok {
+		doc.Branches = append(doc.Branches, branch)
+	} else {
+		b.Add(zoekt.Document{
+			Name:     f.NewName,
+			Content:  c,
+			Branches: []string{branch},
+		})
+	}
+
+	// Re-add docs
+	for _, doc := range hashes {
+		b.Add(*doc)
+	}
+}
+
+func fileAdded(branch string, f *diff.FileDiff, b *build.Builder, d *zoekt.DocReader) {
+	c := parseDiffHuskNew(f.Hunks[0])
+	b.MarkFileAsChangedOrRemoved(f.NewName)
+
+	docs := d.ReadDocs(f.NewName)
+	for i, doc := range docs {
+		if bytes.Equal(c, doc.Content) {
+			docs[i].Branches = append(doc.Branches, branch)
+
+			// Re-add docs
+			for _, doc := range docs[i:] {
+				b.Add(doc)
+			}
+			return
+		} else {
+			b.Add(doc)
+		}
+	}
+
+	// Unique to this branch
+	b.Add(zoekt.Document{
+		Name:     f.NewName,
+		Content:  c,
+		Branches: []string{branch},
+	})
+}
+
+func fileRemoved(branch string, f *diff.FileDiff, b *build.Builder, d *zoekt.DocReader) {
+	// Use original file contents for comparison
+	c := parseDiffHuskOrig(f.Hunks[0])
+	b.MarkFileAsChangedOrRemoved(f.OrigName)
+
+	docs := d.ReadDocs(f.OrigName)
+	for i, doc := range docs {
+		if bytes.Equal(c, doc.Content) {
+			br := removeBranch(branch, doc.Branches)
+
+			// Document only existed on this branch
+			if len(br) == 0 {
+				docs = append(docs[:i], docs[i+1:]...)
+			} else {
+				docs[i].Branches = br
+			}
+
+			// Re-add docs
+			for _, doc := range docs[i:] {
+				b.Add(doc)
+			}
+
+			return
+		} else {
+			b.Add(doc)
+		}
+	}
+}

--- a/cmd/zoekt-index-diff/index_test.go
+++ b/cmd/zoekt-index-diff/index_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_RemoveBranch(t *testing.T) {
+	var tests = []struct {
+		name       string
+		inBranch   string
+		inBranches []string
+		want       []string
+	}{
+		{
+			name:       "branch at start",
+			inBranch:   "main",
+			inBranches: []string{"main", "a", "b"},
+			want:       []string{"a", "b"},
+		},
+		{
+			name:       "branch in middle",
+			inBranch:   "main",
+			inBranches: []string{"a", "main", "b"},
+			want:       []string{"a", "b"},
+		},
+		{
+			name:       "branch at end",
+			inBranch:   "main",
+			inBranches: []string{"a", "b", "main"},
+			want:       []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := removeBranch(tt.inBranch, tt.inBranches)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Incorrect branch removal got %s, wanted %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/zoekt-index-diff/main.go
+++ b/cmd/zoekt-index-diff/main.go
@@ -1,0 +1,153 @@
+// command zoekt-index-diff parses a unified diff from stdin to create a delta build
+// the unified diff should have the following options specified:
+// --full-index
+//		Full file git hash
+// -U<large number>
+//		Include entire file as context in diff.
+//		<large number> specifies max lines per file. Should be greater than longest file
+// --no-prefix
+//		Remove default a/ & b/ prefixes from file names
+// --no-renames
+//		Handle renames as separate file removal and addition
+package main
+
+import (
+	"bufio"
+	"flag"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/google/zoekt/build"
+	"github.com/google/zoekt/cmd"
+	"go.uber.org/automaxprocs/maxprocs"
+)
+
+type Options struct {
+	Name     string
+	RepoURL  string
+	Branch   string
+	Commit   string
+	IndexDir string
+	ID       uint32
+	Archived bool
+	Public   bool
+	Fork     bool
+	Priority float64
+	DiffFile string
+}
+
+// bOptsFromOpts parses build options from CLI flags
+func bOptsFromOpts(opts Options, bOpts *build.Options) {
+	if opts.Name == "" {
+		log.Panic("-name required")
+	}
+
+	if opts.ID == 0 {
+		log.Panic("-id required")
+	}
+
+	if opts.Branch == "" {
+		log.Panic("-branch required")
+	}
+
+	if opts.Commit == "" {
+		log.Panic("-commit required")
+	}
+
+	bOpts.IndexDir = opts.IndexDir
+	bOpts.IsDelta = true
+
+	bOpts.RepositoryDescription.Name = opts.Name
+	bOpts.RepositoryDescription.ID = opts.ID
+
+	// Branch set must be the same for a delta build so read from shard
+	bOpts.RepositoryDescription.Branches = getBranchSetFromShard(*bOpts)
+	for i, b := range bOpts.RepositoryDescription.Branches {
+		if b.Name == opts.Branch {
+			bOpts.RepositoryDescription.Branches[i].Version = opts.Commit
+			break
+		}
+	}
+	bOpts.RepositoryDescription.URL = opts.RepoURL
+	bOpts.RepositoryDescription.RawConfig = map[string]string{
+		"repoid":   strconv.Itoa(int(opts.ID)),
+		"priority": strconv.FormatFloat(opts.Priority, 'g', -1, 64),
+		"public":   marshalBool(opts.Public),
+		"fork":     marshalBool(opts.Fork),
+		"archived": marshalBool(opts.Archived),
+	}
+}
+
+func marshalBool(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+func main() {
+	var (
+		// required
+		name   = flag.String("name", "", "The repository name for the archive")
+		urlRaw = flag.String("url", "", "The repository URL for the archive")
+		branch = flag.String("branch", "", "The branch name for the archive")
+		commit = flag.String("commit", "", "The commit sha. If incremental this will avoid updating shards already at commit")
+		id     = flag.Uint("id", 0, "Sourcegraph repository ID")
+		// optional
+		indexDir = flag.String("index_dir", build.DefaultDir, "Index directory for *.zoekt files")
+		archived = flag.Bool("archived", false, "Set repository `archived` flag")
+		public   = flag.Bool("public", false, "Set repository `public` flag")
+		fork     = flag.Bool("fork", false, "Set repository `fork` flag")
+		priority = flag.Float64("priority", 0, "Set repository priority")
+		// if specified read diff from file
+		diffFile = flag.String("diff_file", "", "Read diff from file instead of stdin")
+	)
+
+	flag.Parse()
+
+	// Tune GOMAXPROCS to match Linux container CPU quota.
+	_, _ = maxprocs.Set()
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	bOpts := cmd.OptionsFromFlags()
+
+	opts := Options{
+		Name:     *name,
+		RepoURL:  *urlRaw,
+		Branch:   *branch,
+		Commit:   *commit,
+		IndexDir: *indexDir,
+		ID:       uint32(*id),
+		Archived: *archived,
+		Public:   *public,
+		Fork:     *fork,
+		Priority: *priority,
+		DiffFile: *diffFile,
+	}
+
+	// Parse options
+	bOptsFromOpts(opts, bOpts)
+
+	// If diff_file specified read from file instead of stdin
+	diff := os.Stdin
+	if *diffFile != "" {
+		if _, err := os.Stat(*diffFile); err != nil {
+			log.Fatalf("Could not get file info %s; %s", *diffFile, err)
+		}
+		f, err := os.Open(*diffFile)
+		if err != nil {
+			log.Fatalf("Could not open file %s; %s", *diffFile, err)
+		}
+		defer f.Close()
+		diff = f
+	}
+
+	r := bufio.NewReader(diff)
+	err := index(r, opts.Branch, opts.Commit, *bOpts)
+	if err != nil {
+		log.Panicf("Failed to index: %v", err)
+		return
+	}
+}

--- a/docreader.go
+++ b/docreader.go
@@ -1,0 +1,155 @@
+package zoekt
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+)
+
+// DocReader provides a non-search based api
+// for reading documents from shards.
+//
+// Close() should be called on DocReader to close opened shards
+//
+// TODO(jac): Support compound shards
+type DocReader struct {
+	indexData []*indexData
+}
+
+func NewDocReader(shards []string) (*DocReader, error) {
+	dr := &DocReader{
+		indexData: make([]*indexData, 0, len(shards)),
+	}
+	// Open each shard and read indexData
+	for _, shard := range shards {
+		f, err := os.Open(shard)
+		if err != nil {
+			dr.Close()
+			return nil, fmt.Errorf("coudln't open shard %s; %s", shard, err)
+		}
+
+		r, err := NewIndexFile(f)
+		if err != nil {
+			f.Close()
+			dr.Close()
+			return nil, fmt.Errorf("couldn't create index file; %s", err)
+		}
+		rd := &reader{r: r}
+
+		var toc indexTOC
+		if err := rd.readTOC(&toc); err != nil {
+			r.Close()
+			dr.Close()
+			return nil, err
+		}
+
+		indexData, err := rd.readIndexData(&toc)
+		if err != nil {
+			indexData.Close()
+			dr.Close()
+			return nil, err
+		}
+		dr.indexData = append(dr.indexData, indexData)
+	}
+
+	return dr, nil
+}
+
+func (d *DocReader) ReadDocs(filename string) []Document {
+	// Can have at most one document per branch
+	docs := make([]Document, 0, len(d.indexData[0].branchNames))
+
+	var wg sync.WaitGroup
+	c := make(chan Document)
+	for i := 0; i < len(d.indexData); i++ {
+		i := i
+		// Check if filename is tombstoned in this shard
+		if _, t := d.indexData[i].repoMetaData[0].FileTombstones[filename]; t {
+			continue
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			findDocsInIndexData(filename, d.indexData[i], c)
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+
+	for {
+		doc, ok := <-c
+		if ok {
+			docs = append(docs, doc)
+		} else {
+			break
+		}
+	}
+
+	return docs
+}
+
+func findDocsInIndexData(name string, d *indexData, c chan Document) {
+	for i := 0; i < len(d.fileNameIndex)-1; i++ {
+		filename := d.fileName(uint32(i))
+		// compiler does not allocate for the comparison
+		if len(name) == len(filename) && name == string(filename) {
+			name := string(filename)
+			content, err := d.readContents(uint32(i))
+			if err != nil {
+				log.Panicf("Couldn't read document %s in shard %s", name, d)
+			}
+
+			// Parse individual branch names from branch mask
+			branches := branchNamesFromMask(uint32(i), d)
+
+			d := Document{
+				Name:     name,
+				Content:  content,
+				Branches: branches,
+			}
+
+			c <- d
+		}
+	}
+}
+
+func branchNamesFromMask(fileIndex uint32, d *indexData) []string {
+	branches := make([]string, 0, len(d.branchNames))
+	mask := d.fileBranchMasks[fileIndex]
+	id := uint32(1)
+	for mask != 0 {
+		if mask&0x1 != 0 {
+			branches = append(branches, d.branchNames[0][uint(id)])
+		}
+		id <<= 1
+		mask >>= 1
+	}
+	return branches
+}
+
+// Close shards opened by the RepoDocReader. Should only be called once
+func (d *DocReader) Close() {
+	for _, shard := range d.indexData {
+		shard.Close()
+	}
+}
+
+// ListDocs lists all documents and their branches across all loaded shards
+//
+// For debugging purposes
+func (d *DocReader) ListDocs() {
+	for _, shard := range d.indexData {
+		fmt.Println(shard.file.Name())
+		for i := 0; i < len(shard.fileNameIndex)-1; i++ {
+			filename := shard.fileName(uint32(i))
+			branches := branchNamesFromMask(uint32(i), shard)
+			fmt.Printf("%s %s\n", filename, branches)
+		}
+		fmt.Println()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/rs/xid v1.4.0
 	github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037
+	github.com/sourcegraph/go-diff v0.6.1
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible
 	github.com/xanzy/go-gitlab v0.64.0

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
+github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -397,6 +399,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037 h1:gk2cs5tfGFtpZfaK5sKnn3Y4iyzrpCfdpncZhTKLz5E=
 github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037/go.mod h1:ZYjpRXoJrRlxjU9ZfpaUKJkk62AjhJPffN3rlw2aqxM=
+github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
+github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Progress on https://github.com/sourcegraph/sourcegraph/issues/37063
**DISCLAIMER: In its current state this PR is a POC. It is not feature complete. It lacks appropriate testing. Its goal is to elicit feedback and guide future development efforts!**

All feedback is welcome. Particularly feedback which discusses the approach which I have outlined in detail below!

### Background context
The foundational work to support incremental indexing resulted in massively decreased indexing times for larger repositories as only the changed files need to be reindexed. However it still requires shallow cloning all files in the repository, including those which have not changed. For large repositories this means substantially more time is spent cloning than performing the index. 
As such, reducing the time spent cloning by only downloading the changed files would cut the time down massively

### Approach
The approach taken in this POC is to use git diffs where the flag -U<larger number> is used to include the entire file in the diff context (as well as some other options, outlined in `cmd/zoekt-index-diff/main.go` to make things easier). 

**For each file:**
 - Parsing the diff allows us to calculate both the original and new file contents as well as the old and new git blob hashes.
 - The original and new file path allow us to determine whether the file has been added/removed/modified
   - Added if original filename is `/dev/null`
   - Removed if new filename is `/dev/null`
   - Modified in all other cases

**For added files:**
 - Check for any documents with the same filename for this repo in a shard
   - Of those check if any document has the same content as the new content from diff
     - If so add current branch to document and insert document into new shard
     - Otherwise this must be a unique version of the file so create a new document for it

**For removed files:**
- Check for any documents with the same filename for this repo in a shard
  - Of those check if any document has the same content as the original content from diff (new content is blank - it's been removed)
    - If so remove current branch from document and insert document into new shard
    - Otherwise the file was unique so no document needs to be updated/added to new shard

**For modified files:**
- Parse the old & new git blob hashes for the file
- Check for any documents with the same filename for this repo in a shard
  - Compute the git blob hashes for each document
  - Check if any document hash matches the old version of the file
    -   If so remove current branch from document and insert document into new shard
    - Otherwise the file was unique so no document needs to be updated/added to new shard
  - Check if any document hash matches the new version of the file
    -  If so add current branch to document and insert document into new shard
    - Otherwise this must be a unique version of the file so create a new document for it

That is the general overview of the approach. In all cases any other documents which matched the `Check for any documents with the same filename for this repo in a shard` but which weren't the one we were looking for are re-added to the new shard for file tombstone consistency.

The current implementation lacks some important checks
- Verify old commit we are diffing against is actually what is on disk
  - Otherwise there will be a mismatch during comparisons and the shard could end up in a bad state
- Handle skipped/ignored files

### DocReader
As reading existing documents is required by this POC I created DocReader as a very simple way of extracting documents directly out of shards without having to go through the Searcher interface. DocReader has enough functionality to get the job done for this POC and not much more.
If a similar indexing method as outlined in this POC is further developed; DocReader like functionality should probably be developed first in a separate PR.

### Drawbacks
Aside from the missing functionality mentioned above this general approach has a major drawback. It does not support multi-branch indexing. If there are changes on multiple branches they will need to be handled sequentially.
It should be possible to adapt this approach by a *not significant* amount to support multi-branch indexing but that was out of scope for this POC

### Test Plan
- I added some tests to verify some functionality around the diffs
- Lacking proper testing around the core flow added/removed/modified docs
  - In its current form probably needs a refactor to be a bit more testable
- Manually verified that the shards appeared correct after creating a delta shard

If you would like to play around with it I would recommend the following:

Add a couple branches to git config which sourcegraphFake will read #393 for indexing.
It's easier for testing if one of these is branch you have checked out.
```
git config add zoekt.branch <branch>
git config add zoekt.branch <branch2>
```
Index the repo with `zoekt-sourcegraph-indexserver`

Make a change to a file and commit it.

Run the following modifying REPO_ID and REPO_NAME, and anything. These can be found in plaintext at the end of an existing shard in the metadata section.
```
git diff HEAD~..HEAD --full-index -U9999999 --no-prefix --no-renames | go run ./cmd/zoekt-index-diff -id "<REPO_ID>" -name "<REPO_NAME>" -branch "$(git rev-parse --abbrev-ref HEAD)" -commit "$(git rev-parse HEAD)"
```
