### PR TITLE
Only set FileMatch.Ranks if UseDocumentRanks is true

### DIFF
--- a/api.go
+++ b/api.go
@@ -39,6 +39,9 @@ type FileMatch struct {
 	// Experimental. Ranks is a vector containing floats in the interval [0, 1]. The
 	// length of the vector depends on the output from the ranking function at index
 	// time.
+	//
+	// This field is only set if the shard contains ranking information and
+	// SearchOptions.UseDocumentRanks is true.
 	Ranks []float64
 
 	// For debugging. Needs DebugScore set, but public so tests in

--- a/eval.go
+++ b/eval.go
@@ -370,7 +370,7 @@ nextFileMatch:
 		// Prefer earlier docs.
 		fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(nextDoc)/float64(len(d.boundaries))), opts.DebugScore)
 
-		if len(d.ranks) > int(nextDoc) {
+		if opts.UseDocumentRanks && (d.ranks) > int(nextDoc) {
 			fileMatch.Ranks = d.ranks[nextDoc]
 		}
 

--- a/eval.go
+++ b/eval.go
@@ -370,7 +370,7 @@ nextFileMatch:
 		// Prefer earlier docs.
 		fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(nextDoc)/float64(len(d.boundaries))), opts.DebugScore)
 
-		if opts.UseDocumentRanks && (d.ranks) > int(nextDoc) {
+		if opts.UseDocumentRanks && len(d.ranks) > int(nextDoc) {
 			fileMatch.Ranks = d.ranks[nextDoc]
 		}
 


### PR DESCRIPTION
We don't need to set this data if we are not using it for ranking.