### PR TITLE
ranking: boost Go interfaces

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -946,6 +946,28 @@ func TestScoring(t *testing.T) {
 			fileName: "src/net/http/client.go",
 			content: []byte(`
 package http
+type aInterface interface {}
+`),
+			query:        &query.Substring{Content: true, Pattern: "aInterface"},
+			wantLanguage: "Go",
+			// 7000 (full base match) + 1000 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8910,
+		},
+		{
+			fileName: "src/net/http/client.go",
+			content: []byte(`
+package http
+type aStruct struct {}
+`),
+			query:        &query.Substring{Content: true, Pattern: "aStruct"},
+			wantLanguage: "Go",
+			// 7000 (full base match) + 950 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8860,
+		},
+		{
+			fileName: "src/net/http/client.go",
+			content: []byte(`
+package http
 func Get() {
 	panic("")
 }

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -684,11 +684,11 @@ func scoreKind(language string, kind string) float64 {
 		}
 	case "Go":
 		switch kind {
-		case "struct": // structs
-			factor = 10
-		case "talias": // type aliases
-			factor = 9.5
 		case "interface": // interfaces
+			factor = 10
+		case "struct": // structs
+			factor = 9.5
+		case "talias": // type aliases
 			factor = 9
 		case "methodSpec": // interface method specification
 			factor = 8.5


### PR DESCRIPTION
A couple of test searches revelead that interfaces should rank higher most of the time. With this change we move interfaces to the top.