### PR TITLE
debug: add ranks and rrf scores to debug string

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -773,16 +773,16 @@ const k = 60
 //
 // Rankings derived from match scores and rank vectors are combined based on
 // "Reciprocal Rank Fusion" (RFF).
-func SortFiles(ms []FileMatch, useDocumentRanks bool, debug bool) {
+func SortFiles(ms []FileMatch, opts *SearchOptions) {
 	sort.Sort(fileMatchesByScore(ms))
 
-	if useDocumentRanks {
+	if opts.UseDocumentRanks {
 		rffScore := make([]float64, len(ms))
 
 		for i := 0; i < len(ms); i++ {
 			rffScore[i] = 1 / (k + float64(i))
-			if debug {
-				ms[i].Debug += fmt.Sprintf("rff_score: %f, ", rffScore[i])
+			if opts.DebugScore {
+				ms[i].Debug += fmt.Sprintf("(%d,", i)
 			}
 		}
 
@@ -793,8 +793,8 @@ func SortFiles(ms []FileMatch, useDocumentRanks bool, debug bool) {
 
 		for i := range rffScore {
 			rffScore[i] += 1 / (k + float64(i))
-			if debug {
-				ms[i].Debug += fmt.Sprintf("rff_rank: %f, rff_sum: %f, ", 1/(k+float64(i)), rffScore[i])
+			if opts.DebugScore {
+				ms[i].Debug += fmt.Sprintf("%d), ", i)
 			}
 		}
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -773,7 +773,7 @@ const k = 60
 //
 // Rankings derived from match scores and rank vectors are combined based on
 // "Reciprocal Rank Fusion" (RFF).
-func SortFiles(ms []FileMatch, useDocumentRanks bool) {
+func SortFiles(ms []FileMatch, useDocumentRanks bool, debug bool) {
 	sort.Sort(fileMatchesByScore(ms))
 
 	if useDocumentRanks {
@@ -781,6 +781,9 @@ func SortFiles(ms []FileMatch, useDocumentRanks bool) {
 
 		for i := 0; i < len(ms); i++ {
 			rffScore[i] = 1 / (k + float64(i))
+			if debug {
+				ms[i].Debug += fmt.Sprintf("rff_score: %f, ", rffScore[i])
+			}
 		}
 
 		// We use stable sort in case we don't have ranks. Without stable sort the order
@@ -790,6 +793,9 @@ func SortFiles(ms []FileMatch, useDocumentRanks bool) {
 
 		for i := range rffScore {
 			rffScore[i] += 1 / (k + float64(i))
+			if debug {
+				ms[i].Debug += fmt.Sprintf("rff_rank: %f, rff_sum: %f, ", 1/(k+float64(i)), rffScore[i])
+			}
 		}
 
 		sort.Sort(fileMatchesByRFFScore{fileMatches: ms, rffScore: rffScore})

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -341,7 +341,7 @@ func TestSortFiles(t *testing.T) {
 	// d1        1/(60+2)   1/(60+1)   0,0325224748810153   2
 	// d4        1/(60+3)   1/(60+2)   0,0320020481310804   3
 
-	SortFiles(in, true)
+	SortFiles(in, true, true)
 
 	wantOrder := []string{"d3", "d2", "d1", "d4"}
 

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -341,7 +341,7 @@ func TestSortFiles(t *testing.T) {
 	// d1        1/(60+2)   1/(60+1)   0,0325224748810153   2
 	// d4        1/(60+3)   1/(60+2)   0,0320020481310804   3
 
-	SortFiles(in, true, true)
+	SortFiles(in, &SearchOptions{UseDocumentRanks: true, DebugScore: true})
 
 	wantOrder := []string{"d3", "d2", "d1", "d4"}
 

--- a/eval.go
+++ b/eval.go
@@ -422,7 +422,7 @@ nextFileMatch:
 	// I am slightly worried about negative interactions with TotalMaxMatchCount
 	// so feature flagging this behaviour behind UseDocumentRanks.
 	if limit := opts.MaxDocDisplayCount; opts.UseDocumentRanks && limit > 0 && limit < len(res.Files) {
-		SortFiles(res.Files, opts.UseDocumentRanks, opts.DebugScore)
+		SortFiles(res.Files, opts)
 		res.Files = res.Files[:limit]
 	}
 

--- a/eval.go
+++ b/eval.go
@@ -376,6 +376,10 @@ nextFileMatch:
 
 		fileMatch.addScore("shard-order", scoreShardRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
 
+		if opts.DebugScore && opts.UseDocumentRanks {
+			fileMatch.Debug += fmt.Sprintf("ranks: %v, ", fileMatch.Ranks)
+		}
+
 		fileMatch.Branches = d.gatherBranches(nextDoc, mt, known)
 		sortMatchesByScore(fileMatch.LineMatches)
 		sortChunkMatchesByScore(fileMatch.ChunkMatches)
@@ -418,7 +422,7 @@ nextFileMatch:
 	// I am slightly worried about negative interactions with TotalMaxMatchCount
 	// so feature flagging this behaviour behind UseDocumentRanks.
 	if limit := opts.MaxDocDisplayCount; opts.UseDocumentRanks && limit > 0 && limit < len(res.Files) {
-		SortFiles(res.Files, opts.UseDocumentRanks)
+		SortFiles(res.Files, opts.UseDocumentRanks, opts.DebugScore)
 		res.Files = res.Files[:limit]
 	}
 

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -29,12 +29,14 @@ type collectSender struct {
 	aggregate          *zoekt.SearchResult
 	maxDocDisplayCount int
 	useDocumentRanks   bool
+	debugScore         bool
 }
 
 func newCollectSender(opts *zoekt.SearchOptions) *collectSender {
 	return &collectSender{
 		maxDocDisplayCount: opts.MaxDocDisplayCount,
 		useDocumentRanks:   opts.UseDocumentRanks,
+		debugScore:         opts.DebugScore,
 	}
 }
 
@@ -80,7 +82,7 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	agg := c.aggregate
 	c.aggregate = nil
 
-	zoekt.SortFiles(agg.Files, c.useDocumentRanks)
+	zoekt.SortFiles(agg.Files, c.useDocumentRanks, c.debugScore)
 
 	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -26,18 +26,12 @@ var (
 // Note: It aggregates Progress as well, and expects that the
 // MaxPendingPriority it receives are monotonically decreasing.
 type collectSender struct {
-	aggregate          *zoekt.SearchResult
-	maxDocDisplayCount int
-	useDocumentRanks   bool
-	debugScore         bool
+	opts      *zoekt.SearchOptions
+	aggregate *zoekt.SearchResult
 }
 
 func newCollectSender(opts *zoekt.SearchOptions) *collectSender {
-	return &collectSender{
-		maxDocDisplayCount: opts.MaxDocDisplayCount,
-		useDocumentRanks:   opts.UseDocumentRanks,
-		debugScore:         opts.DebugScore,
-	}
+	return &collectSender{opts: opts}
 }
 
 func (c *collectSender) Send(r *zoekt.SearchResult) {
@@ -82,9 +76,9 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 	agg := c.aggregate
 	c.aggregate = nil
 
-	zoekt.SortFiles(agg.Files, c.useDocumentRanks, c.debugScore)
+	zoekt.SortFiles(agg.Files, c.opts)
 
-	if max := c.maxDocDisplayCount; max > 0 && len(agg.Files) > max {
+	if max := c.opts.MaxDocDisplayCount; max > 0 && len(agg.Files) > max {
 		agg.Files = agg.Files[:max]
 	}
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -714,13 +714,13 @@ search:
 func sendByRepository(result *zoekt.SearchResult, opts *zoekt.SearchOptions, sender zoekt.Sender) {
 
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
-		zoekt.SortFiles(result.Files, opts.UseDocumentRanks, opts.DebugScore)
+		zoekt.SortFiles(result.Files, opts)
 		sender.Send(result)
 		return
 	}
 
 	send := func(repoName string, a, b int, stats zoekt.Stats) {
-		zoekt.SortFiles(result.Files[a:b], opts.UseDocumentRanks, opts.DebugScore)
+		zoekt.SortFiles(result.Files[a:b], opts)
 		sender.Send(&zoekt.SearchResult{
 			Stats: stats,
 			Progress: zoekt.Progress{

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -714,13 +714,13 @@ search:
 func sendByRepository(result *zoekt.SearchResult, opts *zoekt.SearchOptions, sender zoekt.Sender) {
 
 	if len(result.RepoURLs) <= 1 || len(result.Files) == 0 {
-		zoekt.SortFiles(result.Files, opts.UseDocumentRanks)
+		zoekt.SortFiles(result.Files, opts.UseDocumentRanks, opts.DebugScore)
 		sender.Send(result)
 		return
 	}
 
 	send := func(repoName string, a, b int, stats zoekt.Stats) {
-		zoekt.SortFiles(result.Files[a:b], opts.UseDocumentRanks)
+		zoekt.SortFiles(result.Files[a:b], opts.UseDocumentRanks, opts.DebugScore)
 		sender.Send(&zoekt.SearchResult{
 			Stats: stats,
 			Progress: zoekt.Progress{


### PR DESCRIPTION
The debug string already contains scores, now it contains ranks, too.