### PR TITLE
ranking: boost Java matches based on symbol kind

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -800,6 +800,11 @@ func TestScoring(t *testing.T) {
 		},
 	}
 
+	exampleJava, err := os.ReadFile("./test_data/example.java")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		fileName     string
 		content      []byte
@@ -808,20 +813,52 @@ func TestScoring(t *testing.T) {
 		wantScore    float64
 	}{
 		{
-			fileName: "hw.java",
-			content: []byte(`
-public class HelloWorld
-{
-       public static void main (String[] args)
-       {
-             System.out.println("Hello World!");
-       }
-}
-`),
-			query:        &query.Substring{Content: true, Pattern: "lloWorld"},
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "nnerClass"},
 			wantLanguage: "Java",
 			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "innerEnum"},
+			wantLanguage: "Java",
+			// 7000 (symbol) + 900 (Java enum) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8810,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "innerInterface"},
+			wantLanguage: "Java",
+			// 7000 (symbol) + 800 (Java interface) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8710,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "innerMethod"},
+			wantLanguage: "Java",
+			// 7000 (symbol) + 700 (Java method) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8610,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "field"},
+			wantLanguage: "Java",
+			// 7000 (symbol) + 600 (Java field) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8510,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "B"},
+			wantLanguage: "Java",
+			// 7000 (symbol) + 500 (Java enum constant) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8410,
 		},
 		{
 			fileName:     "a/b/c/config.go",

--- a/build/test_data/example.java
+++ b/build/test_data/example.java
@@ -1,0 +1,99 @@
+package minimized;
+
+public class InnerClasses {
+
+  private final int exampleField;
+
+  private static final String STRING = "asdf";
+
+  private static final int top = 5;
+  private static final int bottom = 10;
+
+  public InnerClasses(int exampleField) {
+    this.exampleField = exampleField;
+  }
+
+  public enum InnerEnum {
+    A,
+    B,
+    C
+  }
+
+  public interface InnerInterface<A, B> {
+    B apply(A a);
+  }
+
+  public @interface InnerAnnotation {
+    int value();
+  }
+
+  @SuppressWarnings(STRING + " ")
+  @InnerAnnotation(top / bottom)
+  public static class InnerStaticClass {
+
+    public static void innerStaticMethod() {}
+  }
+
+  public class InnerClass implements InnerInterface<Integer, Integer> {
+    private final int field;
+
+    public InnerClass(int field) {
+      this.field = field;
+    }
+
+    public void innerMethod() {
+      System.out.println(field + exampleField);
+    }
+
+    @Override
+    public Integer apply(Integer integer) {
+      return field * integer;
+    }
+  }
+
+  private static <A, B> B runInnerInterface(InnerInterface<A, B> fn, A a) {
+    return fn.apply(a);
+  }
+
+  public static void testEnum(InnerEnum magicEnum) {
+    if (System.nanoTime() > System.currentTimeMillis()) {
+      magicEnum = InnerEnum.B;
+    }
+    switch (magicEnum) {
+      case B:
+        System.out.println("b");
+        break;
+      case A:
+        System.out.println("a");
+        break;
+      default:
+        break;
+    }
+    if (magicEnum == InnerEnum.A) System.out.println("a");
+    else if (magicEnum == InnerEnum.C) System.out.println("b");
+    else System.out.println("c");
+  }
+
+  public static void testAnon() {
+    InnerInterface<String, String> fn =
+        new InnerInterface<String, String>() {
+          @Override
+          public String apply(String s) {
+            return s + "b";
+          }
+        };
+    System.out.println(fn.apply("a"));
+  }
+
+  public static String app() {
+    int a = 42;
+    InnerStaticClass.innerStaticMethod();
+    InnerClasses innerClasses = new InnerClasses(a);
+    InnerClass innerClass = innerClasses.new InnerClass(a);
+    innerClass.innerMethod();
+    System.out.println(runInnerInterface(innerClass, a));
+    testEnum(InnerEnum.A);
+    testAnon();
+    return "";
+  }
+}

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -641,8 +641,11 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 // scoreKind boosts a match based on the combination of language and kind. The
 // language string comes from go-enry, the kind string from ctags.
 func scoreKind(language string, kind string) float64 {
-	// Refer to universal-ctags --list-kinds=<language> to learn about the mappings
-	// for a language.
+	// Refer to universal-ctags --list-kinds-full=<language> to learn about which
+	// kinds are detected for which language.
+	//
+	// Note that go-ctags uses universal-ctags's interactive mode and thus returns
+	// the full name for "kind" and not the one-letter abbreviation.
 	var factor float64
 	switch language {
 	case "Java":

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -460,7 +460,7 @@ const (
 	scoreImportantThreshold = 2000.0
 	scoreSymbol             = 7000.0
 	scorePartialSymbol      = 4000.0
-	scoreKindMatch          = 1000.0
+	scoreKindMatch          = 100.0
 	scoreFactorAtomMatch    = 400.0
 	scoreShardRankFactor    = 20.0
 	scoreFileOrderFactor    = 10.0
@@ -643,17 +643,28 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 func scoreKind(language string, kind string) float64 {
 	// Refer to universal-ctags --list-kinds=<language> to learn about the mappings
 	// for a language.
+	var factor float64
 	switch language {
 	case "Java":
 		switch kind {
 		// 2022-03-30: go-ctags contains a regex rule for Java classes that sets "kind"
 		// to "classes" instead of "c". We have to cover both cases to support existing
 		// indexes.
-		case "c", "classes":
-			return scoreKindMatch
+		case "class", "classes":
+			factor = 10
+		case "enum":
+			factor = 9
+		case "interface":
+			factor = 8
+		case "method":
+			factor = 7
+		case "field":
+			factor = 6
+		case "enumConstant":
+			factor = 5
 		}
 	}
-	return 0
+	return factor * scoreKindMatch
 }
 
 type matchScoreSlice []LineMatch


### PR DESCRIPTION
With this change we add more granular boosts for Java matches based on their "kind".

I am also correcting a inconsequential mistake I made earlier. Since we use "interactive" mode in go-ctags, the output format is JSON which sets the "kind" to its long form and not the the single letter form. For example "class" instead of "c". Therfore we can remove the one-letter cases from scoring.

Thanks to @olafurpg for ordering the Java "kinds" by importance.