### PR TITLE
docker: enable indexserver proxy for Sourcegraph's webserver

### DIFF
--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -22,4 +22,4 @@ COPY --from=zoekt /usr/local/bin/zoekt-webserver /usr/local/bin/
 ENV GOGC=25
 
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD zoekt-webserver -index $DATA_DIR -pprof -rpc
+CMD zoekt-webserver -index $DATA_DIR -pprof -rpc -indexserver_proxy


### PR DESCRIPTION
Relates to #487