### PR TITLE
debug: add "score" to debug string

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -497,7 +497,7 @@ func (p *contentProvider) chunkMatchScore(secs []DocumentSection, m *ChunkMatch,
 
 	addScore := func(what string, s float64) {
 		if debug {
-			score.what += fmt.Sprintf("%s:%f, ", what, s)
+			score.what += fmt.Sprintf("%s:%.2f, ", what, s)
 		}
 		score.score += s
 	}
@@ -562,7 +562,11 @@ func (p *contentProvider) chunkMatchScore(secs []DocumentSection, m *ChunkMatch,
 		}
 	}
 
-	return maxScore.score, strings.TrimRight(maxScore.what, ", ")
+	if debug {
+		maxScore.what = fmt.Sprintf("score:%f <- %s", maxScore.score, strings.TrimRight(maxScore.what, ", "))
+	}
+
+	return maxScore.score, maxScore.what
 }
 
 func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, language string, debug bool) (float64, string) {
@@ -576,7 +580,7 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 
 	addScore := func(what string, s float64) {
 		if debug {
-			score.what += fmt.Sprintf("%s:%f, ", what, s)
+			score.what += fmt.Sprintf("%s:%.2f, ", what, s)
 		}
 		score.score += s
 	}
@@ -636,7 +640,12 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 			maxScore.what = score.what
 		}
 	}
-	return maxScore.score, strings.TrimRight(maxScore.what, ", ")
+
+	if debug {
+		maxScore.what = fmt.Sprintf("score:%.2f <- %s", maxScore.score, strings.TrimSuffix(maxScore.what, ", "))
+	}
+
+	return maxScore.score, maxScore.what
 }
 
 // scoreKind boosts a match based on the combination of language and kind. The

--- a/eval.go
+++ b/eval.go
@@ -396,7 +396,7 @@ nextFileMatch:
 		repoMatchCount += matchedChunkRanges
 
 		if opts.DebugScore {
-			fileMatch.Debug = fmt.Sprintf("score:%.2f <- %s", fileMatch.Score, strings.TrimSuffix(fileMatch.Debug, ", "))
+			fileMatch.Debug = fmt.Sprintf("score:%.2f <- %s", fileMatch.Score, fileMatch.Debug)
 		}
 
 		res.Files = append(res.Files, fileMatch)

--- a/eval.go
+++ b/eval.go
@@ -32,7 +32,7 @@ const maxUInt16 = 0xffff
 
 func (m *FileMatch) addScore(what string, s float64, debugScore bool) {
 	if debugScore {
-		m.Debug += fmt.Sprintf("%s:%f, ", what, s)
+		m.Debug += fmt.Sprintf("%s:%.2f, ", what, s)
 	}
 	m.Score += s
 }
@@ -394,6 +394,10 @@ nextFileMatch:
 
 		repoMatchCount += len(fileMatch.LineMatches)
 		repoMatchCount += matchedChunkRanges
+
+		if opts.DebugScore {
+			fileMatch.Debug = fmt.Sprintf("score:%.2f <- %s", fileMatch.Score, strings.TrimSuffix(fileMatch.Debug, ", "))
+		}
 
 		res.Files = append(res.Files, fileMatch)
 		res.Stats.MatchCount += len(fileMatch.LineMatches)

--- a/web/templates.go
+++ b/web/templates.go
@@ -220,14 +220,13 @@ document.onkeydown=function(e){
       {{else}}.{{end}}
     </h5>
     {{range .FileMatches}}
-    {{$showScoreDebug := .ScoreDebug}}
     <table class="table table-hover table-condensed">
       <thead>
         <tr>
           <th>
             {{if .URL}}<a name="{{.ResultID}}" class="result"></a><a href="{{.URL}}" >{{else}}<a name="{{.ResultID}}">{{end}}
             <small>
-              {{.Repo}}:{{.FileName}} {{if $showScoreDebug}}<i>(score:{{.Score}} <-- {{.ScoreDebug}})</i>{{end}}</a>:
+              {{.Repo}}:{{.FileName}} {{if .ScoreDebug}}<i>({{.ScoreDebug}})</i>{{end}}</a>:
               <span style="font-weight: normal">[ {{if .Branches}}{{range .Branches}}<span class="label label-default">{{.}}</span>,{{end}}{{end}} ]</span>
               {{if .Language}}<button
                    title="restrict search to files written in {{.Language}}"
@@ -242,7 +241,7 @@ document.onkeydown=function(e){
         {{range .Matches}}
         <tr>
           <td style="background-color: rgba(238, 238, 255, 0.6);">
-            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}} {{if $showScoreDebug}}<i>(score:{{.Score}} <-- {{.ScoreDebug}})</i>{{end}}</pre>
+            <pre class="inline-pre"><span class="noselect">{{if .URL}}<a href="{{.URL}}">{{end}}<u>{{.LineNum}}</u>{{if .URL}}</a>{{end}}: </span>{{range .Fragments}}{{LimitPre 100 .Pre}}<b>{{.Match}}</b>{{LimitPost 100 .Post}}{{end}} {{if .ScoreDebug}}<i>({{.ScoreDebug}})</i>{{end}}</pre>
           </td>
         </tr>
         {{end}}


### PR DESCRIPTION
This moves the "score" prefix from the template to the debug strings. This way we have a consistent behavior in Sourcegraph and Zoekt.

Additionally, we limit the display precision to 2 digits to reduce the visual noise. 

![image](https://user-images.githubusercontent.com/26413131/200266739-46b30c0d-bfb0-4a2d-8b7c-566315e57f88.png)



