### PR TITLE
docker: build with go 1.19.2 and alpine 3.16.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
           repository: 'sourcegraph/sourcegraph'
           ref: 'main'
       - uses: actions/setup-go@v2
-        with: { go-version: '1.18' }
+        with: { go-version: '1.19' }
       - run: go mod download
       - run: ./dev/zoekt/update
       - uses: peter-evans/create-pull-request@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1-alpine3.15 AS builder
+FROM golang:1.19.2-alpine3.16 AS builder
 
 RUN apk add --no-cache ca-certificates
 
@@ -13,7 +13,7 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd/...
 
-FROM alpine:3.15.4 AS zoekt
+FROM alpine:3.16.2 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git ca-certificates bind-tools tini jansson

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.16.2
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson && \

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.16.2
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
    apk add --no-cache ca-certificates bind-tools tini


### PR DESCRIPTION
More GC improvements as well as some security fixes. So interested to see the impact of this change.

Test Plan: Built locally and just tested if they start

```
docker build -t zoekt .
docker build -t zoekt-indexserver . -f Dockerfile.indexserver
docker build -t zoekt-webserver   . -f Dockerfile.webserver
docker run --rm=true zoekt-indexserver
docker run --rm=true zoekt-webserver
```