### PR TITLE
zoekt-webserver: add JSON API

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -1,0 +1,172 @@
+package json
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/query"
+)
+
+// defaultTimeout is the maximum amount of time a search request should
+// take. This is the same default used by Sourcegraph.
+const defaultTimeout = 20 * time.Second
+
+func JSONServer(searcher zoekt.Searcher) http.Handler {
+	s := jsonSearcher{searcher}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search", s.jsonSearch)
+	mux.HandleFunc("/list", s.jsonList)
+	return mux
+}
+
+type jsonSearcher struct {
+	Searcher zoekt.Searcher
+}
+
+type jsonSearchArgs struct {
+	Q    string
+	Opts *zoekt.SearchOptions
+}
+
+type jsonSearchReply struct {
+	Result *zoekt.SearchResult
+}
+
+type jsonListArgs struct {
+	Q    string
+	Opts *zoekt.ListOptions
+}
+
+type jsonListReply struct {
+	List *zoekt.RepoList
+}
+
+func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	w.Header().Add("Content-Type", "application/json")
+
+	if req.Method != "POST" {
+		jsonError(w, http.StatusMethodNotAllowed, "Only POST is supported")
+		return
+	}
+
+	searchArgs := jsonSearchArgs{}
+	err := json.NewDecoder(req.Body).Decode(&searchArgs)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if searchArgs.Q == "" {
+		jsonError(w, http.StatusBadRequest, "missing query")
+		return
+	}
+	if searchArgs.Opts == nil {
+		searchArgs.Opts = &zoekt.SearchOptions{}
+	}
+
+	query, err := query.Parse(searchArgs.Q)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Set a timeout if the user hasn't specified one.
+	if searchArgs.Opts.MaxWallTime == 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+
+	if err := CalculateDefaultSearchLimits(ctx, query, s.Searcher, searchArgs.Opts); err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	searchResult, err := s.Searcher.Search(ctx, query, searchArgs.Opts)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	json.NewEncoder(w).Encode(jsonSearchReply{searchResult})
+}
+
+func jsonError(w http.ResponseWriter, statusCode int, err string) {
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(struct{ Error string }{Error: err})
+}
+
+// Calculates and sets heuristic defaults on opts for various upper bounds on
+// the number of matches when searching, if none are already specified. The
+// defaults are derived from opts.MaxDocDisplayCount, so if none is set, there
+// is no calculation to do.
+func CalculateDefaultSearchLimits(ctx context.Context,
+	q query.Q,
+	searcher zoekt.Searcher,
+	opts *zoekt.SearchOptions) error {
+	if opts.MaxDocDisplayCount == 0 || opts.ShardMaxMatchCount != 0 || opts.ShardMaxImportantMatch != 0 {
+		return nil
+	}
+
+	maxResultDocs := opts.MaxDocDisplayCount
+	// This is a special mode of Search that _only_ calculates ShardFilesConsidered and bails ASAP.
+	if result, err := searcher.Search(ctx, q, &zoekt.SearchOptions{EstimateDocCount: true}); err != nil {
+		return err
+	} else if numdocs := result.ShardFilesConsidered; numdocs > 10000 {
+		// If the search touches many shards and many files, we
+		// have to limit the number of matches.  This setting
+		// is based on the number of documents eligible after
+		// considering reponames, so large repos (both
+		// android, chromium are about 500k files) aren't
+		// covered fairly.
+
+		// 10k docs, 50 maxResultDocs -> max match = (250 + 250 / 10)
+		opts.ShardMaxMatchCount = maxResultDocs*5 + (5*maxResultDocs)/(numdocs/1000)
+
+		// 10k docs, 50 maxResultDocs -> max important match = 4
+		opts.ShardMaxImportantMatch = maxResultDocs/20 + maxResultDocs/(numdocs/500)
+	} else {
+		// Virtually no limits for a small corpus; important
+		// matches are just as expensive as normal matches.
+		n := numdocs + maxResultDocs*100
+		opts.ShardMaxImportantMatch = n
+		opts.ShardMaxMatchCount = n
+		opts.TotalMaxMatchCount = n
+		opts.TotalMaxImportantMatch = n
+	}
+
+	return nil
+}
+
+func (s *jsonSearcher) jsonList(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
+
+	if req.Method != "POST" {
+		jsonError(w, http.StatusMethodNotAllowed, "Only POST is supported")
+		return
+	}
+
+	listArgs := jsonListArgs{}
+	err := json.NewDecoder(req.Body).Decode(&listArgs)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	query, err := query.Parse(listArgs.Q)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	listResult, err := s.Searcher.List(req.Context(), query, listArgs.Opts)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	json.NewEncoder(w).Encode(jsonListReply{listResult})
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1,0 +1,92 @@
+package json_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/internal/mockSearcher"
+	zjson "github.com/sourcegraph/zoekt/json"
+	"github.com/sourcegraph/zoekt/query"
+)
+
+func TestClientServer(t *testing.T) {
+	searchQuery := "\"hello world|universe\""
+	mock := &mockSearcher.MockSearcher{
+		WantSearch: mustParse(searchQuery),
+		SearchResult: &zoekt.SearchResult{
+			Files: []zoekt.FileMatch{
+				{FileName: "bin.go"},
+			},
+		},
+
+		WantList: &query.Const{Value: true},
+		RepoList: &zoekt.RepoList{
+			Repos: []*zoekt.RepoListEntry{
+				{
+					Repository: zoekt.Repository{
+						ID:   2,
+						Name: "foo/bar",
+					},
+				},
+			},
+		},
+	}
+
+	ts := httptest.NewServer(zjson.JSONServer(mock))
+	defer ts.Close()
+
+	searchBody, err := json.Marshal(struct{ Q string }{Q: searchQuery})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := http.Post(ts.URL+"/search", "application/json", bytes.NewBuffer(searchBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.StatusCode != 200 {
+		body, _ := ioutil.ReadAll(r.Body)
+		t.Fatalf("Got status code %d, err %s", r.StatusCode, string(body))
+	}
+
+	var searchResult struct{ Result *zoekt.SearchResult }
+	err = json.NewDecoder(r.Body).Decode(&searchResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(searchResult.Result, mock.SearchResult) {
+		t.Fatalf("\na %+v\nb %+v", searchResult.Result, mock.SearchResult)
+	}
+
+	listBody, err := json.Marshal(struct{ Q string }{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err = http.Post(ts.URL+"/list", "application/json", bytes.NewBuffer((listBody)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.StatusCode != 200 {
+		body, _ := ioutil.ReadAll(r.Body)
+		t.Fatalf("Got status code %d, err %s", r.StatusCode, string(body))
+	}
+
+	var listResult struct{ List *zoekt.RepoList }
+	err = json.NewDecoder(r.Body).Decode(&listResult)
+	if !reflect.DeepEqual(listResult.List, mock.RepoList) {
+		t.Fatalf("got %+v, want %+v", listResult, mock.RepoList)
+	}
+}
+
+func mustParse(s string) query.Q {
+	q, err := query.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return q
+}

--- a/web/server.go
+++ b/web/server.go
@@ -30,11 +30,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/rpc"
+	zjson "github.com/sourcegraph/zoekt/json"
 	"github.com/sourcegraph/zoekt/stream"
-	"github.com/grafana/regexp"
 )
 
 var Funcmap = template.FuncMap{
@@ -172,7 +173,8 @@ func NewMux(s *Server) (*http.ServeMux, error) {
 		mux.HandleFunc("/print", s.servePrint)
 	}
 	if s.RPC {
-		mux.Handle(rpc.DefaultRPCPath, rpc.Server(traceAwareSearcher{s.Searcher}))       // /rpc
+		mux.Handle(rpc.DefaultRPCPath, rpc.Server(traceAwareSearcher{s.Searcher})) // /rpc
+		mux.Handle("/api/", http.StripPrefix("/api", zjson.JSONServer(traceAwareSearcher{s.Searcher})))
 		mux.Handle(stream.DefaultSSEPath, stream.Server(traceAwareSearcher{s.Searcher})) // /stream
 	}
 
@@ -286,34 +288,13 @@ func (s *Server) serveSearchErr(r *http.Request) (*ApiSearchResult, error) {
 	sOpts.NumContextLines = numCtxLines
 
 	sOpts.SetDefaults()
-
-	ctx := r.Context()
-	if result, err := s.Searcher.Search(ctx, q, &zoekt.SearchOptions{EstimateDocCount: true}); err != nil {
-		return nil, err
-	} else if numdocs := result.ShardFilesConsidered; numdocs > 10000 {
-		// If the search touches many shards and many files, we
-		// have to limit the number of matches.  This setting
-		// is based on the number of documents eligible after
-		// considering reponames, so large repos (both
-		// android, chromium are about 500k files) aren't
-		// covered fairly.
-
-		// 10k docs, 50 num -> max match = (250 + 250 / 10)
-		sOpts.ShardMaxMatchCount = num*5 + (5*num)/(numdocs/1000)
-
-		// 10k docs, 50 num -> max important match = 4
-		sOpts.ShardMaxImportantMatch = num/20 + num/(numdocs/500)
-	} else {
-		// Virtually no limits for a small corpus; important
-		// matches are just as expensive as normal matches.
-		n := numdocs + num*100
-		sOpts.ShardMaxImportantMatch = n
-		sOpts.ShardMaxMatchCount = n
-		sOpts.TotalMaxMatchCount = n
-		sOpts.TotalMaxImportantMatch = n
-	}
 	sOpts.MaxDocDisplayCount = num
 	sOpts.DebugScore = debugScore
+
+	ctx := r.Context()
+	if err := zjson.CalculateDefaultSearchLimits(ctx, q, s.Searcher, &sOpts); err != nil {
+		return nil, err
+	}
 
 	result, err := s.Searcher.Search(ctx, q, &sOpts)
 	if err != nil {


### PR DESCRIPTION
This adds a JSON API that directly exposes the Search and List functions
at /api/search and /api/list in zoekt-webserveer, gated behind the
existing -rpc flag.

Closes #410.