### PR TITLE
docker: only set GOGC for webserver image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,4 @@ RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh
 
 COPY --from=builder /go/bin/* /usr/local/bin/
 
-# zoekt-webserver has a large stable heap size (10s of gigs), and as such the
-# default GOGC=100 could be better tuned. https://dave.cheney.net/tag/gogc
-# In go1.18 the GC changed significantly and from experimentation we tuned it
-# down from 50 to 25.
-ENV GOGC=25
-
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -22,10 +22,4 @@ COPY --from=zoekt \
     /usr/local/bin/zoekt-merge-index \
     /usr/local/bin/
 
-# zoekt indexing has a large stable heap size (gigs), and as such the default
-# GOGC=100 could be better tuned. https://dave.cheney.net/tag/gogc
-# In go1.18 the GC changed significantly and from experimentation we tuned it
-# down from 50 to 25.
-ENV GOGC=25
-
 ENTRYPOINT ["/sbin/tini", "--", "zoekt-sourcegraph-indexserver"]


### PR DESCRIPTION
Only zoekt-webserver zoekt has a large stable heap. So we likely were using a non-optimal value for GOGC in indexserver. Additionally we don't publish the image from "Dockerfile" so we don't need the GOGC envvar there.

Test Plan: built and inspected the env. Only webserver should have a GOGC value. Otherwise will rely on CI.

``` shell
docker build -t zoekt .
docker build -t zoekt-indexserver . -f Dockerfile.indexserver
docker build -t zoekt-webserver   . -f Dockerfile.webserver
docker inspect zoekt-indexserver | jq '.[] | .Config.Env'
docker inspect zoekt-webserver   | jq '.[] | .Config.Env'
```
