### PR TITLE
Send index status to Sourcegraph once repo is indexed

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -594,11 +594,13 @@ func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 		return indexStateFail, err
 	}
 
-	var branches []string
-	for _, b := range args.Branches {
-		branches = append(branches, fmt.Sprintf("%s=%s", b.Name, b.Version))
-	}
-	if err := s.Sourcegraph.UpdateIndexStatus(args.RepoID, args.Branches); err != nil {
+	status := []indexStatus{{RepoID: args.RepoID, Branches: args.Branches}}
+	if err := s.Sourcegraph.UpdateIndexStatus(status); err != nil {
+		branches := make([]string, len(args.Branches))
+		for i, b := range args.Branches {
+			branches[i] = fmt.Sprintf("%s=%s", b.Name, b.Version)
+		}
+
 		s.logger.Error("failed to update index status",
 			sglog.String("repo", args.Name),
 			sglog.Uint32("id", args.RepoID),


### PR DESCRIPTION
This is the client-side part of https://github.com/sourcegraph/sourcegraph/pull/43289.

It adds a method to the `Sourcegraph` client that sends the indexing status of a repository to the SG instance once it's indexed.

I tried to copy as many conventions as I could find: how to send a HTTP request, how to log the status.

What I'm unclear about:

1. Is this the best place to add this? (I'm okay with multiple requests being sent over time for the same repository and I added it where I did because I think that's closest to where the actual indexing happens)
2. What's the best rollout strategy here? The server-side endpoint has been added and that's merged, but it's not released yet. Do we need to wait with merging this until the endpoint has been added in a release?