### PR TITLE
indexserver: log ids of repos we stop tracking

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -318,9 +318,8 @@ func (s *Server) Run() {
 			// Stop indexing repos we don't need to track anymore
 			removed := s.queue.MaybeRemoveMissing(repos.IDs)
 			metricNumStoppedTrackingTotal.Add(float64(len(removed)))
-
 			if len(removed) > 0 {
-				log.Printf("stopped tracking %d repositories: %v", len(removed), formatListUint32(removed, 5))
+				log.Printf("stopped tracking %d repositories: %s", len(removed), formatListUint32(removed, 5))
 			}
 
 			cleanupDone := make(chan struct{})

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -328,8 +328,7 @@ func (s *Server) Run() {
 				sb := strings.Builder{}
 				sb.WriteString(strconv.FormatUint(uint64(removed[0]), 10))
 				for i := 1; i < max; i++ {
-					sb.WriteString(", ")
-					sb.WriteString(strconv.FormatUint(uint64(removed[i]), 10))
+					fmt.Fprintf(&sb, ", %d", removed[i])
 				}
 
 				if n > max {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -319,23 +319,8 @@ func (s *Server) Run() {
 			removed := s.queue.MaybeRemoveMissing(repos.IDs)
 			metricNumStoppedTrackingTotal.Add(float64(len(removed)))
 
-			if n := len(removed); n > 0 {
-				max := 5
-				if n < max {
-					max = n
-				}
-
-				sb := strings.Builder{}
-				sb.WriteString(strconv.FormatUint(uint64(removed[0]), 10))
-				for i := 1; i < max; i++ {
-					fmt.Fprintf(&sb, ", %d", removed[i])
-				}
-
-				if n > max {
-					sb.WriteString(" ...")
-				}
-
-				log.Printf("stopped tracking %d repositories: %v", n, sb.String())
+			if len(removed) > 0 {
+				log.Printf("stopped tracking %d repositories: %v", len(removed), formatListUint32(removed, 5))
 			}
 
 			cleanupDone := make(chan struct{})
@@ -385,6 +370,24 @@ func (s *Server) Run() {
 
 	// block forever
 	select {}
+}
+
+// formatList returns a comma-separated list of the first min(len(v), m) items.
+func formatListUint32(v []uint32, m int) string {
+	if len(v) < m {
+		m = len(v)
+	}
+
+	sb := strings.Builder{}
+	for i := 0; i < m; i++ {
+		fmt.Fprintf(&sb, "%d, ", v[i])
+	}
+
+	if len(v) > m {
+		sb.WriteString("...")
+	}
+
+	return strings.TrimRight(sb.String(), ", ")
 }
 
 func (s *Server) processQueue() {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -141,5 +142,38 @@ func TestCreateEmptyShard(t *testing.T) {
 
 	if got := bo.IncrementalSkipIndexing(); !got {
 		t.Fatalf("wanted %t, got %t", true, got)
+	}
+}
+
+func TestFormatListUint32(t *testing.T) {
+	cases := []struct {
+		in   []uint32
+		want string
+	}{
+		{
+			in:   []uint32{42, 8, 3},
+			want: "42, 8, ...",
+		},
+		{
+			in:   []uint32{42, 8},
+			want: "42, 8",
+		},
+		{
+			in:   []uint32{42},
+			want: "42",
+		},
+		{
+			in:   []uint32{},
+			want: "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(fmt.Sprintf("%v", tt.in), func(t *testing.T) {
+			out := formatListUint32(tt.in, 2)
+			if out != tt.want {
+				t.Fatalf("want %s, got %s", tt.want, out)
+			}
+		})
 	}
 }


### PR DESCRIPTION
With this change we log up to 5 ids of the repos we stopped tracking.
The ids will help us to find out why frontend tells Zoekt to drop
the repos.

```
2022/07/26 19:27:00 stopped tracking 7 repositories: 1286323510, 1772755594, 54565483, 1944134402, 1441460421 ...
```