### PR TITLE
nit: remove uncessary comment from docker ci config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
-      # This is the same tag we used for zoekt in the infrastructure repo.
       - name: version
         id: version
         run: .github/workflows/docker-version.sh


### PR DESCRIPTION
this historical content for comment doesn't seem relevant / necessary any more 