### PR TITLE
ci: enable file protocol for git in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
         run: apk add go git
       - name: install ctags
         run: ./install-ctags-alpine.sh
+      # Needed for submodule tests in gitindex
+      - name: git protocol.file.allow
+        run: git config --global --replace-all protocol.file.allow always
       - name: test
         run: go test ./...
 

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -61,7 +61,6 @@ git config user.name "Your Name"
 git commit -am bmsg
 
 cd ../adir
-git config protocol.file.allow always
 git submodule add --name bname -- ../bdir bname
 git commit -am bmodmsg
 cat .gitmodules

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -61,6 +61,7 @@ git config user.name "Your Name"
 git commit -am bmsg
 
 cd ../adir
+git config protocol.file.allow always
 git submodule add --name bname -- ../bdir bname
 git commit -am bmodmsg
 cat .gitmodules


### PR DESCRIPTION
GitHub seems to have changed the default in the actions. This will allow it again so tests can hopefully pass.

Test Plan: CI