### PR TITLE
log: different msg depending on ctx error

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -481,8 +481,16 @@ func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchO
 			sglog.Duration("opts.MaxWallTime", opts.MaxWallTime),
 			sglog.Int("opts.MaxDocDisplayCount", opts.MaxDocDisplayCount),
 		)
+
 	if err != nil {
-		logger.Error("search failed", sglog.Error(err))
+		switch err {
+		case context.Canceled:
+			logger.Error("search canceled", sglog.Error(err))
+		case context.DeadlineExceeded:
+			logger.Error("search timeout", sglog.Error(err))
+		default:
+			logger.Error("search failed", sglog.Error(err))
+		}
 		return
 	}
 

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"html/template"
@@ -483,10 +484,10 @@ func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchO
 		)
 
 	if err != nil {
-		switch err {
-		case context.Canceled:
+		switch {
+		case errors.Is(err, context.Canceled):
 			logger.Error("search canceled", sglog.Error(err))
-		case context.DeadlineExceeded:
+		case errors.Is(err, context.DeadlineExceeded):
 			logger.Error("search timeout", sglog.Error(err))
 		default:
 			logger.Error("search failed", sglog.Error(err))

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -486,9 +486,9 @@ func (s *loggedSearcher) log(ctx context.Context, q query.Q, opts *zoekt.SearchO
 	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled):
-			logger.Error("search canceled", sglog.Error(err))
+			logger.Warn("search canceled", sglog.Error(err))
 		case errors.Is(err, context.DeadlineExceeded):
-			logger.Error("search timeout", sglog.Error(err))
+			logger.Warn("search timeout", sglog.Error(err))
 		default:
 			logger.Error("search failed", sglog.Error(err))
 		}


### PR DESCRIPTION
Log a slightly different message depending on the err we get. This is mostly to destinguish that a context being cancelled does not mean the search failed.