### PR TITLE
debug: keep track of debug flag across searches

### DIFF
--- a/web/api.go
+++ b/web/api.go
@@ -31,6 +31,9 @@ type LastInput struct {
 
 	// If set, focus on the search box.
 	AutoFocus bool
+
+	// If true, the next search will run in debug mode.
+	Debug bool
 }
 
 // Result holds the data provided to the search results template.

--- a/web/server.go
+++ b/web/server.go
@@ -229,10 +229,7 @@ func (s *Server) serveSearch(w http.ResponseWriter, r *http.Request) {
 func (s *Server) serveSearchErr(r *http.Request) (*ApiSearchResult, error) {
 	qvals := r.URL.Query()
 
-	debugScore := false
-	if qvals.Get("debug") == "1" {
-		debugScore = true
-	}
+	debugScore, _ := strconv.ParseBool(qvals.Get("debug"))
 
 	queryStr := qvals.Get("q")
 	if queryStr == "" {
@@ -321,6 +318,8 @@ func (s *Server) serveSearchErr(r *http.Request) (*ApiSearchResult, error) {
 		// Suppress queueing stats if they are neglible.
 		res.Stats.Wait = 0
 	}
+
+	res.Last.Debug = debugScore
 	return &ApiSearchResult{Result: &res}, nil
 }
 

--- a/web/templates.go
+++ b/web/templates.go
@@ -118,6 +118,8 @@ var TemplateText = map[string]string{
             <input class="form-control" type="number" id="maxhits" name="num" value="{{.Num}}">
           </div>
           <button class="btn btn-primary">Search</button>
+          <!--Hack: we use a hidden form field to keep track of the debug flag across searches-->
+          {{if .Debug}}<input id="debug" name="debug" type="hidden" value="{{.Debug}}">{{end}}
         </div>
       </form>
     </div>


### PR DESCRIPTION
Previously it was a hassle to set the debug flag for every search while debugging. Now we keep track of the state so we only have to set it once.