### PR TITLE
mountinfo: introduce namespace config option

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1073,7 +1073,7 @@ func startServer(conf rootConfig) error {
 	go oc.Run()
 
 	logger := sglog.Scoped("metricsRegistration", "")
-	mountinfo.MustRegisterNewMountPointInfoMetric(logger, map[string]string{"indexDir": conf.index})
+	mountinfo.MustRegisterNewMountPointInfoMetric(logger, mountinfo.MountPointInfoOpts{Namespace: "zoekt_indexserver"}, map[string]string{"indexDir": conf.index})
 
 	s.Run()
 	return nil

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -184,7 +184,7 @@ func main() {
 	metricsLogger := sglog.Scoped("metricsRegistration", "")
 
 	mustRegisterMemoryMapMetrics(metricsLogger)
-	mountinfo.MustRegisterNewMountPointInfoMetric(metricsLogger, map[string]string{"indexDir": *index})
+	mountinfo.MustRegisterNewMountPointInfoMetric(metricsLogger, mountinfo.MountPointInfoOpts{Namespace: "zoekt_webserver"}, map[string]string{"indexDir": *index})
 
 	// Do not block on loading shards so we can become partially available
 	// sooner. Otherwise on large instances zoekt can be unavailable on the

--- a/internal/mountinfo/mountinfo.go
+++ b/internal/mountinfo/mountinfo.go
@@ -17,6 +17,14 @@ import (
 // defaultSysMountPoint is the common mount point for the sysfs pseudo-filesystem.
 const defaultSysMountPoint = "/sys"
 
+// MountPointInfoOpts modifies the behavior of the metric created
+// by MustRegisterNewMountPointInfoMetric.
+type MountPointInfoOpts struct {
+	// If non-empty, Namespace prefixes the "mount_point_info" metric by the provided string and
+	// an underscore ("_").
+	Namespace string
+}
+
 // MustRegisterNewMountPointInfoMetric registers a Prometheus metric named "mount_point_info" that
 // contains the names of the block storage devices that back each of the requested mounts.
 //
@@ -28,12 +36,13 @@ const defaultSysMountPoint = "/sys"
 //
 // This metric only works on Linux-based operating systems that have access to the sysfs pseudo-filesystem.
 // On all other operating systems, this metric will not emit any values.
-func MustRegisterNewMountPointInfoMetric(logger sglog.Logger, mounts map[string]string) {
+func MustRegisterNewMountPointInfoMetric(logger sglog.Logger, opts MountPointInfoOpts, mounts map[string]string) {
 	logger = logger.Scoped("mountPointInfo", "registration logic for mount_point_info Prometheus metric")
 
 	metric := promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mount_point_info",
-		Help: "An info metric with a constant '1' value that contains mount_name, device mappings",
+		Namespace: opts.Namespace,
+		Name:      "mount_point_info",
+		Help:      "An info metric with a constant '1' value that contains mount_name, device mappings",
 	}, []string{"mount_name", "device"})
 
 	// This device discovery logic relies on the sysfs pseudo-filesystem, which only exists

--- a/internal/mountinfo/mountinfo.go
+++ b/internal/mountinfo/mountinfo.go
@@ -61,7 +61,7 @@ func MustRegisterNewMountPointInfoMetric(logger sglog.Logger, opts MountPointInf
 			sglog.String("mountFilePath", filePath),
 		)
 
-		device, err := discoverDeviceName(discoveryLogger, discoverDeviceNameConfig{}, filePath)
+		device, err := discoverDeviceName(discoveryLogger, discoverDeviceNameOpts{}, filePath)
 		if err != nil {
 			discoveryLogger.Warn("skipping metric registration",
 				sglog.String("reason", "failed to discover device name"),
@@ -79,7 +79,7 @@ func MustRegisterNewMountPointInfoMetric(logger sglog.Logger, opts MountPointInf
 	}
 }
 
-type discoverDeviceNameConfig struct {
+type discoverDeviceNameOpts struct {
 	// sysfsMountPoint is the location of the sysfs mount point.
 	// If empty, defaultSysMountPoint will be used instead.
 	sysfsMountPoint string
@@ -92,7 +92,7 @@ type discoverDeviceNameConfig struct {
 
 // discoverDeviceName returns the name of the block device that filePath is
 // stored on.
-func discoverDeviceName(logger sglog.Logger, config discoverDeviceNameConfig, filePath string) (string, error) {
+func discoverDeviceName(logger sglog.Logger, opts discoverDeviceNameOpts, filePath string) (string, error) {
 	// Note: It's quite involved to implement the device discovery logic for
 	// every possible kind of storage device (e.x. logical volumes, NFS, etc.) See
 	// https://unix.stackexchange.com/a/11312 for more information.
@@ -114,13 +114,13 @@ func discoverDeviceName(logger sglog.Logger, config discoverDeviceNameConfig, fi
 	// - https://www.kernel.org/doc/ols/2005/ols2005v1-pages-321-334.pdf
 
 	getDeviceNumber := getDeviceNumber
-	if config.getDeviceNumber != nil {
-		getDeviceNumber = config.getDeviceNumber
+	if opts.getDeviceNumber != nil {
+		getDeviceNumber = opts.getDeviceNumber
 	}
 
 	sysfsMountPoint := defaultSysMountPoint
-	if config.sysfsMountPoint != "" {
-		sysfsMountPoint = config.sysfsMountPoint
+	if opts.sysfsMountPoint != "" {
+		sysfsMountPoint = opts.sysfsMountPoint
 	}
 
 	sysfsMountPoint = filepath.Clean(sysfsMountPoint)

--- a/internal/mountinfo/mountinfo_linux_test.go
+++ b/internal/mountinfo/mountinfo_linux_test.go
@@ -20,7 +20,7 @@ func Test_DeviceName_SmokeTest(t *testing.T) {
 		log.Fatalf("getting current working directory: %s", err)
 	}
 
-	device, err := discoverDeviceName(logger, discoverDeviceNameConfig{}, filePath)
+	device, err := discoverDeviceName(logger, discoverDeviceNameOpts{}, filePath)
 	if err != nil {
 		t.Fatalf("discovering device name for file path %q: %s", filePath, err)
 	}

--- a/internal/mountinfo/mountinfo_test.go
+++ b/internal/mountinfo/mountinfo_test.go
@@ -114,7 +114,7 @@ func Test_DeviceName_Snapshots(t *testing.T) {
 			// execute the test with our injected mocks
 			actualDeviceName, err := discoverDeviceName(
 				logger,
-				discoverDeviceNameConfig{
+				discoverDeviceNameOpts{
 					sysfsMountPoint: mockSysFSDir,
 					getDeviceNumber: mockGetDeviceNumber,
 				},


### PR DESCRIPTION
This PR introduces a `namespace` option that allows us to prefix the mount_point_info metric with another string. This allows us to more easily write promQL queries that target particular instances (such as only zoekt-indexserver's mount_point_info).
 
Namespaces are a general Prometheus pattern that is [called out in their documentation](https://prometheus.io/docs/practices/naming/) and is used [in their client-go library](https://github.com/prometheus/client_golang/blob/dcea97eee2b3257f34fd3203cb922eedeabb42a6/prometheus/collectors/process_collector.go#L26-L28). 