### PR TITLE
ranking: boost Go matches based on symbol kind

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -954,8 +954,8 @@ func Get() {
 				&query.Symbol{Expr: &query.Substring{Pattern: "http", Content: true}},
 				&query.Symbol{Expr: &query.Substring{Pattern: "Get", Content: true}}}},
 			wantLanguage: "Go",
-			// 7000 (full base match) + 500 (word) + 400 (atom) + 10 (file order) + 1 (repetition-boost)
-			wantScore: 7911,
+			// 7000 (full base match) + 800 (Go func) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8710,
 		},
 	}
 
@@ -978,7 +978,7 @@ func Get() {
 			}
 			defer ss.Close()
 
-			srs, err := ss.Search(context.Background(), c.query, new(zoekt.SearchOptions))
+			srs, err := ss.Search(context.Background(), c.query, &zoekt.SearchOptions{DebugScore: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -988,7 +988,7 @@ func Get() {
 			}
 
 			if got := srs.Files[0].Score; got != c.wantScore {
-				t.Fatalf("score: want %f, got %f", c.wantScore, got)
+				t.Fatalf("score: want %f, got %f\ndebug: %s\ndebugscore: %s", c.wantScore, got, srs.Files[0].Debug, srs.Files[0].LineMatches[0].DebugScore)
 			}
 
 			if got := srs.Files[0].Language; got != c.wantLanguage {

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -682,6 +682,33 @@ func scoreKind(language string, kind string) float64 {
 		case "variable":
 			factor = 5
 		}
+	case "Go":
+		switch kind {
+		case "struct": // structs
+			factor = 10
+		case "talias": // type aliases
+			factor = 9.5
+		case "interface": // interfaces
+			factor = 9
+		case "methodSpec": // interface method specification
+			factor = 8.5
+		case "func": // functions
+			factor = 8
+		case "member": // struct members
+			factor = 7
+		case "const": // constants
+			factor = 6
+		case "var": // variables
+			factor = 5
+		}
+		// Could also rank on:
+		//
+		//   - anonMember  struct anonymous members
+		//   - packageName name for specifying imported package
+		//   - receiver    receivers
+		//   - package     packages
+		//   - type        types
+		//   - unknown     unknown
 	}
 	return factor * scoreKindMatch
 }


### PR DESCRIPTION
Heuristics to improve ranking on go files. Weights are based on the pre-existing heuristics we have for Kotlin and Java.

Test Plan: updated test + experimentation with "debug=1" on zoekt-webserver.