### PR TITLE
Improve performance of List

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -586,13 +586,13 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 			return nil, err
 		}
 
-		foundRepos := make(map[uint32]struct{}, len(sr.Files))
+		foundRepos := make(map[string]struct{}, len(sr.Files))
 		for _, file := range sr.Files {
-			foundRepos[file.RepositoryID] = struct{}{}
+			foundRepos[file.Repository] = struct{}{}
 		}
 
 		include = func(rle *RepoListEntry) bool {
-			_, ok := foundRepos[rle.Repository.ID]
+			_, ok := foundRepos[rle.Repository.Name]
 			return ok
 		}
 	}

--- a/eval.go
+++ b/eval.go
@@ -598,6 +598,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 	}
 
 	var l RepoList
+
 	minimal := opts != nil && opts.Minimal
 	if minimal {
 		l.Minimal = make(map[uint32]*MinimalRepoListEntry, len(d.repoListEntry))


### PR DESCRIPTION
This updates the List method to use the `ShardRepoMaxMatchCount` option
when it runs a search so that it doesn't need to search each repository
individually and sequentially. The goal here is to improve performance
for Sourcegraph queries like `repo:has.file(test.go)`.

I don't have a large enough number of repos cloned locally to demonstrate
that this is actually faster, but given that this codepath is really only used for 
queries like `repo:has.file()`, and that's currently performing very badly, 
this seems pretty low risk. This was essentially the approach we used
before switching to using `List()`, except we did it client-side. I've verified
that it's not worse for my ~40 local repos.

Slack thread with context [here](https://sourcegraph.slack.com/archives/C020S8AT3LN/p1661452827522229)