### PR TITLE
docker: fix ctags build behind http proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd
 FROM alpine:3.16.2 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git ca-certificates bind-tools tini jansson
+    apk add --no-cache git ca-certificates bind-tools tini jansson wget
 
 COPY install-ctags-alpine.sh .
 RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh

--- a/install-ctags-alpine.sh
+++ b/install-ctags-alpine.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-set -x
+set -eux
+set -o pipefail
 # Commit from 2022-04-05. Please always pick a commit from the main branch.
 export SOURCEGRAPH_COMMIT=4dd4ce3d91da5cac2ac6169d3005714247178f57
 wget -O - https://raw.githubusercontent.com/sourcegraph/sourcegraph/$SOURCEGRAPH_COMMIT/cmd/symbols/ctags-install-alpine.sh | sh


### PR DESCRIPTION
The install-ctags-alpine.sh silently fails when wget fails to download the ctags-install-alpine.sh script. The resulting container image is then missing ctags support. Update the ctags build script to return non-zero on failure.

The root cause is that the busybox wget implementation can not connect to https behind a http proxy. 
See also https://gitlab.alpinelinux.org/alpine/aports/-/issues/10446
Install GNU wget to resolve this issue.

When using busybox wget you'll get the following error from behind a HTTP proxy

```text
[2/2] STEP 5/9: RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh
+ set -o pipefail
+ export 'SOURCEGRAPH_COMMIT=4dd4ce3d91da5cac2ac6169d3005714247178f57'
+ wget -O - https://raw.githubusercontent.com/sourcegraph/sourcegraph/4dd4ce3d91da5cac2ac6169d3005714247178f57/cmd/symbols/ctags-install-alpine.sh
+ sh
Connecting to proxy.company.com:8080 (1.2.3.4:8080)
wget: error getting response: Resource temporarily unavailable
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh": exit status 1
```