### PR TITLE
stats: add FlushReason

### DIFF
--- a/api.go
+++ b/api.go
@@ -333,7 +333,8 @@ const (
 
 var FlushReasonStrings = map[FlushReason]string{
 	FlushReasonTimerExpired: "timer_expired",
-	FlushReasonFinalFlush:   "final_flush"}
+	FlushReasonFinalFlush:   "final_flush",
+}
 
 func (fr FlushReason) String() string {
 	if v, ok := FlushReasonStrings[fr]; ok {

--- a/api.go
+++ b/api.go
@@ -427,7 +427,9 @@ func (s *Stats) Add(o Stats) {
 	s.Wait += o.Wait
 	s.RegexpsConsidered += o.RegexpsConsidered
 
-	if o.FlushReason != 0 {
+    // We want the first non-zero FlushReason to be sticky. This is a useful
+    // property when aggregating stats from several Zoekts.
+    if s.FlushReason == 0 {
 		s.FlushReason = o.FlushReason
 	}
 }

--- a/api.go
+++ b/api.go
@@ -376,6 +376,9 @@ type Stats struct {
 
 	// Number of times regexp was called on files that we evaluated.
 	RegexpsConsidered int
+
+	// FlushReason explains why results were flushed.
+	FlushReason string
 }
 
 func (s *Stats) sizeBytes() uint64 {
@@ -399,6 +402,10 @@ func (s *Stats) Add(o Stats) {
 	s.ShardsSkippedFilter += o.ShardsSkippedFilter
 	s.Wait += o.Wait
 	s.RegexpsConsidered += o.RegexpsConsidered
+
+	if o.FlushReason != "" {
+		s.FlushReason = o.FlushReason
+	}
 }
 
 // Zero returns true if stats is empty.

--- a/api.go
+++ b/api.go
@@ -329,11 +329,13 @@ type FlushReason uint8
 const (
 	FlushReasonTimerExpired FlushReason = 1 << iota
 	FlushReasonFinalFlush
+	FlushReasonMaxSize
 )
 
 var FlushReasonStrings = map[FlushReason]string{
 	FlushReasonTimerExpired: "timer_expired",
 	FlushReasonFinalFlush:   "final_flush",
+	FlushReasonMaxSize:      "max_size_reached",
 }
 
 func (fr FlushReason) String() string {

--- a/api.go
+++ b/api.go
@@ -381,9 +381,11 @@ type Stats struct {
 	FlushReason string
 }
 
-func (s *Stats) sizeBytes() uint64 {
-	// This assumes we are running on a 64-bit architecture.
-	return 16 * 8
+func (s *Stats) sizeBytes() (sz uint64) {
+	sz = 16 * 8 // This assumes we are running on a 64-bit architecture
+	sz += stringHeaderBytes + uint64(len(s.FlushReason))
+
+	return
 }
 
 func (s *Stats) Add(o Stats) {

--- a/api_test.go
+++ b/api_test.go
@@ -78,7 +78,7 @@ func benchmarkEncoding(data interface{}) func(*testing.B) {
 
 func TestSizeBytesSearchResult(t *testing.T) {
 	var sr = SearchResult{
-		Stats:    Stats{},    // 128 bytes
+		Stats:    Stats{},    // 129 bytes
 		Progress: Progress{}, // 16 bytes
 		Files: []FileMatch{{ // 24 bytes + 460 bytes
 			Score:       0,   // 8 bytes
@@ -109,7 +109,7 @@ func TestSizeBytesSearchResult(t *testing.T) {
 		LineFragments: nil, // 48 bytes
 	}
 
-	var wantBytes uint64 = 740
+	var wantBytes uint64 = 725
 	if sr.SizeBytes() != wantBytes {
 		t.Fatalf("want %d, got %d", wantBytes, sr.SizeBytes())
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -109,7 +109,7 @@ func TestSizeBytesSearchResult(t *testing.T) {
 		LineFragments: nil, // 48 bytes
 	}
 
-	var wantBytes uint64 = 724
+	var wantBytes uint64 = 740
 	if sr.SizeBytes() != wantBytes {
 		t.Fatalf("want %d, got %d", wantBytes, sr.SizeBytes())
 	}

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -118,6 +118,7 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, sender zoekt.Sender) (zoek
 
 		if agg, ok := collectSender.Done(); ok {
 			metricFinalAggregateSize.WithLabelValues(reason).Observe(float64(len(agg.Files)))
+			agg.FlushReason = reason
 			sender.Send(agg)
 		}
 

--- a/shards/aggregate.go
+++ b/shards/aggregate.go
@@ -108,7 +108,7 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, sender zoekt.Sender) (zoek
 
 	// stopCollectingAndFlush will send what we have collected and all future
 	// sends will go via sender directly.
-	stopCollectingAndFlush := func(reason string) {
+	stopCollectingAndFlush := func(reason zoekt.FlushReason) {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -117,7 +117,7 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, sender zoekt.Sender) (zoek
 		}
 
 		if agg, ok := collectSender.Done(); ok {
-			metricFinalAggregateSize.WithLabelValues(reason).Observe(float64(len(agg.Files)))
+			metricFinalAggregateSize.WithLabelValues(reason.String()).Observe(float64(len(agg.Files)))
 			agg.FlushReason = reason
 			sender.Send(agg)
 		}
@@ -136,12 +136,12 @@ func newFlushCollectSender(opts *zoekt.SearchOptions, sender zoekt.Sender) (zoek
 		case <-timerCancel:
 			timer.Stop()
 		case <-timer.C:
-			stopCollectingAndFlush("timer_expired")
+			stopCollectingAndFlush(zoekt.FlushReasonTimerExpired)
 		}
 	}()
 
 	finalFlush := func() {
-		stopCollectingAndFlush("final_flush")
+		stopCollectingAndFlush(zoekt.FlushReasonFinalFlush)
 	}
 
 	return stream.SenderFunc(func(event *zoekt.SearchResult) {


### PR DESCRIPTION
`Stats.FlushReason` lets us document why the collectSender flushed. This is
useful for debugging.