### PR TITLE
Add URL Template for Gitea

### DIFF
--- a/doc/indexing.md
+++ b/doc/indexing.md
@@ -9,7 +9,36 @@ Parameters are in the `zoekt` section of the git-config.
 `https://github.com/hanwen/usb`
 
 * `web-url-type`: type of URL, eg. github. Supported are cgit,
-  gitiles, gitweb and cgit.
+  gitiles, gitweb, cgit and gitea.
 
 * `github-stars`, `github-forks`, `github-watchers`,
   `github-subscribers`: counters for github interactions
+
+## Examples
+
+### gitea
+
+Clone a remote repository and add the indexer configuration.
+
+```sh
+git clone --bare https://codeberg.org/Codeberg/gitea
+cd gitea.git
+git config zoekt.web-url-type gitea
+git config zoekt.web-url https://codeberg.org/Codeberg/gitea
+git config zoekt.name codeberg.org/Codeberg/gitea
+```
+
+The tail of the git *config* should then contain:
+
+```ini
+[zoekt]
+	web-url-type = gitea
+	web-url = https://codeberg.org/Codeberg/gitea
+	name = codeberg.org/Codeberg/gitea
+```
+
+The *gitea.git* repository can then be indexed with `zoekt-git-index`
+
+```sh
+zoekt-git-index  --branches main  -index /data/index -repo_cache /data/repos gitea.git
+```

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -151,6 +151,15 @@ func setTemplates(repo *zoekt.Repository, u *url.URL, typ string) error {
 		repo.CommitURLTemplate = u.String() + "/-/commit/{{.Version}}"
 		repo.FileURLTemplate = u.String() + "/-/blob/{{.Version}}/{{.Path}}"
 		repo.LineFragmentTemplate = "#L{{.LineNumber}}"
+	case "gitea":
+		repo.CommitURLTemplate = u.String() + "/commit/{{.Version}}"
+		// NOTE The `display=source` query parameter is required to disable file rendering.
+		// Since line numbers are disabled in rendered files, you wouldn't be able to jump to
+		// a line without `display=source`. This is supported since gitea 1.17.0.
+		// When /src/{{.Version}} is used it will redirect to /src/commit/{{.Version}},
+		// but the query  parameters are obmitted.
+		repo.FileURLTemplate = u.String() + "/src/commit/{{.Version}}/{{.Path}}?display=source"
+		repo.LineFragmentTemplate = "#L{{.LineNumber}}"
 	default:
 		return fmt.Errorf("URL scheme type %q unknown", typ)
 	}


### PR DESCRIPTION
This adds a URL template for gitea >= 1.17.0.

The `display=source` query parameter was introduced in gitea 1.17.0 and is required to disable file rendering.
Line numbers are disabled in rendered files, so you wouldn't be able to jump to a line without `display=source`.

The **web-url-type = gitea** config option must be set in the bare repositories indexed with `zoekt-git-index` e.g.:

*owner/repo.git/config*

```ini
[zoekt]
        web-url-type = gitea
        web-url = https://gitea.local/owner/repo
        name = owner/repo
```

**NOTE** Already indexed repos must be deleted before reindexing in order to pick up the indexer changes.