### PR TITLE
query: fix expandFileContent

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -653,18 +653,22 @@ func Map(q Q, f func(q Q) Q) Q {
 func ExpandFileContent(q Q) Q {
 	switch s := q.(type) {
 	case *Substring:
-		if !s.FileName && !s.Content {
+		if s.FileName == s.Content {
 			f := *s
 			f.FileName = true
+			f.Content = false
 			c := *s
+			c.FileName = false
 			c.Content = true
 			return NewOr(&f, &c)
 		}
 	case *Regexp:
-		if !s.FileName && !s.Content {
+		if s.FileName == s.Content {
 			f := *s
 			f.FileName = true
+			f.Content = false
 			c := *s
+			c.FileName = false
 			c.Content = true
 			return NewOr(&f, &c)
 		}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -17,6 +17,7 @@ package query
 import (
 	"log"
 	"reflect"
+	"regexp/syntax"
 	"testing"
 
 	"github.com/grafana/regexp"
@@ -109,5 +110,57 @@ func TestVisitAtoms(t *testing.T) {
 	})
 	if count != 3 {
 		t.Errorf("got %d, want 3", count)
+	}
+}
+
+func TestExpandFileContent(t *testing.T) {
+	re, _ := syntax.Parse("foo", syntax.Perl)
+
+	cases := []struct {
+		q    Q
+		want string
+	}{
+		{
+			q:    &Substring{FileName: true, Content: true},
+			want: "(or file_substr:\"\" content_substr:\"\")",
+		},
+		{
+			q:    &Substring{FileName: false, Content: false},
+			want: "(or file_substr:\"\" content_substr:\"\")",
+		},
+
+		{
+			q:    &Substring{FileName: true, Content: false},
+			want: "file_substr:\"\"",
+		},
+		{
+			q:    &Substring{FileName: false, Content: true},
+			want: "content_substr:\"\"",
+		},
+		{
+			q:    &Regexp{Regexp: re, FileName: true, Content: true},
+			want: "(or file_regex:\"foo\" regex:\"foo\")",
+		},
+		{
+			q:    &Regexp{Regexp: re, FileName: false, Content: false},
+			want: "(or file_regex:\"foo\" regex:\"foo\")",
+		},
+
+		{
+			q:    &Regexp{Regexp: re, FileName: true, Content: false},
+			want: "file_regex:\"foo\"",
+		},
+		{
+			q:    &Regexp{Regexp: re, FileName: false, Content: true},
+			want: "regex:\"foo\"",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run("", func(t *testing.T) {
+			if got := ExpandFileContent(tt.q); got.String() != tt.want {
+				t.Fatalf("got %s, want %s\n", got.String(), tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This fixes a bug where if s.FileName and s.Content were TRUE, we didn't expand and the resulting matchTree was implicitly matching filenames only.

Now we match content and filenames if s.Filename == s.Content.