### PR TITLE
ranking: support offline ranking

### DIFF
--- a/api.go
+++ b/api.go
@@ -31,6 +31,10 @@ const sliceHeaderBytes uint64 = 24
 const stringHeaderBytes uint64 = 16
 const pointerSize uint64 = 8
 
+// DocumentScoresFile is the name of the file that contains a mapping of paths
+// to score vectors.
+const DocumentScoresFile = "documents.score"
+
 // FileMatch contains all the matches within a file.
 type FileMatch struct {
 	// Ranking; the higher, the better.

--- a/api.go
+++ b/api.go
@@ -31,10 +31,6 @@ const sliceHeaderBytes uint64 = 24
 const stringHeaderBytes uint64 = 16
 const pointerSize uint64 = 8
 
-// DocumentScoresFile is the name of the file that contains a mapping of paths
-// to score vectors.
-const DocumentScoresFile = "documents.score"
-
 // FileMatch contains all the matches within a file.
 type FileMatch struct {
 	// Ranking; the higher, the better.

--- a/build/builder.go
+++ b/build/builder.go
@@ -946,18 +946,15 @@ func sortDocuments(todo []*zoekt.Document) {
 	}
 }
 
-// sortDocuments2 sorts zoekt.Document according to their Scores. In general,
+// sortDocuments2 sorts []*zoekt.Document according to their Scores. In general,
 // documents can have a nil score vector if the document to be indexed was
 // introduced after the ranking took place. A nil score vector translates to the
-// lowest possible rank.
+// lowest possible rank. Longer vectors are more important than shorter vectors,
+// given all other scores are equal.
 func sortDocuments2(rs []*zoekt.Document) {
 	sort.Slice(rs, func(i, j int) bool {
 		r1 := rs[i].Scores
 		r2 := rs[j].Scores
-
-		if r1 == nil && r2 == nil {
-			return false
-		}
 
 		if r1 == nil {
 			return false

--- a/build/builder.go
+++ b/build/builder.go
@@ -965,8 +965,8 @@ func sortDocuments2(rs []*zoekt.Document) {
 				return r1[i] < r2[i]
 			}
 		}
-		// if r1 has more scores it is more important. ie imagine right padding arrays
-		// with zeros, so they are the same length.
+		// if r1 has more scores it is more important. ie imagine right padding shorter
+		// arrays with ones, so they are the same length.
 		return len(r1) > len(r2)
 	})
 }

--- a/build/builder.go
+++ b/build/builder.go
@@ -950,7 +950,7 @@ func sortDocuments(todo []*zoekt.Document) {
 // documents can have a nil rank vector if the document to be indexed was added
 // after the ranking took place. A nil rank vector translates to the lowest
 // possible rank. Longer vectors are more important than shorter vectors, given
-// all other scores are equal.
+// all other ranks are equal.
 //
 // Note: the logic here is inverted to sortDocuments, where smaller values are
 // better.
@@ -968,7 +968,7 @@ func sortDocuments2(rs []*zoekt.Document) {
 				return r1[i] > r2[i]
 			}
 		}
-		// if r1 has more scores it is more important. ie imagine right padding shorter
+		// if r1 has more entries it is more important. ie imagine right padding shorter
 		// arrays with zeros, so they are the same length.
 		return len(r1) > len(r2)
 	})

--- a/build/builder.go
+++ b/build/builder.go
@@ -947,10 +947,10 @@ func sortDocuments(todo []*zoekt.Document) {
 }
 
 // sortDocuments2 sorts []*zoekt.Document according to their Ranks. In general,
-// documents can have a nil rank vector if the document to be indexed was
-// introduced after the ranking took place. A nil rank vector translates to the
-// lowest possible rank. Longer vectors are more important than shorter vectors,
-// given all other scores are equal.
+// documents can have a nil rank vector if the document to be indexed was added
+// after the ranking took place. A nil rank vector translates to the lowest
+// possible rank. Longer vectors are more important than shorter vectors, given
+// all other scores are equal.
 //
 // Note: the logic here is inverted to sortDocuments, where smaller values are
 // better.

--- a/build/builder.go
+++ b/build/builder.go
@@ -967,15 +967,6 @@ func sortDocuments2(rs []*zoekt.Document) {
 			return true
 		}
 
-		for i := range r1 {
-			if r1[i] < r2[i] {
-				return true
-			}
-			if r1[i] > r2[i] {
-				return false
-			}
-		}
-
 		l := len(r1)
 		if len(r2) < l {
 			l = len(r2)
@@ -985,8 +976,9 @@ func sortDocuments2(rs []*zoekt.Document) {
 				return r1[i] < r2[i]
 			}
 		}
-		// if r2 has more scores it is more important. ie imagine right padding arrays with zeros so they are the same length.
-		return len(r1) < len(r2)
+		// if r1 has more scores it is more important. ie imagine right padding arrays
+		// with zeros, so they are the same length.
+		return len(r1) > len(r2)
 	})
 }
 

--- a/build/builder.go
+++ b/build/builder.go
@@ -956,14 +956,6 @@ func sortDocuments2(rs []*zoekt.Document) {
 		r1 := rs[i].Scores
 		r2 := rs[j].Scores
 
-		if r1 == nil {
-			return false
-		}
-
-		if r2 == nil {
-			return true
-		}
-
 		l := len(r1)
 		if len(r2) < l {
 			l = len(r2)

--- a/build/builder.go
+++ b/build/builder.go
@@ -975,7 +975,17 @@ func sortDocuments2(rs []*zoekt.Document) {
 			}
 		}
 
-		return false
+		l := len(r1)
+		if len(r2) < l {
+		  l = len(r2)
+		}
+		for i := 0; i < l; i++ {
+		  if r1[i] != r2[i] {
+		    return r1[i] < r2[i]
+		  }
+		}
+		// if r2 has more scores it is more important. ie imagine right padding arrays with zeros so they are the same length.
+		return len(r1) < len(r2)
 	})
 }
 

--- a/build/builder.go
+++ b/build/builder.go
@@ -100,8 +100,9 @@ type Options struct {
 	// last run.
 	IsDelta bool
 
-	// OfflineRanking is true if this run is to load ranking info from disk.
-	OfflineRanking bool
+	// DocumentScoresPath is the path to the file with document scores. If empty,
+	// scores will be computed on-the-fly.
+	DocumentScoresPath string
 
 	// changedOrRemovedFiles is a list of file paths that have been changed or removed
 	// since the last indexing job for this repository. These files will be tombstoned
@@ -977,12 +978,12 @@ func sortDocuments2(rs []*zoekt.Document) {
 
 		l := len(r1)
 		if len(r2) < l {
-		  l = len(r2)
+			l = len(r2)
 		}
 		for i := 0; i < l; i++ {
-		  if r1[i] != r2[i] {
-		    return r1[i] < r2[i]
-		  }
+			if r1[i] != r2[i] {
+				return r1[i] < r2[i]
+			}
 		}
 		// if r2 has more scores it is more important. ie imagine right padding arrays with zeros so they are the same length.
 		return len(r1) < len(r2)
@@ -1007,7 +1008,7 @@ func (b *Builder) buildShard(todo []*zoekt.Document, nextShardNum int) (*finishe
 		return nil, err
 	}
 
-	if b.opts.OfflineRanking {
+	if b.opts.DocumentScoresPath != "" {
 		sortDocuments2(todo)
 	} else {
 		sortDocuments(todo)

--- a/build/builder.go
+++ b/build/builder.go
@@ -946,14 +946,16 @@ func sortDocuments(todo []*zoekt.Document) {
 	}
 }
 
+const epsilon = 0.00000001
+
 // sortDocuments2 sorts []*zoekt.Document according to their Ranks. In general,
 // documents can have a nil rank vector if the document to be indexed was added
 // after the ranking took place. A nil rank vector translates to the lowest
 // possible rank. Longer vectors are more important than shorter vectors, given
 // all other ranks are equal.
 //
-// Note: the logic here is inverted to sortDocuments, where smaller values are
-// better.
+// Note: the logic here is inverted to sortDocuments because rank in
+// sortDocuments returns a vector of the form [1-rank, ...].
 func sortDocuments2(rs []*zoekt.Document) {
 	sort.Slice(rs, func(i, j int) bool {
 		r1 := rs[i].Ranks
@@ -964,7 +966,7 @@ func sortDocuments2(rs []*zoekt.Document) {
 			l = len(r2)
 		}
 		for i := 0; i < l; i++ {
-			if r1[i] != r2[i] {
+			if math.Abs(r1[i]-r2[i]) > epsilon {
 				return r1[i] > r2[i]
 			}
 		}

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -941,7 +941,7 @@ func Test_sortDocuments2(t *testing.T) {
 	}
 
 	t.Run("test for panics", func(t *testing.T) {
-		// Special case: test for panics if all documents have nil scores.
+		// Special case: test for panics if all documents have nil rank vectors.
 		sortDocuments2([]*zoekt.Document{{}, {}})
 		sortDocuments2([]*zoekt.Document{{}})
 		sortDocuments2(nil)

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -940,6 +940,11 @@ func Test_sortDocuments2(t *testing.T) {
 		})
 	}
 
-	// Special case: test for panic if all documents have nil scores.
-	sortDocuments2([]*zoekt.Document{{}, {}, {}})
+	t.Run("test for panics", func(t *testing.T) {
+		// Special case: test for panics if all documents have nil scores.
+		sortDocuments2([]*zoekt.Document{{}, {}, {}})
+		sortDocuments2([]*zoekt.Document{{}})
+		sortDocuments2(nil)
+	})
+
 }

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/sourcegraph/zoekt"
 )
 
@@ -843,4 +844,102 @@ func createTestCompoundShard(t *testing.T, indexDir string, repositories []zoekt
 	if err := os.Rename(tmpName, dstName); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func Test_sortDocuments2(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []*zoekt.Document
+		want []string
+	}{
+		{
+			name: "same length",
+			in: []*zoekt.Document{
+				{
+					Name:   "a",
+					Scores: []float64{1, 1, 1},
+				},
+				{
+					Name:   "b",
+					Scores: []float64{0, 0, 0},
+				},
+				{
+					Name:   "c",
+					Scores: []float64{0, 1, 0},
+				},
+			},
+			want: []string{"b", "c", "a"},
+		},
+		{
+			name: "1 nil",
+			in: []*zoekt.Document{
+				{
+					Name:   "a",
+					Scores: []float64{1, 1, 1},
+				},
+				{
+					Name: "b",
+				},
+				{
+					Name:   "c",
+					Scores: []float64{0, 1, 0},
+				},
+			},
+			want: []string{"c", "a", "b"},
+		},
+		{
+			name: "different lengths",
+			in: []*zoekt.Document{
+				{
+					Name:   "a",
+					Scores: []float64{0},
+				},
+				{
+					Name:   "b",
+					Scores: []float64{0, 0},
+				},
+				{
+					Name:   "c",
+					Scores: []float64{0, 0, 0},
+				},
+			},
+			want: []string{"c", "b", "a"},
+		},
+		{
+			name: "different lengths and nil",
+			in: []*zoekt.Document{
+				{
+					Name:   "a",
+					Scores: []float64{0},
+				},
+				{
+					Name:   "b",
+					Scores: []float64{0, 0},
+				},
+				{
+					Name: "c",
+				},
+			},
+			want: []string{"b", "a", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortDocuments2(tt.in)
+
+			for i, name := range tt.want {
+				if tt.in[i].Name != name {
+					var got []string
+					for _, d := range tt.in {
+						got = append(got, d.Name)
+					}
+					t.Fatalf("want %+v, got %+v\n", tt.want, got)
+				}
+			}
+		})
+	}
+
+	// Special case: test for panic if all documents have nil scores.
+	sortDocuments2([]*zoekt.Document{{}, {}, {}})
 }

--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -856,16 +856,16 @@ func Test_sortDocuments2(t *testing.T) {
 			name: "same length",
 			in: []*zoekt.Document{
 				{
-					Name:   "a",
-					Scores: []float64{1, 1, 1},
+					Name:  "a",
+					Ranks: []float64{0, 0, 0},
 				},
 				{
-					Name:   "b",
-					Scores: []float64{0, 0, 0},
+					Name:  "b",
+					Ranks: []float64{1, 1, 1},
 				},
 				{
-					Name:   "c",
-					Scores: []float64{0, 1, 0},
+					Name:  "c",
+					Ranks: []float64{1, 0, 1},
 				},
 			},
 			want: []string{"b", "c", "a"},
@@ -874,15 +874,15 @@ func Test_sortDocuments2(t *testing.T) {
 			name: "1 nil",
 			in: []*zoekt.Document{
 				{
-					Name:   "a",
-					Scores: []float64{1, 1, 1},
+					Name:  "a",
+					Ranks: []float64{1, 1, 0},
 				},
 				{
 					Name: "b",
 				},
 				{
-					Name:   "c",
-					Scores: []float64{0, 1, 0},
+					Name:  "c",
+					Ranks: []float64{1, 1, 1},
 				},
 			},
 			want: []string{"c", "a", "b"},
@@ -891,16 +891,16 @@ func Test_sortDocuments2(t *testing.T) {
 			name: "different lengths",
 			in: []*zoekt.Document{
 				{
-					Name:   "a",
-					Scores: []float64{0},
+					Name:  "a",
+					Ranks: []float64{0},
 				},
 				{
-					Name:   "b",
-					Scores: []float64{0, 0},
+					Name:  "b",
+					Ranks: []float64{0, 0},
 				},
 				{
-					Name:   "c",
-					Scores: []float64{0, 0, 0},
+					Name:  "c",
+					Ranks: []float64{0, 0, 0},
 				},
 			},
 			want: []string{"c", "b", "a"},
@@ -909,12 +909,12 @@ func Test_sortDocuments2(t *testing.T) {
 			name: "different lengths and nil",
 			in: []*zoekt.Document{
 				{
-					Name:   "a",
-					Scores: []float64{0},
+					Name:  "a",
+					Ranks: []float64{0},
 				},
 				{
-					Name:   "b",
-					Scores: []float64{0, 0},
+					Name:  "b",
+					Ranks: []float64{0, 0},
 				},
 				{
 					Name: "c",
@@ -942,7 +942,7 @@ func Test_sortDocuments2(t *testing.T) {
 
 	t.Run("test for panics", func(t *testing.T) {
 		// Special case: test for panics if all documents have nil scores.
-		sortDocuments2([]*zoekt.Document{{}, {}, {}})
+		sortDocuments2([]*zoekt.Document{{}, {}})
 		sortDocuments2([]*zoekt.Document{{}})
 		sortDocuments2(nil)
 	})

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -42,7 +42,7 @@ func run() int {
 		"It also affects name if the indexed repository is under this directory.")
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
-	offlineRanking := flag.Bool("offline_ranking", false, "whether we should load ranking info at index time from disk")
+	offlineRanking := flag.String("offline_ranking", "", "the name of the file that contains the ranking info.")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
@@ -69,7 +69,7 @@ func run() int {
 	}
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
-	opts.OfflineRanking = *offlineRanking
+	opts.DocumentScoresPath = *offlineRanking
 
 	var branches []string
 	if *branchesStr != "" {

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -22,9 +22,10 @@ import (
 	"runtime/pprof"
 	"strings"
 
+	"go.uber.org/automaxprocs/maxprocs"
+
 	"github.com/sourcegraph/zoekt/cmd"
 	"github.com/sourcegraph/zoekt/gitindex"
-	"go.uber.org/automaxprocs/maxprocs"
 )
 
 func run() int {
@@ -41,6 +42,7 @@ func run() int {
 		"It also affects name if the indexed repository is under this directory.")
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
+	offlineRanking := flag.Bool("offline_ranking", false, "whether we should load ranking info at index time from disk")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
@@ -67,6 +69,7 @@ func run() int {
 	}
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
+	opts.OfflineRanking = *offlineRanking
 
 	var branches []string
 	if *branchesStr != "" {

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -69,7 +69,7 @@ func run() int {
 	}
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
-	opts.DocumentScoresPath = *offlineRanking
+	opts.DocumentRanksPath = *offlineRanking
 
 	var branches []string
 	if *branchesStr != "" {

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -333,7 +333,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 
 		r, err := sourcegraph.GetDocumentRanks(context.Background(), o.Name)
 		if err != nil {
-			return err
+			return fmt.Errorf("GetDocumentRanks: %w", err)
 		}
 
 		b, err := json.Marshal(r)
@@ -341,15 +341,8 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 			return err
 		}
 
-		fd, err := os.Create(documentsRankFile)
-		if err != nil {
-			return err
-		}
-		defer fd.Close()
-
-		_, err = fd.Write(b)
-		if err != nil {
-			return err
+		if err := os.WriteFile(documentsRankFile, b, 0600); err != nil {
+			return fmt.Errorf("failed to write %s to disk: %w", documentsRankFile, err)
 		}
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha1"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -83,6 +84,8 @@ type indexArgs struct {
 	// only be true for repositories we explicitly enable.
 	UseDelta bool
 
+	UseOfflineRanking bool
+
 	// DeltaShardNumberFallbackThreshold is an upper limit on the number of preexisting shards that can exist
 	// before attempting a delta build.
 	DeltaShardNumberFallbackThreshold uint64
@@ -151,7 +154,7 @@ type gitIndexConfig struct {
 	findRepositoryMetadata func(args *indexArgs) (repository *zoekt.Repository, ok bool, err error)
 }
 
-func gitIndex(c gitIndexConfig, o *indexArgs, l sglog.Logger) error {
+func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.Logger) error {
 	logger := l.Scoped("gitIndex", "fetch commits and then run zoekt-git-index against contents")
 
 	if len(o.Branches) == 0 {
@@ -319,6 +322,34 @@ func gitIndex(c gitIndexConfig, o *indexArgs, l sglog.Logger) error {
 
 	args := []string{
 		"-submodules=false",
+	}
+
+	// We store the document ranks as JSON in gitDir and add a flag to tell
+	// zoekt-git-index to rank based on the scores in the file, instead of ranking
+	// the files by itself.
+	if o.UseOfflineRanking {
+		args = append(args, "-offline_ranking")
+
+		r, err := sourcegraph.GetDocumentRanks(context.Background(), o.Name)
+		if err != nil {
+			return err
+		}
+
+		b, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+
+		fd, err := os.Create(filepath.Join(gitDir, zoekt.DocumentScoresFile))
+		if err != nil {
+			return err
+		}
+		defer fd.Close()
+
+		_, err = fd.Write(b)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Even though we check for incremental in this process, we still pass it

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -324,11 +324,12 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 		"-submodules=false",
 	}
 
-	// We store the document ranks as JSON in gitDir and add a flag to tell
-	// zoekt-git-index to rank based on the scores in the file, instead of ranking
-	// the files by itself.
+	// We store the document ranks as JSON in gitDir and tell zoekt-git-index where
+	// to find the file.
 	if o.UseOfflineRanking {
-		args = append(args, "-offline_ranking")
+		p := filepath.Join(gitDir, "documents.score")
+
+		args = append(args, "-offline_ranking", p)
 
 		r, err := sourcegraph.GetDocumentRanks(context.Background(), o.Name)
 		if err != nil {
@@ -340,7 +341,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 			return err
 		}
 
-		fd, err := os.Create(filepath.Join(gitDir, zoekt.DocumentScoresFile))
+		fd, err := os.Create(p)
 		if err != nil {
 			return err
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -327,9 +327,9 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 	// We store the document ranks as JSON in gitDir and tell zoekt-git-index where
 	// to find the file.
 	if o.UseOfflineRanking {
-		p := filepath.Join(gitDir, "documents.score")
+		documentsRankFile := filepath.Join(gitDir, "documents.rank")
 
-		args = append(args, "-offline_ranking", p)
+		args = append(args, "-offline_ranking", documentsRankFile)
 
 		r, err := sourcegraph.GetDocumentRanks(context.Background(), o.Name)
 		if err != nil {
@@ -341,7 +341,7 @@ func gitIndex(c gitIndexConfig, o *indexArgs, sourcegraph Sourcegraph, l sglog.L
 			return err
 		}
 
-		fd, err := os.Create(p)
+		fd, err := os.Create(documentsRankFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/sourcegraph/log/logtest"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,6 +11,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/sourcegraph/log/logtest"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -271,7 +272,7 @@ func TestIndex(t *testing.T) {
 				findRepositoryMetadata: findRepositoryMetadata,
 			}
 
-			if err := gitIndex(c, &tc.args, logtest.Scoped(t)); err != nil {
+			if err := gitIndex(c, &tc.args, sourcegraphNop{}, logtest.Scoped(t)); err != nil {
 				t.Fatal(err)
 			}
 			if !cmp.Equal(got, tc.want) {

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -68,6 +69,16 @@ type Sourcegraph interface {
 	// is the forced version of IterateIndexOptions, so will always calculate
 	// options for each id in repos.
 	ForceIterateIndexOptions(onSuccess func(IndexOptions), onError func(uint32, error), repos ...uint32)
+
+	// GetRepoRank returns a score vector for the given repository. Repositories are
+	// assumed to be ordered by each pairwise component of the resulting vector,
+	// lower scores coming earlier.
+	GetRepoRank(ctx context.Context, repoName string) ([]float64, error)
+
+	// GetDocumentRanks returns a map from paths within the given repo to their
+	// score vectors. Paths are assumed to be ordered by each pairwise component of
+	// the resulting vector, lower scores coming earlier
+	GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error)
 }
 
 func newSourcegraphClient(rootURL *url.URL, hostname string, batchSize int) *sourcegraphClient {
@@ -127,6 +138,94 @@ type sourcegraphClient struct {
 	// configFingerprint logic is faulty. When it is cleared out, we fallback to
 	// calculating everything.
 	configFingerprintReset time.Time
+}
+
+// GetRepoRank asks Sourcegraph for the score vector of repoName.
+func (s *sourcegraphClient) GetRepoRank(ctx context.Context, repoName string) ([]float64, error) {
+	u := s.Root.ResolveReference(&url.URL{
+		Path: "/.internal/ranks/" + strings.Trim(repoName, "/"),
+	})
+
+	b, err := s.get(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+
+	var ranks []float64
+	err = json.Unmarshal(b, &ranks)
+	if err != nil {
+		return nil, err
+	}
+
+	return ranks, nil
+}
+
+// GetDocumentRanks asks Sourcegraph for a mapping of file paths to score
+// vectors.
+func (s *sourcegraphClient) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
+	u := s.Root.ResolveReference(&url.URL{
+		Path: "/.internal/ranks/" + strings.Trim(repoName, "/") + "/documents",
+	})
+
+	b, err := s.get(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+
+	ranks := make(map[string][]float64)
+	err = json.Unmarshal(b, &ranks)
+	if err != nil {
+		return nil, err
+	}
+
+	// Invariant: All score vectors have the same length.
+	first := true
+	wantLen := -1
+	for _, v := range ranks {
+		if first {
+			first = false
+			wantLen = len(v)
+			continue
+		}
+		if len(v) != wantLen {
+			return nil, fmt.Errorf("found a document with a different length of scores %d<>%d\n", wantLen, len(v))
+		}
+	}
+
+	return ranks, nil
+}
+
+func (s *sourcegraphClient) get(ctx context.Context, u *url.URL) ([]byte, error) {
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		return nil, &url.Error{
+			Op:  "Get",
+			URL: u.String(),
+			Err: fmt.Errorf("%s: %s", resp.Status, string(b)),
+		}
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
 func (s *sourcegraphClient) List(ctx context.Context, indexed []uint32) (*SourcegraphListResult, error) {
@@ -360,6 +459,61 @@ func (s *sourcegraphClient) doRequest(req *retryablehttp.Request) (*http.Respons
 type sourcegraphFake struct {
 	RootDir string
 	Log     *log.Logger
+}
+
+// GetRepoRank expects a file with exactly 1 line containing a comma separated
+// list of float64 as ranks.
+func (sf sourcegraphFake) GetRepoRank(ctx context.Context, repoName string) ([]float64, error) {
+	dir := filepath.Join(sf.RootDir, filepath.FromSlash(repoName))
+
+	b, err := os.ReadFile(filepath.Join(dir, "SG_REPO_RANKS"))
+	if err != nil {
+		return nil, err
+	}
+
+	return floats64(string(b)), nil
+}
+
+// GetDocumentRanks expects a file where each line has the following format:
+// path<tab>f... . where f=1-rank is a float64 score in the interval [0,1].
+// Multiple f are separated by a comma. Each line has to have the same number of
+// ranks.
+func (sf sourcegraphFake) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
+	dir := filepath.Join(sf.RootDir, filepath.FromSlash(repoName))
+
+	fd, err := os.Open(filepath.Join(dir, "SG_DOCUMENT_RANKS"))
+	if err != nil {
+		return nil, err
+	}
+
+	ranks := make(map[string][]float64)
+
+	scanner := bufio.NewScanner(fd)
+	for scanner.Scan() {
+		s := scanner.Text()
+		pathRanks := strings.Split(s, "\t")
+		ranks[pathRanks[0]] = floats64(pathRanks[1])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return ranks, nil
+}
+
+func floats64(s string) []float64 {
+	parts := strings.Split(s, ",")
+
+	var r []float64
+	for _, rank := range parts {
+		f, err := strconv.ParseFloat(rank, 64)
+		if err != nil {
+			return nil
+		}
+		r = append(r, f)
+	}
+
+	return r
 }
 
 func (sf sourcegraphFake) List(ctx context.Context, indexed []uint32) (*SourcegraphListResult, error) {

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -725,3 +725,21 @@ func fakeID(name string) uint32 {
 	// magic at the end is to ensure we get a positive number when casting.
 	return uint32(crc32.ChecksumIEEE([]byte(name))%(1<<31-1) + 1)
 }
+
+type sourcegraphNop struct{}
+
+func (s sourcegraphNop) List(ctx context.Context, indexed []uint32) (*SourcegraphListResult, error) {
+	return nil, nil
+}
+
+func (s sourcegraphNop) ForceIterateIndexOptions(onSuccess func(IndexOptions), onError func(uint32, error), repos ...uint32) {
+	return
+}
+
+func (s sourcegraphNop) GetRepoRank(ctx context.Context, repoName string) ([]float64, error) {
+	return nil, nil
+}
+
+func (s sourcegraphNop) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
+	return nil, nil
+}

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -72,7 +72,7 @@ type Sourcegraph interface {
 
 	// GetRepoRank returns a rank vector for the given repository. Repositories are
 	// assumed to be ordered by each pairwise component of the resulting vector,
-	// higher scores coming earlier.
+	// higher ranks coming earlier.
 	GetRepoRank(ctx context.Context, repoName string) ([]float64, error)
 
 	// GetDocumentRanks returns a map from paths within the given repo to their

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -188,7 +188,7 @@ func (s *sourcegraphClient) GetDocumentRanks(ctx context.Context, repoName strin
 			continue
 		}
 		if len(v) != wantLen {
-			return nil, fmt.Errorf("found a document with a different length of scores %d<>%d\n", wantLen, len(v))
+			return nil, fmt.Errorf("found rank vectors of different length %d<>%d\n", wantLen, len(v))
 		}
 	}
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -486,8 +486,8 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 	}
 
 	var scores map[string][]float64
-	if opts.BuildOptions.DocumentScoresPath != "" {
-		data, err := os.ReadFile(opts.BuildOptions.DocumentScoresPath)
+	if opts.BuildOptions.DocumentRanksPath != "" {
+		data, err := os.ReadFile(opts.BuildOptions.DocumentRanksPath)
 		if err != nil {
 			return err
 		}
@@ -558,7 +558,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 				Name:              keyFullPath,
 				Content:           contents,
 				Branches:          brs,
-				Scores:            score(keyFullPath),
+				Ranks:             score(keyFullPath),
 			}); err != nil {
 				return fmt.Errorf("error adding document with name %s: %w", keyFullPath, err)
 			}

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -486,8 +486,13 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 	}
 
 	var scores map[string][]float64
-	if opts.BuildOptions.OfflineRanking {
-		scores, err = loadDocumentScores(opts.RepoDir)
+	if opts.BuildOptions.DocumentScoresPath != "" {
+		data, err := os.ReadFile(opts.BuildOptions.DocumentScoresPath)
+		if err != nil {
+			return err
+		}
+
+		err = json.Unmarshal(data, &scores)
 		if err != nil {
 			return err
 		}
@@ -869,19 +874,4 @@ func uniq(ss []string) []string {
 		last = s
 	}
 	return result
-}
-
-func loadDocumentScores(repoDir string) (map[string][]float64, error) {
-	data, err := os.ReadFile(filepath.Join(repoDir, zoekt.DocumentScoresFile))
-	if err != nil {
-		return nil, fmt.Errorf("LoadDocumentScores: %w", err)
-	}
-
-	scores := make(map[string][]float64)
-	err = json.Unmarshal(data, &scores)
-	if err != nil {
-		return nil, err
-	}
-
-	return scores, nil
 }

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -530,10 +530,12 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 				return err
 			}
 
-			if blob.Size > int64(opts.BuildOptions.SizeMax) && !opts.BuildOptions.IgnoreSizeMax(key.FullPath()) {
+			keyFullPath := key.FullPath()
+
+			if blob.Size > int64(opts.BuildOptions.SizeMax) && !opts.BuildOptions.IgnoreSizeMax(keyFullPath) {
 				if err := builder.Add(zoekt.Document{
 					SkipReason:        fmt.Sprintf("file size %d exceeds maximum size %d", blob.Size, opts.BuildOptions.SizeMax),
-					Name:              key.FullPath(),
+					Name:              keyFullPath,
 					Branches:          brs,
 					SubRepositoryPath: key.SubRepoPath,
 				}); err != nil {
@@ -548,10 +550,10 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 			}
 			if err := builder.Add(zoekt.Document{
 				SubRepositoryPath: key.SubRepoPath,
-				Name:              key.FullPath(),
+				Name:              keyFullPath,
 				Content:           contents,
 				Branches:          brs,
-				Scores:            score(key.FullPath()),
+				Scores:            score(keyFullPath),
 			}); err != nil {
 				return fmt.Errorf("error adding document with name %s: %w", key.FullPath(), err)
 			}

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -114,7 +114,7 @@ func setTemplates(repo *zoekt.Repository, u *url.URL, typ string) error {
 	repo.URL = u.String()
 	switch typ {
 	case "gitiles":
-		// / eg. https://gerrit.googlesource.com/gitiles/+/master/tools/run_dev.sh#20
+		// eg. https://gerrit.googlesource.com/gitiles/+/master/tools/run_dev.sh#20
 		repo.CommitURLTemplate = u.String() + "/+/{{.Version}}"
 		repo.FileURLTemplate = u.String() + "/+/{{.Version}}/{{.Path}}"
 		repo.LineFragmentTemplate = "#{{.LineNumber}}"

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -485,21 +485,21 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 		return fmt.Errorf("build.NewBuilder: %w", err)
 	}
 
-	var scores map[string][]float64
+	var ranks map[string][]float64
 	if opts.BuildOptions.DocumentRanksPath != "" {
 		data, err := os.ReadFile(opts.BuildOptions.DocumentRanksPath)
 		if err != nil {
 			return err
 		}
 
-		err = json.Unmarshal(data, &scores)
+		err = json.Unmarshal(data, &ranks)
 		if err != nil {
 			return err
 		}
 	}
 
-	score := func(path string) []float64 {
-		s, ok := scores[path]
+	rankVecForPath := func(path string) []float64 {
+		s, ok := ranks[path]
 		if !ok {
 			return nil
 		}
@@ -558,7 +558,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 				Name:              keyFullPath,
 				Content:           contents,
 				Branches:          brs,
-				Ranks:             score(keyFullPath),
+				Ranks:             rankVecForPath(keyFullPath),
 			}); err != nil {
 				return fmt.Errorf("error adding document with name %s: %w", keyFullPath, err)
 			}

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -114,7 +114,7 @@ func setTemplates(repo *zoekt.Repository, u *url.URL, typ string) error {
 	repo.URL = u.String()
 	switch typ {
 	case "gitiles":
-		/// eg. https://gerrit.googlesource.com/gitiles/+/master/tools/run_dev.sh#20
+		// / eg. https://gerrit.googlesource.com/gitiles/+/master/tools/run_dev.sh#20
 		repo.CommitURLTemplate = u.String() + "/+/{{.Version}}"
 		repo.FileURLTemplate = u.String() + "/+/{{.Version}}/{{.Path}}"
 		repo.LineFragmentTemplate = "#{{.LineNumber}}"
@@ -560,7 +560,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 				Branches:          brs,
 				Scores:            score(keyFullPath),
 			}); err != nil {
-				return fmt.Errorf("error adding document with name %s: %w", key.FullPath(), err)
+				return fmt.Errorf("error adding document with name %s: %w", keyFullPath, err)
 			}
 		}
 	}

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -286,6 +286,11 @@ type Document struct {
 	// Document sections for symbols. Offsets should use bytes.
 	Symbols         []DocumentSection
 	SymbolsMetaData []*Symbol
+
+	// Scores stores the score vector of a document as provided by a
+	// DocumentScoresFile file in the git repo. This field is experimental and may
+	// change at any time without warning.
+	Scores []float64
 }
 
 type symbolSlice struct {

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -287,14 +287,14 @@ type Document struct {
 	Symbols         []DocumentSection
 	SymbolsMetaData []*Symbol
 
-	// Scores is the score vector of a document as provided by a DocumentScoresFile
+	// Ranks is a vector of ranks for a document as provided by a DocumentRanksFile
 	// file in the git repo.
 	//
-	// Two documents can be ordered by comparing the components of their score
-	// vector. Smaller entries are better, as are longer vectors.
+	// Two documents can be ordered by comparing the components of their rank
+	// vectors. Bigger entries are better, as are longer vectors.
 	//
 	// This field is experimental and may change at any time without warning.
-	Scores []float64
+	Ranks []float64
 }
 
 type symbolSlice struct {

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -287,9 +287,13 @@ type Document struct {
 	Symbols         []DocumentSection
 	SymbolsMetaData []*Symbol
 
-	// Scores stores the score vector of a document as provided by a
-	// DocumentScoresFile file in the git repo. This field is experimental and may
-	// change at any time without warning.
+	// Scores is the score vector of a document as provided by a DocumentScoresFile
+	// file in the git repo.
+	//
+	// Two documents can be ordered by comparing the components of their score
+	// vector. Smaller entries are better, as are longer vectors.
+	//
+	// This field is experimental and may change at any time without warning.
 	Scores []float64
 }
 


### PR DESCRIPTION
Most of the new code is behind a feature flag.

To test, set `OFFLINE_RANKING_REPOS_ALLOW_LIST=<comma-separated list of repos>` for zoekt-sourcegraph-indexserver.

Design:
  - indexserver pops a repo from the index queue
  - if the repo is on the allow list, indexserver downloads the document scores and stores them as JSON in the gitDir of the repo to be indexed
  - The flag `-offline-ranking` tells `zoekt-git-index` to read the new file and sort the documents accordingly.

Becauses `sourcegraphFake` implements the new methods I added to the interface `Sourcegraph`, everything can be tested by just running Zoekt.

Missing:
I haven't incorporated repo rank yet.