### PR TITLE
indexserver: introduce DocumentRankVersion

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -104,6 +104,11 @@ type Options struct {
 	// ranks will be computed on-the-fly.
 	DocumentRanksPath string
 
+	// DocumentRanksVersion is a string which when changed will cause us to
+	// reindex a shard. This field is used so that when the contents of
+	// DocumentRanksPath changes, we can reindex.
+	DocumentRanksVersion string
+
 	// changedOrRemovedFiles is a list of file paths that have been changed or removed
 	// since the last indexing job for this repository. These files will be tombstoned
 	// in the older shards for this repository.
@@ -117,15 +122,20 @@ type HashOptions struct {
 	ctagsPath        string
 	cTagsMustSucceed bool
 	largeFiles       []string
+
+	// documentRankVersion is an experimental field which will change when the
+	// DocumentRanksPath content changes. If empty we ignore it.
+	documentRankVersion string
 }
 
 func (o *Options) HashOptions() HashOptions {
 	return HashOptions{
-		sizeMax:          o.SizeMax,
-		disableCTags:     o.DisableCTags,
-		ctagsPath:        o.CTagsPath,
-		cTagsMustSucceed: o.CTagsMustSucceed,
-		largeFiles:       o.LargeFiles,
+		sizeMax:             o.SizeMax,
+		disableCTags:        o.DisableCTags,
+		ctagsPath:           o.CTagsPath,
+		cTagsMustSucceed:    o.CTagsMustSucceed,
+		largeFiles:          o.LargeFiles,
+		documentRankVersion: o.DocumentRanksVersion,
 	}
 }
 
@@ -138,6 +148,11 @@ func (o *Options) GetHash() string {
 	hasher.Write([]byte(fmt.Sprintf("%d", h.sizeMax)))
 	hasher.Write([]byte(fmt.Sprintf("%q", h.largeFiles)))
 	hasher.Write([]byte(fmt.Sprintf("%t", h.disableCTags)))
+
+	if h.documentRankVersion != "" {
+		hasher.Write([]byte{0})
+		io.WriteString(hasher, h.documentRankVersion)
+	}
 
 	return fmt.Sprintf("%x", hasher.Sum(nil))
 }

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -43,6 +43,7 @@ func run() int {
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
 	offlineRanking := flag.String("offline_ranking", "", "the name of the file that contains the ranking info.")
+	offlineRankingVersion := flag.String("offline_ranking_version", "", "a version string identifying the contents in offline_ranking.")
 	flag.Parse()
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
@@ -70,6 +71,7 @@ func run() int {
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
 	opts.DocumentRanksPath = *offlineRanking
+	opts.DocumentRanksVersion = *offlineRankingVersion
 
 	var branches []string
 	if *branchesStr != "" {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -512,8 +512,6 @@ func jitterTicker(d time.Duration, sig ...os.Signal) <-chan struct{} {
 	return ticker
 }
 
-var rankingEnabled, _ = strconv.ParseBool(os.Getenv("ENABLE_EXPERIMENTAL_RANKING"))
-
 // Index starts an index job for repo name at commit.
 func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	tr := trace.New("index", args.Name)

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -617,6 +617,10 @@ func (sf sourcegraphFake) getIndexOptions(name string) (IndexOptions, error) {
 		Priority: float("SG_PRIORITY"),
 	}
 
+	if stat, err := os.Stat(filepath.Join(dir, "SG_DOCUMENT_RANKS")); err == nil {
+		opts.DocumentRanksVersion = stat.ModTime().String()
+	}
+
 	branches, err := sf.getBranches(name)
 	if err != nil {
 		return opts, err


### PR DESCRIPTION
This field allows us to indicate when the ranks have changed, which forces us to re-index. We introduce DocumentRankVersion as a builder options such that it can influence that behavior. By making a corresponding change to Sourcegraph to set this field we will automatically update indexes as document ranks change for a repository.

Note: We remove the document ranking feature flag from index server. This is now completely controlled by frontend.

Note: I got started on a larger refactor here to make this more clean. The idea is to make DocumentRanksPath a URL which is controlled by Sourcegraph. We can then use the URL changing to indicate re-indexing for example. For now this is a much smaller change which will unblock us sooner.

Test Plan: Ran a local server and tested that when the ranks are missing nothing happens. When the ranks change or are added we reindex. Additionally when the ranks do not change it does nothing.

```
  go install ./cmd/zoekt-git-index
  go run ./cmd/zoekt-sourcegraph-indexserver \
    -sourcegraph_url ~/src/github.com/sourcegraph/ \
    -listen 127.0.0.1:6072

  # We expect this to trigger an index
  echo -e "README.md\t0.1" > ~/src/github.com/sourcegraph/zoekt/SG_DOCUMENT_RANKS
  pkill -SIGUSR1 zoekt-sourcegra

  # We expect this to do nothing since the ranks have not changed
  pkill -SIGUSR1 zoekt-sourcegra

  # We expect this to trigger a re-index
  echo -e "README.md\t0.2" > ~/src/github.com/sourcegraph/zoekt/SG_DOCUMENT_RANKS
  pkill -SIGUSR1 zoekt-sourcegra
```