### PR TITLE
shards: use repo priority in match scores

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -971,6 +971,14 @@ func mkRankedShard(s zoekt.Searcher) *rankedShard {
 			if priority > maxPriority {
 				maxPriority = priority
 			}
+
+			// No one is reading s yet, so we can mutate it.
+			// zoekt-sourcegraph-indexserver does not set Rank so at this point we
+			// treat Priority like star count and set it.
+			if repo.Rank == 0 && priority > 0 {
+				l := math.Log(float64(priority))
+				repo.Rank = uint16((1.0 - 1.0/math.Pow(1+l, 0.6)) * 10000)
+			}
 		}
 	}
 


### PR DESCRIPTION
In the original zoekt code base each repository has a uint16 called Rank which is computed from repository signals like star count. zoekt-sourcegraph-indexserver did not set those signals, instead we created our own field which is a float64 called priority. In practice this value is just the star count.

This commit detects empty rank fields and sets them using the same calculation based on priority. This will make Zoekt's ranking now use star count as a signal.

Note: when we are ready, we can use more advanced signals as the input (and code-intel is working on that).

Note: this won't affect current ranking on Sourcegraph since we bucketed by star count => repos in the same bucket will have the same rank.

Test Plan: Ran zoekt-webserver with an extra log line and observed it logging Rank values. Additionally rank some searches with "debug=1" set in the URL params and observed influences on the computed scores.

```
log.Println("RANK", repo.Name, repo.Rank)
go run ./cmd/zoekt-webserver -listen 127.0.0.1:6070
```