### PR TITLE
ranking: set repo.Rank on read

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -971,14 +971,6 @@ func mkRankedShard(s zoekt.Searcher) *rankedShard {
 			if priority > maxPriority {
 				maxPriority = priority
 			}
-
-			// No one is reading our searcher yet, so we can mutate it.
-			// zoekt-sourcegraph-indexserver does not set Rank so at this point we
-			// treat Priority like star count and set it.
-			if repo.Rank == 0 && priority > 0 {
-				l := math.Log(float64(priority))
-				repo.Rank = uint16((1.0 - 1.0/math.Pow(1+l, 0.6)) * 10000)
-			}
 		}
 	}
 


### PR DESCRIPTION
The current code sets the repo rank of a `rankedShard`. However we don't read `rankedShard.repos` during evaluation, so setting the repo rank had no effect.

Now we set repo rank when we load the shard.

As a consequence, file matches receive a boost (shard-order) based on their shard's priority.
The effective contribution ranges from `[0, scoresShardRankFactor(=20)]`.


<img width="1879" alt="Screenshot 2022-11-14 at 12 56 58" src="https://user-images.githubusercontent.com/26413131/201654609-e0bbb43e-28e6-4518-9f97-316876a8469b.png">

