### PR TITLE
ranking: add boost if pattern equals match bitewise

### DIFF
--- a/api.go
+++ b/api.go
@@ -164,9 +164,9 @@ type ChunkMatch struct {
 	// its length will equal that of Ranges. Any of its elements may be nil.
 	SymbolInfo []*Symbol
 
-	// CaseSensitiveMatch tracks whether the pattern and match have
+	// caseSensitiveMatch tracks whether the pattern and match have
 	// the same case. Its length equals that of Ranges.
-	CaseSensitiveMatch []bool
+	caseSensitiveMatch []bool
 
 	Score      float64
 	DebugScore string
@@ -308,9 +308,9 @@ type LineFragmentMatch struct {
 
 	SymbolInfo *Symbol
 
-	// CaseSensitiveMatch tracks whether the pattern and match have
+	// caseSensitiveMatch tracks whether the pattern and match have
 	// the same case.
-	CaseSensitiveMatch bool
+	caseSensitiveMatch bool
 }
 
 func (lfm *LineFragmentMatch) sizeBytes() (sz uint64) {

--- a/api.go
+++ b/api.go
@@ -164,6 +164,10 @@ type ChunkMatch struct {
 	// its length will equal that of Ranges. Any of its elements may be nil.
 	SymbolInfo []*Symbol
 
+	// CaseSensitiveMatch tracks whether the pattern and match have
+	// the same case. Its length equals that of Ranges.
+	CaseSensitiveMatch []bool
+
 	Score      float64
 	DebugScore string
 }
@@ -303,6 +307,10 @@ type LineFragmentMatch struct {
 	MatchLength int
 
 	SymbolInfo *Symbol
+
+	// CaseSensitiveMatch tracks whether the pattern and match have
+	// the same case.
+	CaseSensitiveMatch bool
 }
 
 func (lfm *LineFragmentMatch) sizeBytes() (sz uint64) {

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -832,7 +832,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "oxyPreloader"},
+			query:        &query.Substring{Content: true, Pattern: "oxypreloader"},
 			wantLanguage: "Kotlin",
 			// 5500 (partial symbol at boundary) + 1000 (Kotlin class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
@@ -840,7 +840,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "ViewMetadata"},
+			query:        &query.Substring{Content: true, Pattern: "viewmetadata"},
 			wantLanguage: "Kotlin",
 			// 7000 (symbol) + 900 (Kotlin interface) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8810,
@@ -848,7 +848,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "onScrolled"},
+			query:        &query.Substring{Content: true, Pattern: "onscrolled"},
 			wantLanguage: "Kotlin",
 			// 7000 (symbol) + 800 (Kotlin method) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8710,
@@ -856,7 +856,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "PreloadErrorHandler"},
+			query:        &query.Substring{Content: true, Pattern: "preloaderrorhandler"},
 			wantLanguage: "Kotlin",
 			// 7000 (symbol) + 700 (Kotlin typealias) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8610,
@@ -864,7 +864,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "FLING_THRESHOLD_PX"},
+			query:        &query.Substring{Content: true, Pattern: "fling_threshold_px"},
 			wantLanguage: "Kotlin",
 			// 7000 (symbol) + 600 (Kotlin constant) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8510,
@@ -872,7 +872,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.kt",
 			content:      exampleKotlin,
-			query:        &query.Substring{Content: true, Pattern: "scrollState"},
+			query:        &query.Substring{Content: true, Pattern: "scrollstate"},
 			wantLanguage: "Kotlin",
 			// 7000 (symbol) + 500 (Kotlin variable) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8410,
@@ -883,7 +883,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "nerClass"},
+			query:        &query.Substring{Content: true, Pattern: "nnerclass"},
 			wantLanguage: "Java",
 			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
@@ -899,7 +899,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "innerEnum"},
+			query:        &query.Substring{Content: true, Pattern: "innerenum"},
 			wantLanguage: "Java",
 			// 7000 (symbol) + 900 (Java enum) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8810,
@@ -907,7 +907,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "innerInterface"},
+			query:        &query.Substring{Content: true, Pattern: "innerinterface"},
 			wantLanguage: "Java",
 			// 7000 (symbol) + 800 (Java interface) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8710,
@@ -915,7 +915,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "innerMethod"},
+			query:        &query.Substring{Content: true, Pattern: "innermethod"},
 			wantLanguage: "Java",
 			// 7000 (symbol) + 700 (Java method) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8610,
@@ -925,13 +925,13 @@ func TestScoring(t *testing.T) {
 			content:      exampleJava,
 			query:        &query.Substring{Content: true, Pattern: "field"},
 			wantLanguage: "Java",
-			// 7000 (symbol) + 600 (Java field) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8510,
+			// 7000 (symbol) + 600 (Java field) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8610,
 		},
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "B"},
+			query:        &query.Substring{Content: true, Pattern: "b"},
 			wantLanguage: "Java",
 			// 7000 (symbol) + 500 (Java enum constant) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8410,
@@ -943,22 +943,22 @@ func TestScoring(t *testing.T) {
 			fileName:     "a/b/c/config.go",
 			query:        &query.Substring{FileName: true, Pattern: "config"},
 			wantLanguage: "Go",
-			// 5500 (partial base at boundary) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 6410,
+			// 5500 (partial base at boundary) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 6510,
 		},
 		{
 			fileName:     "a/b/c/config.go",
 			query:        &query.Substring{FileName: true, Pattern: "config.go"},
 			wantLanguage: "Go",
-			// 7000 (full base match) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 7910,
+			// 7000 (full base match) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8010,
 		},
 		{
 			fileName:     "a/config/c/d.go",
 			query:        &query.Substring{FileName: true, Pattern: "config"},
 			wantLanguage: "Go",
-			// 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 910,
+			// 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 1010,
 		},
 		{
 			fileName: "src/net/http/client.go",
@@ -966,7 +966,7 @@ func TestScoring(t *testing.T) {
 package http
 type aInterface interface {}
 `),
-			query:        &query.Substring{Content: true, Pattern: "aInterface"},
+			query:        &query.Substring{Content: true, Pattern: "ainterface"},
 			wantLanguage: "Go",
 			// 7000 (full base match) + 1000 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8910,
@@ -977,7 +977,7 @@ type aInterface interface {}
 package http
 type aStruct struct {}
 `),
-			query:        &query.Substring{Content: true, Pattern: "aStruct"},
+			query:        &query.Substring{Content: true, Pattern: "astruct"},
 			wantLanguage: "Go",
 			// 7000 (full base match) + 900 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8810,
@@ -992,7 +992,7 @@ func Get() {
 `),
 			query: &query.And{Children: []query.Q{
 				&query.Symbol{Expr: &query.Substring{Pattern: "http", Content: true}},
-				&query.Symbol{Expr: &query.Substring{Pattern: "Get", Content: true}}}},
+				&query.Symbol{Expr: &query.Substring{Pattern: "get", Content: true}}}},
 			wantLanguage: "Go",
 			// 7000 (full base match) + 800 (Go func) + 500 (word) + 400 (atom) + 10 (file order)
 			wantScore: 8710,
@@ -1003,7 +1003,7 @@ func Get() {
 		{
 			fileName:     "example.cc",
 			content:      exampleCpp,
-			query:        &query.Substring{Content: true, Pattern: "FooClass"},
+			query:        &query.Substring{Content: true, Pattern: "fooclass"},
 			wantLanguage: "C++",
 			// 7000 (Symbol) + 1000 (C++ class) + 500 (full word) + 400 (atom) + 10 (file order)
 			wantScore: 8910,
@@ -1011,7 +1011,7 @@ func Get() {
 		{
 			fileName:     "example.cc",
 			content:      exampleCpp,
-			query:        &query.Substring{Content: true, Pattern: "NestedEnum"},
+			query:        &query.Substring{Content: true, Pattern: "nestedenum"},
 			wantLanguage: "C++",
 			// 7000 (Symbol) + 900 (C++ enum) + 500 (full word) + 400 (atom) + 10 (file order)
 			wantScore: 8810,
@@ -1021,13 +1021,13 @@ func Get() {
 			content:      exampleCpp,
 			query:        &query.Substring{Content: true, Pattern: "main"},
 			wantLanguage: "C++",
-			// 7000 (Symbol) + 800 (C++ function) + 500 (full word) + 400 (atom) + 10 (file order)
-			wantScore: 8710,
+			// 7000 (Symbol) +  800 (C++ function) + 500 (full word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8810,
 		},
 		{
 			fileName:     "example.cc",
 			content:      exampleCpp,
-			query:        &query.Substring{Content: true, Pattern: "FooStruct"},
+			query:        &query.Substring{Content: true, Pattern: "foostruct"},
 			wantLanguage: "C++",
 			// 7000 (Symbol) + 700 (C++ struct) + 500 (full word) + 400 (atom) + 10 (file order)
 			wantScore: 8610,
@@ -1037,8 +1037,8 @@ func Get() {
 			content:      exampleCpp,
 			query:        &query.Substring{Content: true, Pattern: "TheUnion"},
 			wantLanguage: "C++",
-			// 7000 (Symbol) + 600 (C++ union) + 500 (full word) + 400 (atom) + 10 (file order)
-			wantScore: 8510,
+			// 7000 (Symbol) + 600 (C++ union) + 500 (full word) + 400 (atom) + 100 (case-sensitive)  + 10 (file order)
+			wantScore: 8610,
 		},
 		//
 		// Scala

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -883,7 +883,7 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "nnerclass"},
+			query:        &query.Substring{Content: true, Pattern: "nerclass"},
 			wantLanguage: "Java",
 			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
@@ -893,8 +893,8 @@ func TestScoring(t *testing.T) {
 			content:      exampleJava,
 			query:        &query.Substring{Content: true, Pattern: "StaticClass"},
 			wantLanguage: "Java",
-			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 7410,
+			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word) + 400 (atom) + 100 (case-sensitive) +  10 (file order)
+			wantScore: 7510,
 		},
 		{
 			fileName:     "example.java",
@@ -1048,32 +1048,32 @@ func Get() {
 			content:      exampleScala,
 			query:        &query.Substring{Content: true, Pattern: "SymbolIndexBucket"},
 			wantLanguage: "Scala",
-			// 7000 (symbol) + 1000 (Scala class) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8910,
+			// 7000 (symbol) + 1000 (Scala class) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 9010,
 		},
 		{
 			fileName:     "example.scala",
 			content:      exampleScala,
 			query:        &query.Substring{Content: true, Pattern: "stdLibPatches"},
 			wantLanguage: "Scala",
-			// 7000 (symbol) + 800 (Scala object) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8710,
+			// 7000 (symbol) + 800 (Scala object) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8810,
 		},
 		{
 			fileName:     "example.scala",
 			content:      exampleScala,
 			query:        &query.Substring{Content: true, Pattern: "close"},
 			wantLanguage: "Scala",
-			// 7000 (symbol) + 700 (Scala method) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8610,
+			// 7000 (symbol) + 700 (Scala method) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8710,
 		},
 		{
 			fileName:     "example.scala",
 			content:      exampleScala,
 			query:        &query.Substring{Content: true, Pattern: "javaSymbol"},
 			wantLanguage: "Scala",
-			// 7000 (symbol) + 500 (Scala method) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8410,
+			// 7000 (symbol) + 500 (Scala method) + 500 (word) + 400 (atom) + 100 (case-sensitive) + 10 (file order)
+			wantScore: 8510,
 		},
 	}
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -147,7 +147,7 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int,
 				LineOffset:         int(m.byteOffset),
 				MatchLength:        int(m.byteMatchSz),
 				Offset:             m.byteOffset,
-				CaseSensitiveMatch: m.caseSensitiveMatch,
+				caseSensitiveMatch: m.caseSensitiveMatch,
 			})
 
 			result = []LineMatch{res}
@@ -187,7 +187,6 @@ func (p *contentProvider) fillChunkMatches(ms []*candidateMatch, numContextLines
 					Column:     uint32(utf8.RuneCount(fileName[:m.byteOffset+m.byteMatchSz]) + 1),
 				},
 			})
-
 			caseSensitiveMatch = append(caseSensitiveMatch, m.caseSensitiveMatch)
 		}
 
@@ -196,7 +195,7 @@ func (p *contentProvider) fillChunkMatches(ms []*candidateMatch, numContextLines
 			ContentStart:       Location{ByteOffset: 0, LineNumber: 1, Column: 1},
 			Ranges:             ranges,
 			FileName:           true,
-			CaseSensitiveMatch: caseSensitiveMatch,
+			caseSensitiveMatch: caseSensitiveMatch,
 		}}
 	} else {
 		result = p.fillContentChunkMatches(ms, numContextLines)
@@ -271,7 +270,7 @@ func (p *contentProvider) fillContentMatches(ms []*candidateMatch, numContextLin
 				Offset:             m.byteOffset,
 				LineOffset:         int(m.byteOffset) - lineStart,
 				MatchLength:        int(m.byteMatchSz),
-				CaseSensitiveMatch: m.caseSensitiveMatch,
+				caseSensitiveMatch: m.caseSensitiveMatch,
 			}
 			if m.symbol {
 				start := p.id.fileEndSymbol[p.idx]
@@ -349,7 +348,7 @@ func (p *contentProvider) fillContentChunkMatches(ms []*candidateMatch, numConte
 			FileName:           false,
 			Ranges:             ranges,
 			SymbolInfo:         symbolInfo,
-			CaseSensitiveMatch: caseSensitiveMatch,
+			caseSensitiveMatch: caseSensitiveMatch,
 		})
 	}
 	return chunkMatches
@@ -566,7 +565,7 @@ func (p *contentProvider) chunkMatchScore(secs []DocumentSection, m *ChunkMatch,
 			}
 		}
 
-		if len(m.CaseSensitiveMatch) > i && m.CaseSensitiveMatch[i] {
+		if len(m.caseSensitiveMatch) > i && m.caseSensitiveMatch[i] {
 			addScore("caseSensitive", scoreCaseSensitive)
 		}
 
@@ -650,7 +649,7 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 
 		}
 
-		if f.CaseSensitiveMatch {
+		if f.caseSensitiveMatch {
 			addScore("caseSensitive", scoreCaseSensitive)
 		}
 

--- a/index_test.go
+++ b/index_test.go
@@ -217,7 +217,7 @@ func TestNewlines(t *testing.T) {
 					Offset:             8,
 					LineOffset:         2,
 					MatchLength:        3,
-					CaseSensitiveMatch: true,
+					caseSensitiveMatch: true,
 				}},
 				Line:       []byte("line2"),
 				LineStart:  6,
@@ -248,12 +248,12 @@ func TestNewlines(t *testing.T) {
 					Start: Location{ByteOffset: 8, LineNumber: 2, Column: 3},
 					End:   Location{ByteOffset: 11, LineNumber: 2, Column: 6},
 				}},
-				CaseSensitiveMatch: []bool{true},
+				caseSensitiveMatch: []bool{true},
 			}},
 		}}
 
-		if diff := cmp.Diff(want, matches); diff != "" {
-			t.Fatal(diff)
+		if !reflect.DeepEqual(matches, want) {
+			t.Errorf("got %v, want %v", matches, want)
 		}
 	})
 }
@@ -565,7 +565,7 @@ func TestFileSearch(t *testing.T) {
 				Offset:             1,
 				LineOffset:         1,
 				MatchLength:        4,
-				CaseSensitiveMatch: true,
+				caseSensitiveMatch: true,
 			}},
 			FileName: true,
 		}
@@ -595,12 +595,13 @@ func TestFileSearch(t *testing.T) {
 				End:   Location{ByteOffset: 5, LineNumber: 1, Column: 6},
 			}},
 			FileName:           true,
-			CaseSensitiveMatch: []bool{true},
+			caseSensitiveMatch: []bool{true},
 		}
 
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatal(diff)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
 		}
+
 	})
 }
 
@@ -1161,11 +1162,11 @@ func TestRegexp(t *testing.T) {
 				Start: Location{ByteOffset: 3, LineNumber: 1, Column: 4},
 				End:   Location{ByteOffset: 14, LineNumber: 1, Column: 15},
 			}},
-			CaseSensitiveMatch: []bool{false},
+			caseSensitiveMatch: []bool{false},
 		}
 
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatal(diff)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
 		}
 	})
 }

--- a/index_test.go
+++ b/index_test.go
@@ -214,9 +214,10 @@ func TestNewlines(t *testing.T) {
 			FileName: "filename",
 			LineMatches: []LineMatch{{
 				LineFragments: []LineFragmentMatch{{
-					Offset:      8,
-					LineOffset:  2,
-					MatchLength: 3,
+					Offset:             8,
+					LineOffset:         2,
+					MatchLength:        3,
+					CaseSensitiveMatch: true,
 				}},
 				Line:       []byte("line2"),
 				LineStart:  6,
@@ -247,6 +248,7 @@ func TestNewlines(t *testing.T) {
 					Start: Location{ByteOffset: 8, LineNumber: 2, Column: 3},
 					End:   Location{ByteOffset: 11, LineNumber: 2, Column: 6},
 				}},
+				CaseSensitiveMatch: []bool{true},
 			}},
 		}}
 
@@ -560,9 +562,10 @@ func TestFileSearch(t *testing.T) {
 		want := LineMatch{
 			Line: []byte("banana"),
 			LineFragments: []LineFragmentMatch{{
-				Offset:      1,
-				LineOffset:  1,
-				MatchLength: 4,
+				Offset:             1,
+				LineOffset:         1,
+				MatchLength:        4,
+				CaseSensitiveMatch: true,
 			}},
 			FileName: true,
 		}
@@ -591,7 +594,8 @@ func TestFileSearch(t *testing.T) {
 				Start: Location{ByteOffset: 1, LineNumber: 1, Column: 2},
 				End:   Location{ByteOffset: 5, LineNumber: 1, Column: 6},
 			}},
-			FileName: true,
+			FileName:           true,
+			CaseSensitiveMatch: []bool{true},
 		}
 
 		if diff := cmp.Diff(want, got); diff != "" {
@@ -1157,6 +1161,7 @@ func TestRegexp(t *testing.T) {
 				Start: Location{ByteOffset: 3, LineNumber: 1, Column: 4},
 				End:   Location{ByteOffset: 14, LineNumber: 1, Column: 15},
 			}},
+			CaseSensitiveMatch: []bool{false},
 		}
 
 		if diff := cmp.Diff(want, got); diff != "" {

--- a/read_test.go
+++ b/read_test.go
@@ -226,7 +226,14 @@ func TestReadSearch(t *testing.T) {
 				continue
 			}
 
-			if d := cmp.Diff(res.Files, want.FileMatches[j]); d != "" {
+			// The golden files don't have the unexported fields, hence we
+			// ignore them in this test.
+			diffOpts := []cmp.Option{
+				cmpopts.IgnoreUnexported(LineFragmentMatch{}),
+				cmpopts.IgnoreUnexported(ChunkMatch{}),
+			}
+
+			if d := cmp.Diff(res.Files, want.FileMatches[j], diffOpts...); d != "" {
 				t.Errorf("matches for %s on %s\n%s", q, name, d)
 			}
 		}

--- a/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
@@ -4,7 +4,7 @@
   "FileMatches": [
     [
       {
-        "Score": 910,
+        "Score": 1010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -19,14 +19,15 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 601,
             "DebugScore": "",
             "LineFragments": [
               {
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -66,7 +67,8 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": false
               }
             ]
           }
@@ -84,7 +86,7 @@
     ],
     [
       {
-        "Score": 8410,
+        "Score": 8010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -99,7 +101,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 8001,
+            "Score": 7601,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -111,7 +113,8 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                }
+                },
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -129,7 +132,7 @@
     ],
     [
       {
-        "Score": 6260,
+        "Score": 5760,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -144,7 +147,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 6051,
+            "Score": 5551,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -156,7 +159,8 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                }
+                },
+                "CaseSensitiveMatch": false
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
@@ -26,8 +26,7 @@
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": true
+                "SymbolInfo": null
               }
             ]
           }
@@ -67,8 +66,7 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": false
+                "SymbolInfo": null
               }
             ]
           }
@@ -86,7 +84,7 @@
     ],
     [
       {
-        "Score": 8010,
+        "Score": 8510,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -101,7 +99,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 7601,
+            "Score": 8101,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -113,8 +111,7 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                },
-                "CaseSensitiveMatch": true
+                }
               }
             ]
           }
@@ -132,7 +129,7 @@
     ],
     [
       {
-        "Score": 5760,
+        "Score": 6260,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -147,7 +144,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 5551,
+            "Score": 6051,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -159,8 +156,7 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                },
-                "CaseSensitiveMatch": false
+                }
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
@@ -4,7 +4,7 @@
   "FileMatches": [
     [
       {
-        "Score": 910,
+        "Score": 1010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -19,14 +19,15 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 601,
             "DebugScore": "",
             "LineFragments": [
               {
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -66,7 +67,8 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": false
               }
             ]
           }
@@ -84,7 +86,7 @@
     ],
     [
       {
-        "Score": 8410,
+        "Score": 8010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -99,7 +101,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 8001,
+            "Score": 7601,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -111,7 +113,8 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                }
+                },
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -129,7 +132,7 @@
     ],
     [
       {
-        "Score": 6260,
+        "Score": 5760,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -144,7 +147,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 6051,
+            "Score": 5551,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -156,7 +159,8 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                }
+                },
+                "CaseSensitiveMatch": false
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
@@ -26,8 +26,7 @@
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": true
+                "SymbolInfo": null
               }
             ]
           }
@@ -67,8 +66,7 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": false
+                "SymbolInfo": null
               }
             ]
           }
@@ -86,7 +84,7 @@
     ],
     [
       {
-        "Score": 8010,
+        "Score": 8510,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -101,7 +99,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 7601,
+            "Score": 8101,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -113,8 +111,7 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                },
-                "CaseSensitiveMatch": true
+                }
               }
             ]
           }
@@ -132,7 +129,7 @@
     ],
     [
       {
-        "Score": 5760,
+        "Score": 6260,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -147,7 +144,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 5551,
+            "Score": 6051,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -159,8 +156,7 @@
                   "Kind": "var",
                   "Parent": "main",
                   "ParentKind": "package"
-                },
-                "CaseSensitiveMatch": false
+                }
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo17_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/repo17_v17.00000.golden
@@ -4,7 +4,7 @@
   "FileMatches": [
     [
       {
-        "Score": 910,
+        "Score": 1010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -19,14 +19,15 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 601,
             "DebugScore": "",
             "LineFragments": [
               {
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -66,7 +67,8 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": false
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo17_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/repo17_v17.00000.golden
@@ -26,8 +26,7 @@
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": true
+                "SymbolInfo": null
               }
             ]
           }
@@ -67,8 +66,7 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": false
+                "SymbolInfo": null
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo2_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo2_v16.00000.golden
@@ -4,7 +4,7 @@
   "FileMatches": [
     [
       {
-        "Score": 910,
+        "Score": 1010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -19,14 +19,15 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 601,
             "DebugScore": "",
             "LineFragments": [
               {
                 "LineOffset": 0,
                 "Offset": 33,
                 "MatchLength": 9,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -66,7 +67,8 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": false
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo2_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo2_v16.00000.golden
@@ -26,8 +26,7 @@
                 "LineOffset": 0,
                 "Offset": 33,
                 "MatchLength": 9,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": true
+                "SymbolInfo": null
               }
             ]
           }
@@ -67,8 +66,7 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": false
+                "SymbolInfo": null
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo_v16.00000.golden
@@ -4,7 +4,7 @@
   "FileMatches": [
     [
       {
-        "Score": 910,
+        "Score": 1010,
         "Ranks": null,
         "Debug": "",
         "FileName": "main.go",
@@ -19,14 +19,15 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 601,
             "DebugScore": "",
             "LineFragments": [
               {
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": true
               }
             ]
           }
@@ -66,7 +67,8 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null
+                "SymbolInfo": null,
+                "CaseSensitiveMatch": false
               }
             ]
           }

--- a/testdata/golden/TestReadSearch/repo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo_v16.00000.golden
@@ -26,8 +26,7 @@
                 "LineOffset": 0,
                 "Offset": 69,
                 "MatchLength": 9,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": true
+                "SymbolInfo": null
               }
             ]
           }
@@ -67,8 +66,7 @@
                 "LineOffset": 0,
                 "Offset": 0,
                 "MatchLength": 7,
-                "SymbolInfo": null,
-                "CaseSensitiveMatch": false
+                "SymbolInfo": null
               }
             ]
           }


### PR DESCRIPTION
We use the capitalizaton of the query as signal for scoring and boost matches that have the same capitalization as the pattern. This is particulary relevant for Sourcegraph, which defaults to case-insensitive matching.

Example 1:

Query: FooBar case:no
Match1: foobar (no boost)
Match2: FooBar (boost)

Example 2:

Query: foobar case:no
Match1: foobar (boost)
Match2: FooBar (no boost)

The core of the change is in matchiter.go `candidateMatch.matchContent`.

### Test plan
- I updated existing scoring tests: Naturally, some of the tests now get higher scores because their pattern matches the content exactly. In some cases I lowercased the patterns (same score), in other cases I updated the score (same pattern).
- I verified with the debug=1 query parameter that the boost is assigned properly.

<img width="1307" alt="Screenshot 2022-11-04 at 10 39 29" src="https://user-images.githubusercontent.com/26413131/199941937-5998d9d4-62bc-4f16-bff9-42ceff763239.png">

 