### PR TITLE
streaming search that aggregates and ranks for FlushWallTime

### DIFF
--- a/api.go
+++ b/api.go
@@ -86,7 +86,7 @@ type FileMatch struct {
 	Version string
 }
 
-func (m *FileMatch) SizeBytes() (sz uint64) {
+func (m *FileMatch) sizeBytes() (sz uint64) {
 	// Score
 	sz += 8
 
@@ -463,7 +463,7 @@ func (sr *SearchResult) SizeBytes() (sz uint64) {
 	// Files
 	sz += sliceHeaderBytes
 	for _, f := range sr.Files {
-		sz += f.SizeBytes()
+		sz += f.sizeBytes()
 	}
 
 	// RepoURLs

--- a/api.go
+++ b/api.go
@@ -86,7 +86,7 @@ type FileMatch struct {
 	Version string
 }
 
-func (m *FileMatch) sizeBytes() (sz uint64) {
+func (m *FileMatch) SizeBytes() (sz uint64) {
 	// Score
 	sz += 8
 
@@ -463,7 +463,7 @@ func (sr *SearchResult) SizeBytes() (sz uint64) {
 	// Files
 	sz += sliceHeaderBytes
 	for _, f := range sr.Files {
-		sz += f.sizeBytes()
+		sz += f.SizeBytes()
 	}
 
 	// RepoURLs

--- a/api.go
+++ b/api.go
@@ -782,6 +782,10 @@ type SearchOptions struct {
 	// be sent and then the behaviour will revert to the normal streaming.
 	FlushWallTime time.Duration
 
+	// MaxSizesBytes if non-zero limits the number of bytes Zoekt is allowed to hold
+	// in memory for file matches before flushing.
+	MaxSizeBytes int
+
 	// Trim the number of results after collating and sorting the
 	// results
 	MaxDocDisplayCount int
@@ -795,6 +799,10 @@ type SearchOptions struct {
 	// If true, ChunkMatches will be returned in each FileMatch rather than LineMatches
 	// EXPERIMENTAL: the behavior of this flag may be changed in future versions.
 	ChunkMatches bool
+
+	// EXPERIMENTAL. If true, document ranks are used as additional input for
+	// sorting matches.
+	UseDocumentRanks bool
 
 	// Trace turns on opentracing for this request if true and if the Jaeger address was provided as
 	// a command-line flag

--- a/api.go
+++ b/api.go
@@ -777,6 +777,11 @@ type SearchOptions struct {
 	// Abort the search after this much time has passed.
 	MaxWallTime time.Duration
 
+	// FlushWallTime if non-zero will stop streaming behaviour at first and
+	// instead will collate and sort results. At FlushWallTime the results will
+	// be sent and then the behaviour will revert to the normal streaming.
+	FlushWallTime time.Duration
+
 	// Trim the number of results after collating and sorting the
 	// results
 	MaxDocDisplayCount int

--- a/api.go
+++ b/api.go
@@ -782,10 +782,6 @@ type SearchOptions struct {
 	// be sent and then the behaviour will revert to the normal streaming.
 	FlushWallTime time.Duration
 
-	// MaxSizesBytes if non-zero limits the number of bytes Zoekt is allowed to hold
-	// in memory for file matches before flushing.
-	MaxSizeBytes int
-
 	// Trim the number of results after collating and sorting the
 	// results
 	MaxDocDisplayCount int

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -720,10 +720,10 @@ const k = 60
 //
 // Rankings derived from match scores and rank vectors are combined based on
 // "Reciprocal Rank Fusion" (RFF).
-func SortFiles(ms []FileMatch) {
+func SortFiles(ms []FileMatch, useDocumentRanks bool) {
 	sort.Sort(fileMatchesByScore(ms))
 
-	if hasRanks(ms) {
+	if useDocumentRanks && hasRanks(ms) {
 		rffScore := make([]float64, len(ms))
 
 		for i := 0; i < len(ms); i++ {

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -341,7 +341,7 @@ func TestSortFiles(t *testing.T) {
 	// d1        1/(60+2)   1/(60+1)   0,0325224748810153   2
 	// d4        1/(60+3)   1/(60+2)   0,0320020481310804   3
 
-	SortFiles(in)
+	SortFiles(in, true)
 
 	wantOrder := []string{"d3", "d2", "d1", "d4"}
 

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -160,7 +160,6 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, sender zoekt.Sender) (zoek
 			// happen for queries yielding an extreme number of results.
 			if opts.MaxSizeBytes > 0 && collectSender.sizeBytes > uint64(opts.MaxSizeBytes) {
 				stopCollectingAndFlush("max_size_reached")
-
 			}
 		} else {
 			sender.Send(event)

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -28,7 +28,6 @@ var (
 type collectSender struct {
 	aggregate          *zoekt.SearchResult
 	maxDocDisplayCount int
-	maxSizeBytes       int
 	useDocumentRanks   bool
 }
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -685,7 +685,7 @@ search:
 			r.Priority = r.priority
 			r.MaxPendingPriority = pending.max()
 
-			sendByRepository(r.SearchResult, sender)
+			sendByRepository(r.SearchResult, opts, sender)
 		}
 	}
 
@@ -698,16 +698,16 @@ search:
 //
 // We split by repository instead of by priority because it is easier to set
 // RepoURLs and LineFragments in zoekt.SearchResult.
-func sendByRepository(result *zoekt.SearchResult, sender zoekt.Sender) {
+func sendByRepository(result *zoekt.SearchResult, opts *zoekt.SearchOptions, sender zoekt.Sender) {
 
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
-		zoekt.SortFiles(result.Files)
+		zoekt.SortFiles(result.Files, opts.UseDocumentRanks)
 		sender.Send(result)
 		return
 	}
 
 	send := func(repoName string, a, b int, stats zoekt.Stats) {
-		zoekt.SortFiles(result.Files[a:b])
+		zoekt.SortFiles(result.Files[a:b], opts.UseDocumentRanks)
 		sender.Send(&zoekt.SearchResult{
 			Stats: stats,
 			Progress: zoekt.Progress{

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/regexp"
+
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/stream"
@@ -764,7 +765,7 @@ func TestSendByRepository(t *testing.T) {
 		sr := createMockSearchResult(n1, n2, n3, wantStats)
 
 		mock := &mockSender{}
-		sendByRepository(sr, mock)
+		sendByRepository(sr, &zoekt.SearchOptions{}, mock)
 
 		if diff := cmp.Diff(wantStats, mock.stats); diff != "" {
 			t.Logf("-want,+got\n%s", diff)


### PR DESCRIPTION
We introduce FlushWallTime which will adjust streaming searches behaviour to collect results for that duration of time before sending. This gives a chance for zoekt to do ranking, while still maintaining low latency for time to first result.

Additionally we also make it so that streaming search respects MaxDocDisplayCount.

Test Plan: go test
