### PR TITLE
add metrics for memory maps to zoekt-webserver

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -180,7 +180,7 @@ func main() {
 
 	mustRegisterDiskMonitor(*index)
 
-	mmapLogger := sglog.Scoped("zoekt_webserver_prometheus_memory_map_metrics", "")
+	mmapLogger := sglog.Scoped("zoekt_webserver_proc_metrics_memory_map", "")
 	mustRegisterMemoryMapMetrics(mmapLogger)
 
 	// Do not block on loading shards so we can become partially available

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -527,7 +527,7 @@ func mustRegisterMemoryMapMetrics(logger sglog.Logger) {
 	}
 
 	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "zoekt_webserver_max_memory_map_count",
+		Name: "proc_metrics_memory_map_max_limit",
 		Help: "Upper limit on amount of memory mapped regions a process may have.",
 	}, func() float64 {
 		vm, err := fs.VM()
@@ -549,7 +549,7 @@ func mustRegisterMemoryMapMetrics(logger sglog.Logger) {
 	}))
 
 	prometheus.MustRegister(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "zoekt_webserver_current_memory_map_count",
+		Name: "proc_metrics_memory_map_current_count",
 		Help: "Amount of memory mapped regions this process is currently using.",
 	}, func() float64 {
 		self, err := fs.Self()

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -511,9 +511,9 @@ var (
 	})
 )
 
-func mustRegisterMemoryMapMetrics(l sglog.Logger) {
+func mustRegisterMemoryMapMetrics(logger sglog.Logger) {
 	if runtime.GOOS != "linux" {
-		l.Debug(
+		logger.Debug(
 			"skipping registration: must be running on a linux-based operating system",
 			sglog.String("current_operating_system", runtime.GOOS),
 			sglog.String("desired_operating_system", "linux"))
@@ -532,7 +532,7 @@ func mustRegisterMemoryMapMetrics(l sglog.Logger) {
 	}, func() float64 {
 		vm, err := fs.VM()
 		if err != nil {
-			l.Debug(
+			logger.Debug(
 				"failed to read VM statistics",
 				sglog.String("path", path.Join(procfs.DefaultMountPoint, "sys", "vm")),
 				sglog.String("error", err.Error()),
@@ -554,7 +554,7 @@ func mustRegisterMemoryMapMetrics(l sglog.Logger) {
 	}, func() float64 {
 		self, err := fs.Self()
 		if err != nil {
-			l.Debug(
+			logger.Debug(
 				"failed to read process statistics",
 				sglog.String("path", path.Join(procfs.DefaultMountPoint, "self")),
 				sglog.String("error", err.Error()),
@@ -565,7 +565,7 @@ func mustRegisterMemoryMapMetrics(l sglog.Logger) {
 
 		procMaps, err := self.ProcMaps()
 		if err != nil {
-			l.Debug(
+			logger.Debug(
 				"failed to read memory mappings",
 				sglog.String("path", path.Join(procfs.DefaultMountPoint, "self", "maps")),
 				sglog.String("error", err.Error()),

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/procfs v0.8.0
 	github.com/rs/xid v1.4.0
 	github.com/sourcegraph/go-ctags v0.0.0-20220611154803-db463692f037
 	github.com/sourcegraph/log v0.0.0-20220901143117-fc0516a694c9
@@ -42,7 +43,7 @@ require (
 	go.uber.org/automaxprocs v1.5.1
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
@@ -91,7 +92,6 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
-	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,9 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
+github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
@@ -786,8 +787,9 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/41849

As a response to the above issue, this PR adds two new Prometheus metrics:

- `proc_metrics_memory_map_max_limit`: A gauge that tracks the max number of memory maps a process is allowed to allocate. See https://docs.kernel.org/_sources/admin-guide/sysctl/vm.rst.txt for more information.

- `proc_metrics_memory_map_current_count`: A gauge that tracks the _current_ number of memory maps the `zoekt-webseve`r process is currently using. 


See the following screenshot for an example of what these metrics look like in Grafana.

<img width="1632" alt="Screen Shot 2022-09-26 at 9 43 04 AM" src="https://user-images.githubusercontent.com/9022011/192333954-b6136cfa-5e91-42ad-84d3-03e72e62dc5c.png">
