### PR TITLE
Add a zoekt-dynamic-indexserver cmd with HTTP interface for indexing

### DIFF
--- a/cmd/zoekt-dynamic-indexserver/main.go
+++ b/cmd/zoekt-dynamic-indexserver/main.go
@@ -1,0 +1,252 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This program manages a zoekt dynamic indexing deployment:
+// * listens to indexing commands
+// * reindexes specified repositories
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+func loggedRun(cmd *exec.Cmd) error {
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
+
+	log.Printf("run %v", cmd.Args)
+	if err := cmd.Run(); err != nil {
+		log.Printf("command %s failed: %v\nOUT: %s\nERR: %s",
+			cmd.Args, err, outBuf.String(), errBuf.String())
+		return fmt.Errorf("command %s failed: %v", cmd.Args, err)
+	}
+
+	return nil
+}
+
+type Options struct {
+	indexTimeout time.Duration
+	dataDir      string
+	indexDir     string
+	repoDir      string
+	listen       string
+}
+
+func (o *Options) createMissingDirectories() {
+	for _, s := range []string{o.dataDir, o.indexDir, o.repoDir} {
+		if err := os.MkdirAll(s, 0o755); err != nil {
+			log.Fatalf("MkdirAll %s: %v", s, err)
+		}
+	}
+}
+
+type indexRequest struct {
+	CloneURL string // TODO: Decide if tokens can be in the URL or if we should pass separately
+	RepoID   uint32
+}
+
+// This function is declared as var so that we can stub it in test
+var executeCmd = func(ctx context.Context, name string, arg ...string) error {
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Stdin = &bytes.Buffer{}
+	err := loggedRun(cmd)
+
+	return err
+}
+
+func indexRepository(opts Options, req indexRequest) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), opts.indexTimeout)
+	defer cancel()
+
+	args := []string{}
+	args = append(args, "-dest", opts.repoDir)
+	args = append(args, "-name", strconv.FormatUint(uint64(req.RepoID), 10))
+	args = append(args, "-repoid", strconv.FormatUint(uint64(req.RepoID), 10))
+	args = append(args, req.CloneURL)
+	err := executeCmd(ctx, "zoekt-git-clone", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	gitRepoPath, err := filepath.Abs(filepath.Join(opts.repoDir, fmt.Sprintf("%d.git", req.RepoID)))
+	if err != nil {
+		return nil, err
+	}
+
+	args = []string{
+		"-C",
+		gitRepoPath,
+		"fetch",
+	}
+	err = executeCmd(ctx, "git", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	args = []string{
+		"-index", opts.indexDir,
+		gitRepoPath,
+	}
+	err = executeCmd(ctx, "zoekt-git-index", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	response := map[string]any{
+		"Success": true,
+	}
+
+	return response, nil
+}
+
+type indexServer struct {
+	opts Options
+}
+
+func (s *indexServer) serveIndex(w http.ResponseWriter, r *http.Request) {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	var req indexRequest
+	err := dec.Decode(&req)
+
+	if err != nil {
+		log.Printf("Error decoding index request: %v", err)
+		http.Error(w, "JSON parser error", http.StatusBadRequest)
+		return
+	}
+
+	response, err := indexRepository(s.opts, req)
+	if err != nil {
+		respondWithError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (s *indexServer) serveTruncate(w http.ResponseWriter, r *http.Request) {
+	err := emptyDirectory(s.opts.repoDir)
+
+	if err != nil {
+		err = fmt.Errorf("Failed to empty repoDir repoDir: %v with error: %v", s.opts.repoDir, err)
+
+		respondWithError(w, err)
+		return
+	}
+
+	err = emptyDirectory(s.opts.indexDir)
+
+	if err != nil {
+		err = fmt.Errorf("Failed to empty repoDir indexDir: %v with error: %v", s.opts.repoDir, err)
+
+		respondWithError(w, err)
+		return
+	}
+
+	response := map[string]any{
+		"Success": true,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func respondWithError(w http.ResponseWriter, err error) {
+	log.Print(err)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	response := map[string]any{
+		"Success": false,
+		"Error":   err.Error(),
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func (s *indexServer) startIndexingApi() {
+	http.HandleFunc("/index", s.serveIndex)
+	http.HandleFunc("/truncate", s.serveTruncate)
+
+	if err := http.ListenAndServe(s.opts.listen, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func emptyDirectory(dir string) error {
+	files, err := os.ReadDir(dir)
+
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		filePath := filepath.Join(dir, file.Name())
+		err := os.RemoveAll(filePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func parseOptions() Options {
+	dataDir := flag.String("data_dir", "", "directory holding all data.")
+	indexDir := flag.String("index_dir", "", "directory holding index shards. Defaults to $data_dir/index/")
+	timeout := flag.Duration("index_timeout", time.Hour, "kill index job after this much time")
+	listen := flag.String("listen", ":6060", "listen on this address.")
+	flag.Parse()
+
+	if *dataDir == "" {
+		log.Fatal("must set -data_dir")
+	}
+
+	if *indexDir == "" {
+		*indexDir = filepath.Join(*dataDir, "index")
+	}
+
+	return Options{
+		dataDir:      *dataDir,
+		repoDir:      filepath.Join(*dataDir, "repos"),
+		indexDir:     *indexDir,
+		indexTimeout: *timeout,
+		listen:       *listen,
+	}
+}
+
+func main() {
+	opts := parseOptions()
+	opts.createMissingDirectories()
+
+	server := indexServer{
+		opts: opts,
+	}
+
+	server.startIndexingApi()
+}

--- a/cmd/zoekt-dynamic-indexserver/main_test.go
+++ b/cmd/zoekt-dynamic-indexserver/main_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	cmdTimeout = 100 * time.Millisecond
+)
+
+func captureOutput(f func()) string {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer func() { log.SetOutput(os.Stderr) }()
+	f()
+	return buf.String()
+}
+
+func TestLoggedRun(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "echo", "-n", "1")
+
+	stdout := captureOutput(func() {
+		loggedRun(cmd)
+	})
+
+	if !strings.Contains(stdout, "run [echo -n 1]") {
+		t.Errorf("loggedRun output is incorrect: %v", stdout)
+	}
+}
+
+func TestLoggedRunFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "false")
+
+	stdout := captureOutput(func() {
+		loggedRun(cmd)
+	})
+
+	if !strings.Contains(stdout, "failed: exit status 1") {
+		t.Errorf("loggedRun output is incorrect: %v", stdout)
+	}
+}
+
+func TestIndexRepository(t *testing.T) {
+	var cmdHistory [][]string
+
+	executeCmd = func(ctx context.Context, name string, arg ...string) (err error) {
+		currentCmd := append([]string{name}, arg...)
+		cmdHistory = append(cmdHistory, currentCmd)
+
+		return
+	}
+
+	opts := Options{
+		indexTimeout: cmdTimeout,
+		repoDir:      "/repo_dir",
+		indexDir:     "/index_dir",
+	}
+
+	req := indexRequest{
+		CloneURL: "https://example.com/repository.git",
+		RepoID:   100,
+	}
+
+	_, err := indexRepository(opts, req)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedHistory := [][]string{
+		{"zoekt-git-clone", "-dest", "/repo_dir", "-name", "100", "-repoid", "100", "https://example.com/repository.git"},
+		{"git", "-C", "/repo_dir/100.git", "fetch"},
+		{"zoekt-git-index", "-index", "/index_dir", "/repo_dir/100.git"},
+	}
+
+	if !reflect.DeepEqual(cmdHistory, expectedHistory) {
+		t.Errorf("cmdHistory output is incorrect: %v, expected output: %v", cmdHistory, expectedHistory)
+	}
+}
+
+func TestIndexRepositoryWhenErr(t *testing.T) {
+	var cmdHistory [][]string
+
+	executeCmd = func(ctx context.Context, name string, arg ...string) (err error) {
+		currentCmd := append([]string{name}, arg...)
+		cmdHistory = append(cmdHistory, currentCmd)
+
+		if len(cmdHistory) > 1 {
+			return errors.New("command failed")
+		}
+
+		return
+	}
+
+	opts := Options{
+		indexTimeout: cmdTimeout,
+		repoDir:      "/repo_dir",
+		indexDir:     "/index_dir",
+	}
+
+	req := indexRequest{
+		CloneURL: "https://example.com/repository.git",
+		RepoID:   100,
+	}
+
+	_, err := indexRepository(opts, req)
+
+	if err == nil {
+		t.Errorf("Error is empty, when it should be present")
+	}
+
+	expectedHistory := [][]string{
+		{"zoekt-git-clone", "-dest", "/repo_dir", "-name", "100", "-repoid", "100", "https://example.com/repository.git"},
+		{"git", "-C", "/repo_dir/100.git", "fetch"},
+	}
+
+	if !reflect.DeepEqual(cmdHistory, expectedHistory) {
+		t.Errorf("cmdHistory output is incorrect: %v, expected output: %v", cmdHistory, expectedHistory)
+	}
+}

--- a/cmd/zoekt-git-clone/main.go
+++ b/cmd/zoekt-git-clone/main.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/zoekt/gitindex"
@@ -33,7 +34,7 @@ import (
 func main() {
 	dest := flag.String("dest", "", "destination directory")
 	nameFlag := flag.String("name", "", "name of repository")
-	repoIdFlag := flag.String("repoid", "", "id of repository")
+	repoIDFlag := flag.Uint("repoid", 0, "id of repository")
 	flag.Parse()
 
 	if *dest == "" {
@@ -53,16 +54,18 @@ func main() {
 		name = strings.TrimSuffix(name, ".git")
 	}
 
-	repoId := *repoIdFlag
-
 	destDir := filepath.Dir(filepath.Join(*dest, name))
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		log.Fatal(err)
 	}
 
 	config := map[string]string{
-		"zoekt.name":   name,
-		"zoekt.repoid": repoId,
+		"zoekt.name": name,
+	}
+
+	repoID := *repoIDFlag
+	if repoID != 0 {
+		config["zoekt.repoid"] = strconv.FormatUint(uint64(repoID), 10)
 	}
 
 	destRepo, err := gitindex.CloneRepo(destDir, filepath.Base(name), u.String(), config)

--- a/cmd/zoekt-git-clone/main.go
+++ b/cmd/zoekt-git-clone/main.go
@@ -32,6 +32,7 @@ import (
 
 func main() {
 	dest := flag.String("dest", "", "destination directory")
+	nameFlag := flag.String("name", "", "name of repository")
 	flag.Parse()
 
 	if *dest == "" {
@@ -45,8 +46,11 @@ func main() {
 		log.Fatalf("url.Parse: %v", err)
 	}
 
-	name := filepath.Join(u.Host, u.Path)
-	name = strings.TrimSuffix(name, ".git")
+	name := *nameFlag
+	if name == "" {
+		name = filepath.Join(u.Host, u.Path)
+		name = strings.TrimSuffix(name, ".git")
+	}
 
 	destDir := filepath.Dir(filepath.Join(*dest, name))
 	if err := os.MkdirAll(destDir, 0o755); err != nil {

--- a/cmd/zoekt-git-clone/main.go
+++ b/cmd/zoekt-git-clone/main.go
@@ -33,6 +33,7 @@ import (
 func main() {
 	dest := flag.String("dest", "", "destination directory")
 	nameFlag := flag.String("name", "", "name of repository")
+	repoIdFlag := flag.String("repoid", "", "id of repository")
 	flag.Parse()
 
 	if *dest == "" {
@@ -52,13 +53,16 @@ func main() {
 		name = strings.TrimSuffix(name, ".git")
 	}
 
+	repoId := *repoIdFlag
+
 	destDir := filepath.Dir(filepath.Join(*dest, name))
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
 		log.Fatal(err)
 	}
 
 	config := map[string]string{
-		"zoekt.name": name,
+		"zoekt.name":   name,
+		"zoekt.repoid": repoId,
 	}
 
 	destRepo, err := gitindex.CloneRepo(destDir, filepath.Base(name), u.String(), config)

--- a/cmd/zoekt-indexserver/main.go
+++ b/cmd/zoekt-indexserver/main.go
@@ -172,7 +172,7 @@ type indexRequest struct {
 	RepositoryId  string
 }
 
-func startIndexingApi(repoDir string, indexDir string, indexTimeout time.Duration) {
+func startIndexingApi(repoDir string, indexDir string, listen string, indexTimeout time.Duration) {
 	http.HandleFunc("/index", func(w http.ResponseWriter, r *http.Request) {
 		dec := json.NewDecoder(r.Body)
 		dec.DisallowUnknownFields()
@@ -238,7 +238,7 @@ func startIndexingApi(repoDir string, indexDir string, indexTimeout time.Duratio
 		}
 	})
 
-	if err := http.ListenAndServe(":6060", nil); err != nil {
+	if err := http.ListenAndServe(listen, nil); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -360,6 +360,7 @@ func main() {
 		filepath.Join(os.Getenv("HOME"), "zoekt-serving"), "directory holding all data.")
 	indexDir := flag.String("index_dir", "", "directory holding index shards. Defaults to $data_dir/index/")
 	dynamicIndexServer := flag.Bool("dynamic_server", false, "whether or not to start dynamic web server to allow client to specify repos to index dynamically")
+	listen := flag.String("listen", ":6060", "listen on this address.")
 	flag.Parse()
 	opts.validate()
 
@@ -389,7 +390,7 @@ func main() {
 	}
 
 	if *dynamicIndexServer {
-		startIndexingApi(repoDir, *indexDir, opts.indexTimeout)
+		startIndexingApi(repoDir, *indexDir, *listen, opts.indexTimeout)
 	} else {
 		_, err := readConfigURL(opts.mirrorConfigFile)
 		if err != nil {

--- a/cmd/zoekt-indexserver/main.go
+++ b/cmd/zoekt-indexserver/main.go
@@ -168,8 +168,8 @@ func indexPendingRepos(indexDir, repoDir string, opts *Options, repos <-chan str
 }
 
 type indexRequest struct {
-	RepositoryUrl  string // TODO: Decide if tokens can be in the URL or if we should pass separately
-	RepositoryName string
+	RepositoryUrl string // TODO: Decide if tokens can be in the URL or if we should pass separately
+	RepositoryId  string
 }
 
 func startIndexingApi(repoDir string, indexDir string, indexTimeout time.Duration) {
@@ -191,7 +191,8 @@ func startIndexingApi(repoDir string, indexDir string, indexTimeout time.Duratio
 
 		args := []string{}
 		args = append(args, "-dest", repoDir)
-		args = append(args, "-name", req.RepositoryName)
+		args = append(args, "-name", req.RepositoryId)
+		args = append(args, "-repoid", req.RepositoryId)
 		args = append(args, req.RepositoryUrl)
 		cmd := exec.CommandContext(ctx, "zoekt-git-clone", args...)
 		cmd.Stdin = &bytes.Buffer{}
@@ -199,9 +200,9 @@ func startIndexingApi(repoDir string, indexDir string, indexTimeout time.Duratio
 
 		args = []string{}
 
-		gitRepoPath, err := filepath.Abs(filepath.Join(repoDir, req.RepositoryName+".git"))
+		gitRepoPath, err := filepath.Abs(filepath.Join(repoDir, req.RepositoryId+".git"))
 		if err != nil {
-			log.Printf("Error loading git repo path: %v", err)
+			log.Printf("error loading git repo path: %v", err)
 			http.Error(w, "JSON parser error", http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
I'm trying to build an integration in GitLab for indexing code in Zoekt and querying it as a backend for our code search engine https://gitlab.com/gitlab-org/gitlab/-/merge_requests/105049 .

## Objectives

In my attempts to implement this I ran into a few features I would have liked to have:

1. I want the project name in Zoekt to be the `id` in the GitLab database so that I can efficiently filter to hundreds or thousands of project ids. Using the full project URL like `r:gitlab.com/gitlab-org/gitlab` results in very long regex strings to be parsed and even constructing a reliable regex to match this was kinda a mess. I'd actually prefer to update the webserver to take an array of ids as an argument so I don't need regexes at all but for now I've just implemented a way to pass the repository name to `zoekt-git-clone`
2. I want the client (GitLab) to control the indexing via push for efficiency (looping through and polling millions of repos seems too slow and wasteful) so I've added an API to the indexserver to allow me to tell it to index a repo
3. I want to control the rollout of which repos are indexed from the GitLab side so I want to pass in the repo URL to the indexserver so that it indexes this repo and this same endpoint can be used for updates
4. I want this endpoint to support local `.git` bare repos as well as remote `.git` URLs so that I can use this locally in tests to trigger indexing without having to run a webserver that can accept a `git clone` request. Luckily the `zoekt-git-clone` already does this so it worked without much effort but also this is part of the reason this needs to be push not pull because I don't want to run the git web server during tests

## Questions

This is a scrappy draft implementation and I'm trying to get early feedback on the direction here. A few questions I have:

1. Would you rather be discussing this in the context of an issue or is this PR an OK place for us to evaluate these objectives and iterate towards a solution?
1. Does a dynamic indexing API like this violate some other design goals of Zoekt? It moves from pull to push but it offers flexibility for deployment and testing environments as the client has full control over the index
2. Does this belong in indexserver, webserver or should it be extracted to another binary that wraps the executables it is calling?
3. I notice that there is a proxy from webserver -> sourcegraph-indexserver already implemented. Would it make sense instead to have indexserver listen on a socket and be proxied from webserver in the same way? It could use the same socket as sourcegraph-indexserver so it will just make that implementation more generic
4. What kind of tests are appropriate here? Lots of the `cmd` don't have tests yet. I could add to `web/e2e_test.go` or build something similar which is end-to-end of both indexing and web

I also recognise my Go code here is not great as I'm not really experienced but I'll probably get some more feedback from other Go experts before polishing this up but I wanted to see if the direction made sense first.

## Example usage:

```
$ zoekt-indexserver -data_dir zoekt/data -index_dir zoekt/index -dynamic_server
```

```
$ curl -XPOST -d '{"RepositoryUrl":"https://gitlab.com/gitlab-org/gitlab-elasticsearch-indexer.git","RepositoryId":"2953390"}' -H 'Content-Type: application/json' http://127.0.0.1:6060/index
```