### PR TITLE
rpc: register SearchResult

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -130,6 +130,7 @@ var once sync.Once
 // once, because calls to gob.Register are protected by a sync.Once.
 func RegisterGob() {
 	once.Do(func() {
+		gobRegister(&zoekt.SearchResult{})
 		gobRegister(&query.And{})
 		gobRegister(&query.BranchRepos{})
 		gobRegister(&query.BranchesRepos{})

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -6,7 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"net/http"
-	"sync"
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
@@ -30,7 +29,7 @@ func (e eventType) string() string {
 
 // Server returns an http.Handler which is the server side of StreamSearch.
 func Server(searcher zoekt.Streamer) http.Handler {
-	registerGob()
+	rpc.RegisterGob()
 	return &handler{Searcher: searcher}
 }
 
@@ -153,13 +152,4 @@ func (e *eventStreamWriter) event(event eventType, data interface{}) error {
 	}
 	e.flush()
 	return nil
-}
-
-var once sync.Once
-
-func registerGob() {
-	once.Do(func() {
-		gob.Register(&zoekt.SearchResult{})
-	})
-	rpc.RegisterGob()
 }


### PR DESCRIPTION
I can't remember why we explicitly register SearchResult in stream.
However, it feels appropriate to collect all gob registrations in one
place. Especially since we added a special version of gob.Register.

Test Plan: no functional change here, but go test.