### PR TITLE
Use modern GitLab URLs

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -145,8 +145,10 @@ func setTemplates(repo *zoekt.Repository, u *url.URL, typ string) error {
 		repo.FileURLTemplate = u.String() + "/{{.Path}}?at={{.Version}}"
 		repo.LineFragmentTemplate = "#{{.LineNumber}}"
 	case "gitlab":
-		repo.CommitURLTemplate = u.String() + "/commit/{{.Version}}"
-		repo.FileURLTemplate = u.String() + "/blob/{{.Version}}/{{.Path}}"
+		// https://gitlab.com/gitlab-org/omnibus-gitlab/-/commit/b152c864303dae0e55377a1e2c53c9592380ffed
+		// https://gitlab.com/gitlab-org/omnibus-gitlab/-/blob/aad04155b3f6fc50ede88aedaee7fc624d481149/files/gitlab-config-template/gitlab.rb.template
+		repo.CommitURLTemplate = u.String() + "/-/commit/{{.Version}}"
+		repo.FileURLTemplate = u.String() + "/-/blob/{{.Version}}/{{.Path}}"
 		repo.LineFragmentTemplate = "#L{{.LineNumber}}"
 	default:
 		return fmt.Errorf("URL scheme type %q unknown", typ)


### PR DESCRIPTION
I have no idea when GitLab started using this URL scheme, but all modern GitLab instances I have access to use this URL pattern.

The old scheme still works, but leads to some UI problems (for example, the branch drop-down is broken), see for comparison:
- Old: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/aad04155b3f6fc50ede88aedaee7fc624d481149/files/gitlab-config-template/gitlab.rb.template
- New: https://gitlab.com/gitlab-org/omnibus-gitlab/-/blob/aad04155b3f6fc50ede88aedaee7fc624d481149/files/gitlab-config-template/gitlab.rb.template

Try to switch to the `master` branch on both and see how you loose the file path in the old URL