### PR TITLE
rank: make go structs and aliases the same

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -979,8 +979,8 @@ type aStruct struct {}
 `),
 			query:        &query.Substring{Content: true, Pattern: "aStruct"},
 			wantLanguage: "Go",
-			// 7000 (full base match) + 950 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
-			wantScore: 8860,
+			// 7000 (full base match) + 900 (Go interface) + 500 (word) + 400 (atom) + 10 (file order)
+			wantScore: 8810,
 		},
 		{
 			fileName: "src/net/http/client.go",

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -718,7 +718,7 @@ func scoreKind(language string, kind string) float64 {
 		case "interface": // interfaces
 			factor = 10
 		case "struct": // structs
-			factor = 9.5
+			factor = 9
 		case "talias": // type aliases
 			factor = 9
 		case "methodSpec": // interface method specification


### PR DESCRIPTION
Type aliases are super common in Go. From experimentally searching around I often failed to find something since it was a type alias to a map. EG when searching Header in the stdlib. So this change makes them equivalent.

Test Plan: go test