### PR TITLE
Environment Variables for backoff duration

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -953,6 +953,19 @@ func getEnvWithDefaultString(k string, defaultVal string) string {
 	return v
 }
 
+func getEnvWithDefaultDuration(k string, defaultVal time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return defaultVal
+	}
+
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Fatalf("error parsing ENV %s to duration: %s", k, err)
+	}
+	return d
+}
+
 func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
 	set := map[string]struct{}{}
 	for _, v := range strings.Split(os.Getenv(k), ",") {
@@ -1038,8 +1051,8 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.StringVar(&rc.hostname, "hostname", hostnameBestEffort(), "the name we advertise to Sourcegraph when asking for the list of repositories to index. Can also be set via the NODE_NAME environment variable.")
 	fs.Float64Var(&rc.cpuFraction, "cpu_fraction", 1.0, "use this fraction of the cores for indexing.")
 	fs.IntVar(&rc.blockProfileRate, "block_profile_rate", getEnvWithDefaultInt("BLOCK_PROFILE_RATE", -1), "Sampling rate of Go's block profiler in nanoseconds. Values <=0 disable the blocking profiler Var(default). A value of 1 includes every blocking event. See https://pkg.go.dev/runtime#SetBlockProfileRate")
-	fs.DurationVar(&rc.backoffDuration, "backoff_duration", 10*time.Minute, "for the given duration we backoff from enqueue operations for a repository that's failed its previous indexing attempt. Consecutive failures increase the duration of the delay linearly up to the maxBackoffDuration. A negative value disables indexing backoff.")
-	fs.DurationVar(&rc.maxBackoffDuration, "max_backoff_duration", 120*time.Minute, "the maximum duration to backoff from enqueueing a repo for indexing.  A negative value disables indexing backoff.")
+	fs.DurationVar(&rc.backoffDuration, "backoff_duration", getEnvWithDefaultDuration("BACKOFF_DURATION", 10*time.Minute), "for the given duration we backoff from enqueue operations for a repository that's failed its previous indexing attempt. Consecutive failures increase the duration of the delay linearly up to the maxBackoffDuration. A negative value disables indexing backoff.")
+	fs.DurationVar(&rc.maxBackoffDuration, "max_backoff_duration", getEnvWithDefaultDuration("MAX_BACKOFF_DURATION", 120*time.Minute), "the maximum duration to backoff from enqueueing a repo for indexing.  A negative value disables indexing backoff.")
 }
 
 func startServer(conf rootConfig) error {


### PR DESCRIPTION
In addition to the command flag argument we also have the option to set backoff duration and maximum backoff duration using environment variables.

The backoff logic works fine without this but we can introduce the option of configuring deployments with environment variable.

Test plan: Go test