### PR TITLE
api: deprecate .*ImportantMatch

### DIFF
--- a/api.go
+++ b/api.go
@@ -760,11 +760,10 @@ type SearchOptions struct {
 	// be set to 1 to find all repositories containing a result.
 	ShardRepoMaxMatchCount int
 
-	// Maximum number of important matches: skip processing
-	// shard after we found this many important matches.
+	// Deprecated: this field is not read anymore.
 	ShardMaxImportantMatch int
 
-	// Maximum number of important matches across shards.
+	// Deprecated: this field is not read anymore.
 	TotalMaxImportantMatch int
 
 	// Abort the search after this much time has passed.

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -442,8 +442,6 @@ func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchO
 			sglog.Bool("opts.Whole", opts.Whole),
 			sglog.Int("opts.ShardMaxMatchCount", opts.ShardMaxMatchCount),
 			sglog.Int("opts.TotalMaxMatchCount", opts.TotalMaxMatchCount),
-			sglog.Int("opts.ShardMaxImportantMatch", opts.ShardMaxImportantMatch),
-			sglog.Int("opts.TotalMaxImportantMatch", opts.TotalMaxImportantMatch),
 			sglog.Duration("opts.MaxWallTime", opts.MaxWallTime),
 			sglog.Int("opts.MaxDocDisplayCount", opts.MaxDocDisplayCount),
 		)

--- a/eval.go
+++ b/eval.go
@@ -133,12 +133,6 @@ func (o *SearchOptions) SetDefaults() {
 	if o.TotalMaxMatchCount == 0 {
 		o.TotalMaxMatchCount = 10 * o.ShardMaxMatchCount
 	}
-	if o.ShardMaxImportantMatch == 0 {
-		o.ShardMaxImportantMatch = 10
-	}
-	if o.TotalMaxImportantMatch == 0 {
-		o.TotalMaxImportantMatch = 10 * o.ShardMaxImportantMatch
-	}
 }
 
 func (d *indexData) Search(ctx context.Context, q query.Q, opts *SearchOptions) (sr *SearchResult, err error) {
@@ -260,8 +254,7 @@ nextFileMatch:
 			repoMatchCount = 0
 		}
 
-		if canceled || (res.Stats.MatchCount >= opts.ShardMaxMatchCount && opts.ShardMaxMatchCount > 0) ||
-			(opts.ShardMaxImportantMatch > 0 && importantMatchCount >= opts.ShardMaxImportantMatch) {
+		if canceled || (res.Stats.MatchCount >= opts.ShardMaxMatchCount && opts.ShardMaxMatchCount > 0) {
 			res.Stats.FilesSkipped += int(docCount - nextDoc)
 			break
 		}

--- a/index_test.go
+++ b/index_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/regexp"
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/sourcegraph/zoekt/query"
 )
 
@@ -1853,43 +1854,6 @@ func TestOr(t *testing.T) {
 
 		if len(sres.Files) != 2 {
 			t.Fatalf("got %v, want 2 files", sres.Files)
-		}
-	})
-}
-
-func TestImportantCutoff(t *testing.T) {
-	t.Skip()
-
-	content := []byte("func bla() blub")
-	// ----------------012345678901234
-	b := testIndexBuilder(t, nil,
-		Document{
-			Name:    "f1",
-			Content: content,
-			Symbols: []DocumentSection{{5, 8}},
-		}, Document{
-			Name:    "f2",
-			Content: content,
-		})
-
-	t.Run("LineMatches", func(t *testing.T) {
-		opts := SearchOptions{
-			ShardMaxImportantMatch: 1,
-		}
-		sres := searchForTest(t, b, &query.Substring{Pattern: "bla"}, opts)
-		if len(sres.Files) != 1 || sres.Files[0].FileName != "f1" {
-			t.Errorf("got %v, wanted 1 match 'f1'", sres.Files)
-		}
-	})
-
-	t.Run("ChunkMatches", func(t *testing.T) {
-		opts := SearchOptions{
-			ShardMaxImportantMatch: 1,
-			ChunkMatches:           true,
-		}
-		sres := searchForTest(t, b, &query.Substring{Pattern: "bla"}, opts)
-		if len(sres.Files) != 1 || sres.Files[0].FileName != "f1" {
-			t.Errorf("got %v, wanted 1 match 'f1'", sres.Files)
 		}
 	})
 }

--- a/json/json.go
+++ b/json/json.go
@@ -127,8 +127,7 @@ func CalculateDefaultSearchLimits(ctx context.Context,
 		opts.ShardMaxMatchCount = maxResultDocs*5 + (5*maxResultDocs)/(numdocs/1000)
 
 	} else {
-		// Virtually no limits for a small corpus; important
-		// matches are just as expensive as normal matches.
+		// Virtually no limits for a small corpus.
 		n := numdocs + maxResultDocs*100
 		opts.ShardMaxMatchCount = n
 		opts.TotalMaxMatchCount = n

--- a/json/json.go
+++ b/json/json.go
@@ -107,7 +107,7 @@ func CalculateDefaultSearchLimits(ctx context.Context,
 	q query.Q,
 	searcher zoekt.Searcher,
 	opts *zoekt.SearchOptions) error {
-	if opts.MaxDocDisplayCount == 0 || opts.ShardMaxMatchCount != 0 || opts.ShardMaxImportantMatch != 0 {
+	if opts.MaxDocDisplayCount == 0 || opts.ShardMaxMatchCount != 0 {
 		return nil
 	}
 
@@ -126,16 +126,12 @@ func CalculateDefaultSearchLimits(ctx context.Context,
 		// 10k docs, 50 maxResultDocs -> max match = (250 + 250 / 10)
 		opts.ShardMaxMatchCount = maxResultDocs*5 + (5*maxResultDocs)/(numdocs/1000)
 
-		// 10k docs, 50 maxResultDocs -> max important match = 4
-		opts.ShardMaxImportantMatch = maxResultDocs/20 + maxResultDocs/(numdocs/500)
 	} else {
 		// Virtually no limits for a small corpus; important
 		// matches are just as expensive as normal matches.
 		n := numdocs + maxResultDocs*100
-		opts.ShardMaxImportantMatch = n
 		opts.ShardMaxMatchCount = n
 		opts.TotalMaxMatchCount = n
-		opts.TotalMaxImportantMatch = n
 	}
 
 	return nil


### PR DESCRIPTION
We deprecate TotalMaxImportantMatch and ShardMaxImportantMatch.

TotalMaxImportantMatch was never read, so deprecating it has no consequence.

Without ShardMaxImportantMatch, the limit per shard is determined by ShardMaxMatchCount only, which makes it easier to reason about the limits.