### PR TITLE
run ranking inside of shard

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -414,6 +414,14 @@ nextFileMatch:
 			atom.updateStats(&res.Stats)
 		}
 	})
+
+	// I am slightly worried about negative interactions with TotalMaxMatchCount
+	// so feature flagging this behaviour behind UseDocumentRanks.
+	if limit := opts.MaxDocDisplayCount; opts.UseDocumentRanks && limit > 0 && limit < len(res.Files) {
+		SortFiles(res.Files, opts.UseDocumentRanks)
+		res.Files = res.Files[:limit]
+	}
+
 	return &res, nil
 }
 


### PR DESCRIPTION
If we have a MaxDocDisplayCount set, then there is no need sending all matches found in a shard when at most MaxDocDisplayCount will end up being in the final result set.

This should improve ranking and let us do more work per shard. I am slightly worried about negative interactions with TotalMaxMatchCount so I am feature flagging this behaviour behind UseDocumentRanks.

Test Plan: unit tested without the feature flag.