### PR TITLE
ranking: parametrize contribution of document ranks

### DIFF
--- a/api.go
+++ b/api.go
@@ -803,6 +803,11 @@ type SearchOptions struct {
 	// sorting matches.
 	UseDocumentRanks bool
 
+	// RanksDampingFactor determines the contribution of documents ranks to the
+	// final ranking based on RRF. A value in (0,1] reduces the contribution,
+	// while a value in (-inf,0) increases it.
+	RanksDampingFactor float64
+
 	// Trace turns on opentracing for this request if true and if the Jaeger address was provided as
 	// a command-line flag
 	Trace bool

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -900,7 +900,7 @@ func SortFiles(ms []FileMatch, opts *SearchOptions) {
 		sort.Stable(fileMatchesByRank{fileMatches: ms, rrfScore: rrfScore})
 
 		for i := range rrfScore {
-			rrfScore[i] += 1 / (k + float64(i))
+			rrfScore[i] += (1 - opts.RanksDampingFactor) / (k + float64(i))
 			if opts.DebugScore {
 				ms[i].Debug += fmt.Sprintf("%d), ", i)
 			}


### PR DESCRIPTION
We tune the contribution of document ranks to the final ranking with a damping factor. The zero value of the damping factor leads to an equal contribution of scores and ranks, while a damping factor of 1 effectively eliminates the influence of document ranks.

The default is 0 IE equal contribution.