### PR TITLE
indexserver: send port when updating index status

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -44,7 +44,7 @@ func TestGetIndexOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sg := newSourcegraphClient(u, "", 0)
+	sg := newSourcegraphClient(u, "", 0, 0)
 
 	cases := map[string]*IndexOptions{
 		`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"os/exec"
@@ -1189,7 +1190,11 @@ func newServer(conf rootConfig) (*Server, error) {
 			}
 		}
 
-		sg = newSourcegraphClient(rootURL, conf.hostname, batchSize)
+		var port uint16
+		if ipp, err := netip.ParseAddrPort(conf.listen); err == nil {
+			port = ipp.Port()
+		}
+		sg = newSourcegraphClient(rootURL, conf.hostname, port, batchSize)
 	} else {
 		sg = sourcegraphFake{
 			RootDir: rootURL.String(),

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1250,7 +1250,6 @@ func toPort(s string) (uint16, error) {
 
 	if i == -1 {
 		return 0, errors.New("no ip:port")
-
 	}
 
 	port := s[i+1:]

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -183,3 +183,65 @@ func TestFormatListUint32(t *testing.T) {
 		})
 	}
 }
+
+func TestToPort(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		want      uint16
+		wantError bool
+	}{
+		{
+			name: "no ip",
+			in:   ":1234",
+			want: 1234,
+		},
+		{
+			name: "ip6",
+			in:   "1b02:8071:b85:10:b13b:612a:86b0:8776:1234",
+			want: 1234,
+		},
+		{
+			name: "ip4",
+			in:   "127.0.0.1:1234",
+			want: 1234,
+		},
+		{
+			name: "any string",
+			in:   "localhost:1234",
+			want: 1234,
+		},
+		{
+			name:      "no port",
+			in:        "asdf:",
+			wantError: true,
+		},
+		{
+			name:      "no ip",
+			in:        "asdf",
+			wantError: true,
+		},
+		{
+			name:      "invalid port",
+			in:        "foo:bar",
+			wantError: true,
+		},
+		{
+			name:      "empty",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toPort(tt.in)
+			if err != nil && !tt.wantError {
+				t.Fatal(err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("want %d, got %d", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -27,7 +27,7 @@ func TestServer_defaultArgs(t *testing.T) {
 	}
 
 	s := &Server{
-		Sourcegraph: newSourcegraphClient(root, "", 0),
+		Sourcegraph: newSourcegraphClient(root, "", 0, 0),
 		IndexDir:    "/testdata/index",
 		CPUCount:    6,
 	}
@@ -70,7 +70,7 @@ func TestListRepoIDs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := newSourcegraphClient(u, "test-indexed-search-1", 0)
+	s := newSourcegraphClient(u, "test-indexed-search-1", 0, 0)
 
 	gotRepos, err := s.List(context.Background(), []uint32{1, 3})
 	if err != nil {
@@ -102,7 +102,7 @@ func TestListRepoIDs_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := newSourcegraphClient(u, "test-indexed-search-1", 0)
+	s := newSourcegraphClient(u, "test-indexed-search-1", 0, 0)
 	s.Client.RetryMax = 0
 
 	_, err = s.List(context.Background(), []uint32{1, 3})

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -125,8 +125,8 @@ type sourcegraphClient struct {
 	// list of repositories to index.
 	Hostname string
 
-	// Port is the port on which this indexserver listens. If the indexserver
-	// is not listening on any port, Port=0.
+	// Port is the port on which this indexserver is listening. Port=0 if the
+	// indexserver is not listening on any port.
 	Port uint16
 
 	// BatchSize is how many repository configurations we request at once. If


### PR DESCRIPTION
This is part of a bigger effort to add a reindex button to Sourcegraph's index status page. The first challenge is to map indexes/repos to "their" indexserver. Once we have a mapping index -> ip:port, we can easily trigger a reindex from frontend.

Design:
Indexserver already sends frontend an update every time it indexes a new version. With this PR we let indexserver send its port along with the repo status. Frontend can then extract the ip from the incoming request and associate the ip:port of the owning indexserver with each indexed repo. We could EG store the ip:port in the table "zoekt_repos" as a new column.