### PR TITLE
ranking: favor short paths and multiple matches

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -844,6 +844,21 @@ public class HelloWorld
 			// 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 910,
 		},
+		{
+			fileName: "src/net/http/client.go",
+			content: []byte(`
+package http
+func Get() {
+	panic("")
+}
+`),
+			query: &query.And{Children: []query.Q{
+				&query.Symbol{Expr: &query.Substring{Pattern: "http", Content: true}},
+				&query.Symbol{Expr: &query.Substring{Pattern: "Get", Content: true}}}},
+			wantLanguage: "Go",
+			// 7000 (full base match) + 500 (word) + 400 (atom) + 10 (file order) + 1 (repetition-boost)
+			wantScore: 7911,
+		},
 	}
 
 	for _, c := range cases {

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -465,6 +465,7 @@ const (
 	scoreShardRankFactor    = 20.0
 	scoreFileOrderFactor    = 10.0
 	scoreLineOrderFactor    = 1.0
+	scoreRepetitionFactor   = 1.0
 )
 
 // findSection checks whether a section defined by offset and size lies within

--- a/eval.go
+++ b/eval.go
@@ -343,9 +343,13 @@ nextFileMatch:
 		}
 
 		maxFileScore := 0.0
+		repetitions := 0
 		for i := range fileMatch.LineMatches {
 			if maxFileScore < fileMatch.LineMatches[i].Score {
 				maxFileScore = fileMatch.LineMatches[i].Score
+				repetitions = 0
+			} else if maxFileScore == fileMatch.LineMatches[i].Score {
+				repetitions += 1
 			}
 
 			// Order by ordering in file.
@@ -365,6 +369,10 @@ nextFileMatch:
 		// strictly dominates the in-file ordering of
 		// the matches.
 		fileMatch.addScore("fragment", maxFileScore, opts.DebugScore)
+
+		// Prefer docs with several top-scored matches.
+		fileMatch.addScore("repetition-boost", scoreRepetitionFactor*float64(repetitions), opts.DebugScore)
+
 		fileMatch.addScore("atom", float64(atomMatchCount)/float64(totalAtomCount)*scoreFactorAtomMatch, opts.DebugScore)
 
 		// Prefer earlier docs.


### PR DESCRIPTION
This changes our scoring logic slightly to put more emphasis on shorter filenames and to recognize multiple matches.
 
1.  Index time: Sort documents with short filenames even earlier
2. Query time: Boost the score of documents with several top-ranked matches.

Nr. 1 favors short paths over short contents and many symbols. This is based on the assumption that in many cases short paths (IE early in the file tree) signify the most important components in a code base.

Nr. 2 adds a small boost to the score if there are several matches with a top score. So far we only looked at the top score in each document, which can lead to surprising results if the query contained multiple terms. For example, the previous ranking caused the following documents to have the same score

Query: "foo and bar"

document 1
```
foo (match)
bar (match)
```


document 2
```
foo (match)
wunderbar (partial match)
bas (no match)
```

Since document 2 has more symbols than doucment 1, document 2 was stored before document 1 in the shard. Since they both yield the same score based on their top matches, document 2 received an overal higher score based on its location in the shard. 



 