### PR TITLE
indexserver: add debug endpoint for deleting repository shards

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -345,7 +345,6 @@ func removeAll(shards ...shard) {
 		paths, err := zoekt.IndexFilePaths(shard.Path)
 		if err != nil {
 			debug.Printf("failed to remove shard %s: %v", shard.Path, err)
-
 		}
 
 		for _, p := range paths {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -335,10 +335,7 @@ func removeAll(shards ...shard) {
 	// Deleting shards in reverse sorted order (2 -> 1 -> 0) always ensures that we don't leave an inconsistent
 	// state behind even if we crash.
 
-	var sortedShards []shard
-	for _, s := range shards {
-		sortedShards = append(sortedShards, s)
-	}
+	sortedShards := append([]shard{}, shards...)
 
 	sort.Slice(sortedShards, func(i, j int) bool {
 		return sortedShards[i].Path > sortedShards[j].Path

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -455,6 +455,127 @@ func TestCleanupCompoundShards(t *testing.T) {
 	}
 }
 
+func TestDeleteShards(t *testing.T) {
+	remainingRepoA := zoekt.Repository{ID: 1, Name: "A"}
+	remainingRepoB := zoekt.Repository{ID: 2, Name: "B"}
+	repositoryToDelete := zoekt.Repository{ID: 99, Name: "DELETE_ME"}
+
+	t.Run("delete repository from set of normal shards", func(t *testing.T) {
+		indexDir := t.TempDir()
+
+		// map of repoID -> list of associated shard paths + metadata paths
+		shardMap := make(map[uint32][]string)
+
+		// setup: create shards for each repository, and populate the shard map
+		for _, r := range []zoekt.Repository{
+			remainingRepoA,
+			remainingRepoB,
+			repositoryToDelete,
+		} {
+			shards := createTestNormalShard(t, indexDir, r, 3)
+
+			for _, shard := range shards {
+				// create stub meta file
+				metaFile := shard + ".meta"
+				f, err := os.Create(metaFile)
+				if err != nil {
+					t.Fatalf("creating metadata file %q: %s", metaFile, err)
+				}
+
+				f.Close()
+
+				shardMap[r.ID] = append(shardMap[r.ID], shard, metaFile)
+			}
+		}
+
+		// run test: delete repository
+		options := &build.Options{
+			IndexDir:              indexDir,
+			RepositoryDescription: repositoryToDelete,
+		}
+		options.SetDefaults()
+
+		err := deleteShards(options)
+		if err != nil {
+			t.Errorf("unexpected error when deleting shards: %s", err)
+		}
+
+		// run assertions: gather all the shards + meta files that remain and
+		// check to see that only the files associated with the "remaining" repositories
+		// are present
+		var actualShardFiles []string
+
+		for _, pattern := range []string{"*.zoekt", "*.meta"} {
+			files, err := filepath.Glob(filepath.Join(indexDir, pattern))
+			if err != nil {
+				t.Fatalf("globbing indexDir: %s", err)
+			}
+
+			actualShardFiles = append(actualShardFiles, files...)
+		}
+
+		var expectedShardFiles []string
+		expectedShardFiles = append(expectedShardFiles, shardMap[remainingRepoA.ID]...)
+		expectedShardFiles = append(expectedShardFiles, shardMap[remainingRepoB.ID]...)
+
+		sort.Strings(actualShardFiles)
+		sort.Strings(expectedShardFiles)
+
+		if diff := cmp.Diff(expectedShardFiles, actualShardFiles); diff != "" {
+			t.Errorf("unexpected diff in list of shard files (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("delete repository from compound shard", func(t *testing.T) {
+		indexDir := t.TempDir()
+
+		// setup: enable shard merging for compound shards
+		t.Setenv("SRC_ENABLE_SHARD_MERGING", "1")
+
+		// setup: create compound shard with all repositories
+		repositories := []zoekt.Repository{remainingRepoA, remainingRepoB, repositoryToDelete}
+		shard := createTestCompoundShard(t, indexDir, repositories)
+
+		// run test: delete repository
+		options := &build.Options{
+			IndexDir:              indexDir,
+			RepositoryDescription: repositoryToDelete,
+		}
+		options.SetDefaults()
+
+		err := deleteShards(options)
+		if err != nil {
+			t.Errorf("unexpected error when deleting shards: %s", err)
+		}
+
+		// verify: read the compound shard, and ensure that only
+		// the repositories that we expect are in the shard (and the deleted one has been tombstoned)
+		actualRepositories, _, err := zoekt.ReadMetadataPathAlive(shard)
+		if err != nil {
+			t.Fatalf("reading repository metadata from shard: %s", err)
+		}
+
+		expectedRepositories := []*zoekt.Repository{&remainingRepoA, &remainingRepoB}
+
+		sort.Slice(actualRepositories, func(i, j int) bool {
+			return actualRepositories[i].ID < actualRepositories[j].ID
+		})
+
+		sort.Slice(expectedRepositories, func(i, j int) bool {
+			return expectedRepositories[i].ID < expectedRepositories[j].ID
+		})
+
+		opts := []cmp.Option{
+			cmpopts.IgnoreUnexported(zoekt.Repository{}),
+			cmpopts.IgnoreFields(zoekt.Repository{}, "IndexOptions", "HasSymbols"),
+			cmpopts.EquateEmpty(),
+		}
+		if diff := cmp.Diff(expectedRepositories, actualRepositories, opts...); diff != "" {
+			t.Errorf("unexpected diff in list of repositories (-want +got):\n%s", diff)
+		}
+	})
+}
+
 // createCompoundShard returns a path to a compound shard containing repos with
 // ids. Use optsFns to overwrite fields of zoekt.Repository for all repos.
 func createCompoundShard(t *testing.T, dir string, ids []uint32, optFns ...func(in *zoekt.Repository)) string {

--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -95,6 +95,10 @@ func debugCmd() *ffcli.Command {
     "wget -q -O - http://localhost:6072/metrics -sS | grep index_shard_merging_running". It is only possible
     to trigger one merge operation at a time.
 
+  wget -q -O - http://localhost:6072/debug/delete?id=[REPOSITORY_ID]
+	delete all of the shards associated with the given repository id. You can find the id associated with a 
+	repository via the "/debug/indexed" route.
+  
   wget -q -O - http://localhost:6072/debug/queue
     list the repositories in the indexing queue, sorted by descending priority.
 

--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -96,8 +96,13 @@ func debugCmd() *ffcli.Command {
     to trigger one merge operation at a time.
 
   wget -q -O - http://localhost:6072/debug/delete?id=[REPOSITORY_ID]
-	delete all of the shards associated with the given repository id. You can find the id associated with a 
-	repository via the "/debug/indexed" route.
+	delete all of the shards associated with the given repository id. 
+	
+	You can find the id associated with a repository via the "/debug/indexed" route. 
+	If you need to delete multiple repositories at once, you can create a small shell pipeline. See the following example
+	(that removes the first listed repository from the ""/debug/indexed" route for inspiration):
+	
+	> wget -q -O - http://localhost:6072/debug/indexed | awk '{print $1}' | tail -n +2 | head -n 1 | xargs -I {} -- wget -q -O -  "http://localhost:6072/debug/delete?id={}"
   
   wget -q -O - http://localhost:6072/debug/queue
     list the repositories in the indexing queue, sorted by descending priority.

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -806,6 +806,9 @@ func (s *Server) handleDebugDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("repository id %q not found", rawID), http.StatusBadRequest)
 		return
 	}
+
+	_, _ = w.Write([]byte(fmt.Sprintf("deleted repository %q\n", rawID)))
+
 }
 
 func (s *Server) handleDebugIndexed(w http.ResponseWriter, r *http.Request) {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -4,18 +4,23 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	sglog "github.com/sourcegraph/log"
-	"github.com/sourcegraph/log/logtest"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	sglog "github.com/sourcegraph/log"
+	"github.com/sourcegraph/log/logtest"
+	"github.com/sourcegraph/zoekt/build"
 
 	"github.com/sourcegraph/zoekt"
 )
@@ -88,6 +93,127 @@ func TestListRepoIDs(t *testing.T) {
 	}
 }
 
+func TestDeleteShards(t *testing.T) {
+	remainingRepoA := zoekt.Repository{ID: 1, Name: "A"}
+	remainingRepoB := zoekt.Repository{ID: 2, Name: "B"}
+	repositoryToDelete := zoekt.Repository{ID: 99, Name: "DELETE_ME"}
+
+	t.Run("delete repository from set of normal shards", func(t *testing.T) {
+		indexDir := t.TempDir()
+
+		// map of repoID -> list of associated shard paths + metadata paths
+		shardMap := make(map[uint32][]string)
+
+		// setup: create shards for each repository, and populate the shard map
+		for _, r := range []zoekt.Repository{
+			remainingRepoA,
+			remainingRepoB,
+			repositoryToDelete,
+		} {
+			shards := createTestNormalShard(t, indexDir, r, 3)
+
+			for _, shard := range shards {
+				// create stub meta file
+				metaFile := shard + ".meta"
+				f, err := os.Create(metaFile)
+				if err != nil {
+					t.Fatalf("creating metadata file %q: %s", metaFile, err)
+				}
+
+				f.Close()
+
+				shardMap[r.ID] = append(shardMap[r.ID], shard, metaFile)
+			}
+		}
+
+		// run test: delete repository
+		options := &build.Options{
+			IndexDir:              indexDir,
+			RepositoryDescription: repositoryToDelete,
+		}
+		options.SetDefaults()
+
+		err := deleteShards(options)
+		if err != nil {
+			t.Errorf("unexpected error when deleting shards: %s", err)
+		}
+
+		// run assertions: gather all the shards + meta files that remain and
+		// check to see that only the files associated with the "remaining" repositories
+		// are present
+		var actualShardFiles []string
+
+		for _, pattern := range []string{"*.zoekt", "*.meta"} {
+			files, err := filepath.Glob(filepath.Join(indexDir, pattern))
+			if err != nil {
+				t.Fatalf("globbing indexDir: %s", err)
+			}
+
+			actualShardFiles = append(actualShardFiles, files...)
+		}
+
+		var expectedShardFiles []string
+		expectedShardFiles = append(expectedShardFiles, shardMap[remainingRepoA.ID]...)
+		expectedShardFiles = append(expectedShardFiles, shardMap[remainingRepoB.ID]...)
+
+		sort.Strings(actualShardFiles)
+		sort.Strings(expectedShardFiles)
+
+		if diff := cmp.Diff(expectedShardFiles, actualShardFiles); diff != "" {
+			t.Errorf("unexpected diff in list of shard files (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("delete repository from compound shard", func(t *testing.T) {
+		indexDir := t.TempDir()
+
+		// setup: enable shard merging for compound shards
+		t.Setenv("SRC_ENABLE_SHARD_MERGING", "1")
+
+		// setup: create compound shard with all repositories
+		repositories := []zoekt.Repository{remainingRepoA, remainingRepoB, repositoryToDelete}
+		shard := createTestCompoundShard(t, indexDir, repositories)
+
+		// run test: delete repository
+		options := &build.Options{
+			IndexDir:              indexDir,
+			RepositoryDescription: repositoryToDelete,
+		}
+		options.SetDefaults()
+
+		err := deleteShards(options)
+		if err != nil {
+			t.Errorf("unexpected error when deleting shards: %s", err)
+		}
+
+		// verify: read the compound shard, and ensure that only
+		// the repositories that we expect are in the shard (and the deleted one has been tombstoned)
+		actualRepositories, _, err := zoekt.ReadMetadataPathAlive(shard)
+		if err != nil {
+			t.Fatalf("reading repository metadata from shard: %s", err)
+		}
+
+		expectedRepositories := []*zoekt.Repository{&remainingRepoA, &remainingRepoB}
+
+		sort.Slice(actualRepositories, func(i, j int) bool {
+			return actualRepositories[i].ID < actualRepositories[j].ID
+		})
+
+		sort.Slice(expectedRepositories, func(i, j int) bool {
+			return expectedRepositories[i].ID < expectedRepositories[j].ID
+		})
+
+		opts := []cmp.Option{
+			cmpopts.IgnoreUnexported(zoekt.Repository{}),
+			cmpopts.IgnoreFields(zoekt.Repository{}, "IndexOptions", "HasSymbols"),
+			cmpopts.EquateEmpty(),
+		}
+		if diff := cmp.Diff(expectedRepositories, actualRepositories, opts...); diff != "" {
+			t.Errorf("unexpected diff in list of repositories (-want +got):\n%s", diff)
+		}
+	})
+}
+
 func TestListRepoIDs_Error(t *testing.T) {
 	msg := "deadbeaf deadbeaf"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -122,6 +248,109 @@ func TestMain(m *testing.M) {
 
 	logtest.InitWithLevel(m, level)
 	os.Exit(m.Run())
+}
+
+func createTestNormalShard(t *testing.T, indexDir string, r zoekt.Repository, numShards int, optFns ...func(options *build.Options)) []string {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(indexDir), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	o := build.Options{
+		IndexDir:              indexDir,
+		RepositoryDescription: r,
+		ShardMax:              75, // create a new shard every 75 bytes
+	}
+	o.SetDefaults()
+
+	for _, fn := range optFns {
+		fn(&o)
+	}
+
+	b, err := build.NewBuilder(o)
+	if err != nil {
+		t.Fatalf("NewBuilder: %v", err)
+	}
+
+	if numShards == 0 {
+		// We have to make at least 1 shard.
+		numShards = 1
+	}
+
+	for i := 0; i < numShards; i++ {
+		// Create entries (file + contents) that are ~100 bytes each.
+		// This (along with our shardMax setting of 75 bytes) means that each shard
+		// will contain at most one of these.
+		fileName := strconv.Itoa(i)
+		document := zoekt.Document{Name: fileName, Content: []byte(strings.Repeat("A", 100))}
+		for _, branch := range o.RepositoryDescription.Branches {
+			document.Branches = append(document.Branches, branch.Name)
+		}
+
+		err := b.Add(document)
+		if err != nil {
+			t.Fatalf("failed to add file %q to builder: %s", fileName, err)
+		}
+	}
+
+	if err := b.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	return o.FindAllShards()
+}
+
+func createTestCompoundShard(t *testing.T, indexDir string, repositories []zoekt.Repository, optFns ...func(options *build.Options)) string {
+	t.Helper()
+
+	var shardNames []string
+
+	for _, r := range repositories {
+		// create an isolated scratch space to store normal shards for this repository
+		scratchDir := t.TempDir()
+
+		// create shards that'll be merged later
+		createTestNormalShard(t, scratchDir, r, 1, optFns...)
+
+		// discover file names for all the normal shards we created
+		// note: this only looks in the immediate 'scratchDir' folder and doesn't recurse
+		shards, err := filepath.Glob(filepath.Join(scratchDir, "*.zoekt"))
+		if err != nil {
+			t.Fatalf("while globbing %q to find normal shards: %s", scratchDir, err)
+		}
+
+		shardNames = append(shardNames, shards...)
+	}
+
+	// load the normal shards that we created
+	var files []zoekt.IndexFile
+	for _, shard := range shardNames {
+		f, err := os.Open(shard)
+		if err != nil {
+			t.Fatalf("opening shard file: %s", err)
+		}
+		defer f.Close()
+
+		indexFile, err := zoekt.NewIndexFile(f)
+		if err != nil {
+			t.Fatalf("creating index file: %s", err)
+		}
+		defer indexFile.Close()
+
+		files = append(files, indexFile)
+	}
+
+	// merge all the simple shards into a compound shard
+	tmpName, dstName, err := zoekt.Merge(indexDir, files...)
+	if err != nil {
+		t.Fatalf("merging index files into compound shard: %s", err)
+	}
+	if err := os.Rename(tmpName, dstName); err != nil {
+		t.Fatal(err)
+	}
+
+	return dstName
 }
 
 func TestCreateEmptyShard(t *testing.T) {


### PR DESCRIPTION
This PR adds a new debug endpoint `/debug/delete?id=$REPO_ID`. When a user calls this URL, all the shards associated with this ID will be deleted (or tombstoned if they're in compound shards). 

Given the frequent [memory-map incidents](https://sourcegraph.slack.com/archives/C07KZF47K/p1668120346452419) that we had this this week, this PR should make it easier for users to recover when they're in this state. 

They should be able:

1. Grab a list of all IDs / repositories that are indexed on the instance:
	```bash
	wget -q -O - http://localhost:6072/debug/indexed                                                                                                                                              (base) 14:51:36
	ID              Name
	736075603       wut
	1309754292      whatever
	```
1. Extract some subset of repo ids via some method like `awk | tail/head`
	```bash
	wget -q -O - http://localhost:6072/debug/indexed | awk '{print $1}' | tail -n +2 | head -n 2                                                                                                  (base) 15:01:56
	736075603
	1309754292
	```
1. Pipe their chosen ids to this new debug route:
	```bash
	wget -q -O - http://localhost:6072/debug/indexed | awk '{print $1}' | tail -n +2 | head -n 2 | xargs -I {} -- wget -q -O -  "http://localhost:6072/debug/delete?id={}"
	```

This should also be useful for customers that want to try incremental indexing (and need a faster way to revert other than waiting for a new build). 

---

_(notes)_ 

- This PR still isn't final, I still need to add basic tests for `deleteShards`.

- I decided to put this logic entirely in `main.go`. This [logic is quite similar to the logic used in build/builder.go](https://sourcegraph.com/github.com/sourcegraph/zoekt/-/blob/build/builder.go?L759-777), but 
	- I didn't want to export this as a public function, I can't see anyone else needing to re-use this shard deletion logic (this debug endpoint should be the only user)
	- Builder has its own custom logic around shard deletion that's battle-tested (deleting shards only when it successfully finishes a new build). 
	
- I think the use of `build.Options` here isn't great. That object is so huge, and we ultimately only need the `indexDir`, `repoID`, and `repoName` out of it - everything else is irrelevant for this use case. I tried [experimenting](https://github.com/sourcegraph/zoekt/commit/aa80a5bc2c8fd3bb3cba7592bf0e965b24099415) with refactoring some of those interfaces, but I ended up just creating a bunch of [pass-through-methods](https://medium.com/@nathan.fooo/7-notes-different-layer-different-abstraction-fe0a64b04305) instead (from https://www.amazon.com/Philosophy-Software-Design-John-Ousterhout/dp/1732102201). What are your thoughts on this? Is it it worth the refactor? Can we create a smaller "options" object that doesn't have so many extraneous fields?




