### PR TITLE
webserver: proxy requests to indexserver via socket

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1119,7 +1119,7 @@ func startServer(conf rootConfig) error {
 				log.Fatalf("failed to listen on socket: %s", err)
 			}
 			debug.Printf("serving HTTP on %s", socket)
-			log.Fatal(http.Serve(l, http.StripPrefix("/indexserver", mux)))
+			log.Fatal(http.Serve(l, mux))
 		}()
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -6,10 +6,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"html/template"
 	"io"
+	"io/fs"
 	"log"
 	"math"
 	"math/rand"
@@ -1107,9 +1109,11 @@ func startServer(conf rootConfig) error {
 		go func() {
 			socket := filepath.Join(s.IndexDir, "indexserver.sock")
 			// We cannot bind a socket to an existing pathname.
-			if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
+			if err := os.Remove(socket); err != nil && !errors.Is(err, fs.ErrNotExist) {
 				log.Fatalf("error removing socket file: %s", socket)
 			}
+			// The "unix" network corresponds to stream sockets. (cf. unixgram,
+			// unixpacket).
 			l, err := net.Listen("unix", socket)
 			if err != nil {
 				log.Fatalf("failed to listen on socket: %s", err)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1118,6 +1118,15 @@ func startServer(conf rootConfig) error {
 			if err != nil {
 				log.Fatalf("failed to listen on socket: %s", err)
 			}
+			// Indexserver (root) and webserver (Sourcegraph) run with
+			// different users. Per default, the socket is created with
+			// permission 755 (root root), which doesn't let webserver write to
+			// it.
+			//
+			// See https://github.com/golang/go/issues/11822 for more context.
+			if err := os.Chmod(socket, 0777); err != nil {
+				log.Fatalf("failed to change permission of socket %s: %s", socket, err)
+			}
 			debug.Printf("serving HTTP on %s", socket)
 			log.Fatal(http.Serve(l, mux))
 		}()

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -144,7 +144,7 @@ func main() {
 	index := flag.String("index", build.DefaultDir, "set index directory to use")
 	html := flag.Bool("html", true, "enable HTML interface")
 	enableRPC := flag.Bool("rpc", false, "enable go/net RPC")
-	enableSocketProxy := flag.Bool("socket", getEnvWithDefaultBool("SRC_ENABLE_SOCKET_PROXY", false), "proxy requests to /indexserver/ to <index dir>/indexserver.sock")
+	enableIndexserverProxy := flag.Bool("indexserver_proxy", getEnvWithDefaultBool("SRC_ENABLE_INDEXSERVER_PROXY", false), "proxy requests with URLs matching the path /indexserver/ to <index>/indexserver.sock")
 	print := flag.Bool("print", false, "enable local result URLs")
 	enablePprof := flag.Bool("pprof", false, "set to enable remote profiling.")
 	sslCert := flag.String("ssl_cert", "", "set path to SSL .pem holding certificate.")
@@ -259,7 +259,7 @@ func main() {
 
 	debugserver.AddHandlers(handler, *enablePprof)
 
-	if *enableSocketProxy {
+	if *enableIndexserverProxy {
 		socket := filepath.Join(*index, "indexserver.sock")
 		sglog.Scoped("server", "").Info("adding reverse proxy", sglog.String("socket", socket))
 		addProxyHandler(handler, socket)

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -318,9 +318,7 @@ func addProxyHandler(mux *http.ServeMux, socket string) {
 			return d.DialContext(ctx, "unix", socket)
 		},
 	}
-	mux.HandleFunc("/indexserver/", func(w http.ResponseWriter, r *http.Request) {
-		proxy.ServeHTTP(w, r)
-	})
+	mux.Handle("/indexserver/", http.StripPrefix("/indexserver/", http.HandlerFunc(proxy.ServeHTTP)))
 }
 
 // shutdownOnSignal will listen for SIGINT or SIGTERM and call

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -123,19 +123,6 @@ func writeTemplates(dir string) error {
 	return nil
 }
 
-func getEnvWithDefaultBool(k string, defaultVal bool) bool {
-	v := os.Getenv(k)
-	if v == "" {
-		return defaultVal
-	}
-
-	d, err := strconv.ParseBool(v)
-	if err != nil {
-		log.Fatalf("error parsing ENV %s to bool: %s", k, err)
-	}
-	return d
-}
-
 func main() {
 	logDir := flag.String("log_dir", "", "log to this directory rather than stderr.")
 	logRefresh := flag.Duration("log_refresh", 24*time.Hour, "if using --log_dir, start writing a new file this often.")
@@ -144,7 +131,7 @@ func main() {
 	index := flag.String("index", build.DefaultDir, "set index directory to use")
 	html := flag.Bool("html", true, "enable HTML interface")
 	enableRPC := flag.Bool("rpc", false, "enable go/net RPC")
-	enableIndexserverProxy := flag.Bool("indexserver_proxy", getEnvWithDefaultBool("SRC_ENABLE_INDEXSERVER_PROXY", false), "proxy requests with URLs matching the path /indexserver/ to <index>/indexserver.sock")
+	enableIndexserverProxy := flag.Bool("indexserver_proxy", false, "proxy requests with URLs matching the path /indexserver/ to <index>/indexserver.sock")
 	print := flag.Bool("print", false, "enable local result URLs")
 	enablePprof := flag.Bool("pprof", false, "set to enable remote profiling.")
 	sslCert := flag.String("ssl_cert", "", "set path to SSL .pem holding certificate.")


### PR DESCRIPTION
With this change, webserver proxies request to `<webserver>/indexserver/` to the unix domain socket at `<index dir>/indexserver.socket`. Since this is a Sourcegraph feature, we put the proxy handler in webserver behind a flag which is toggled off per default.

The motivation is to expose indexserver endpoints on webserver addresses, which in case of Sourcegraph, are easily accessible at runtime.

### Test Plan
- start webserver with flag `--indexserver_proxy`
- start indexserver
- inspect output from `curl http://localhost:6070/indexserver/`