### PR TITLE
shards: implement markReady on shardedSearcher

### DIFF
--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -65,19 +65,32 @@ func TestCrashResilience(t *testing.T) {
 	ss := newShardedSearcher(2)
 	ss.ranked.Store([]*rankedShard{{Searcher: &crashSearcher{}}})
 
-	q := &query.Substring{Pattern: "hoi"}
-	opts := &zoekt.SearchOptions{}
-	if res, err := ss.Search(context.Background(), q, opts); err != nil {
-		t.Fatalf("Search: %v", err)
-	} else if res.Stats.Crashes != 1 {
-		t.Errorf("got stats %#v, want crashes = 1", res.Stats)
+	var wantCrashes int
+	test := func(t *testing.T) {
+		q := &query.Substring{Pattern: "hoi"}
+		opts := &zoekt.SearchOptions{}
+		if res, err := ss.Search(context.Background(), q, opts); err != nil {
+			t.Fatalf("Search: %v", err)
+		} else if res.Stats.Crashes != wantCrashes {
+			t.Errorf("got stats %#v, want crashes = %d", res.Stats, wantCrashes)
+		}
+
+		if res, err := ss.List(context.Background(), q, nil); err != nil {
+			t.Fatalf("List: %v", err)
+		} else if res.Crashes != wantCrashes {
+			t.Errorf("got result %#v, want crashes = %d", res, wantCrashes)
+		}
 	}
 
-	if res, err := ss.List(context.Background(), q, nil); err != nil {
-		t.Fatalf("List: %v", err)
-	} else if res.Crashes != 1 {
-		t.Errorf("got result %#v, want crashes = 1", res)
-	}
+	// Before we are marked as ready we have one extra crash
+	wantCrashes = 2
+	t.Run("loading", test)
+
+	// After marking as ready we should only have the crashSearcher
+	// contributing.
+	ss.markReady()
+	wantCrashes = 1
+	t.Run("ready", test)
 }
 
 type rankSearcher struct {
@@ -376,6 +389,7 @@ func TestShardedSearcher_List(t *testing.T) {
 		"3": searcherForTest(t, testIndexBuilder(t, repos[1], doc)),
 		"4": searcherForTest(t, testIndexBuilder(t, repos[1])),
 	})
+	ss.markReady()
 
 	stats := zoekt.RepoStats{
 		Shards:                     2,


### PR DESCRIPTION
This is the final commit implementing a non-zero Crashes value while
shardedSearcher is startin up. This is meant to communicate when a zoekt
is partially available. When landed, Sourcegraph's APIs will communicate
that the user may have partial results and should retry.

Test Plan: go test. Additionally added a large sleep to loader.load to
simulate a slow startup. Then did searches in zoekt-webserver and
observed it returning non-zero crash counts until all shards loaded.

plz-review-url: https://plz.review/review/15657