### PR TITLE
ranking: boost camelCase

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -150,16 +150,20 @@ func splitNGrams(str []byte) []runeNgramOff {
 }
 
 const (
-	_classChar  = 0
-	_classDigit = iota
-	_classPunct = iota
-	_classOther = iota
-	_classSpace = iota
+	_classLowerChar int = iota
+	_classUpperChar
+	_classDigit
+	_classPunct
+	_classOther
+	_classSpace
 )
 
 func byteClass(c byte) int {
-	if (c >= 'a' && c <= 'z') || c >= 'A' && c <= 'Z' {
-		return _classChar
+	if c >= 'a' && c <= 'z' {
+		return _classLowerChar
+	}
+	if c >= 'A' && c <= 'Z' {
+		return _classUpperChar
 	}
 	if c >= '0' && c <= '9' {
 		return _classDigit

--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -878,10 +878,18 @@ func TestScoring(t *testing.T) {
 		{
 			fileName:     "example.java",
 			content:      exampleJava,
-			query:        &query.Substring{Content: true, Pattern: "nnerClass"},
+			query:        &query.Substring{Content: true, Pattern: "nerClass"},
 			wantLanguage: "Java",
 			// 5500 (partial symbol at boundary) + 1000 (Java class) + 50 (partial word) + 400 (atom) + 10 (file order)
 			wantScore: 6960,
+		},
+		{
+			fileName:     "example.java",
+			content:      exampleJava,
+			query:        &query.Substring{Content: true, Pattern: "StaticClass"},
+			wantLanguage: "Java",
+			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 7410,
 		},
 		{
 			fileName:     "example.java",


### PR DESCRIPTION
With this change we recognize changes in capitalization as word boundaries.

There is a corner case which was caught in the tests, where we falsly classify "nnerClass" as word, because the preceeding letter in the code is a capital "I". However, I don't believe this corner case is relevant in practice and by accepting it we keep the code simple.