### PR TITLE
Custom marshaller for RepoList

### DIFF
--- a/api.go
+++ b/api.go
@@ -769,6 +769,18 @@ type RepoList struct {
 	Stats RepoStats
 }
 
+// MarshalBinary implements a specialized encoder for FileNameSet.
+func (q *RepoList) MarshalBinary() ([]byte, error) {
+	return stringSetEncode(q.Minimal)
+}
+
+// UnmarshalBinary implements a specialized decoder for RepoList.
+func (q *RepoList) UnmarshalBinary(b []byte) error {
+	var err error
+	q.Minimal, err = stringSetDecode(b)
+	return err
+}
+
 type Searcher interface {
 	Search(ctx context.Context, q query.Q, opts *SearchOptions) (*SearchResult, error)
 

--- a/api.go
+++ b/api.go
@@ -754,31 +754,38 @@ type MinimalRepoListEntry struct {
 	Branches   []RepositoryBranch
 }
 
+type ReposMap map[uint32]MinimalRepoListEntry
+
+// MarshalBinary implements a specialized encoder for ReposMap.
+func (q ReposMap) MarshalBinary() ([]byte, error) {
+	return stringSetEncode(q)
+}
+
+// UnmarshalBinary implements a specialized decoder for ReposMap.
+func (q *ReposMap) UnmarshalBinary(b []byte) error {
+	var err error
+	(*q), err = stringSetDecode(b)
+	return err
+}
+
 // RepoList holds a set of Repository metadata.
 type RepoList struct {
-	// Full response to a List request. Returned when ListOptions.Minimal is false.
+	// Returned when ListOptions.Field is RepoListFieldRepos.
 	Repos []*RepoListEntry
 
-	Crashes int
+	// Returned when ListOptions.Field is RepoListFieldMinimal.
+	//
+	// Deprecated: use ReposMap.
+	Minimal map[uint32]*MinimalRepoListEntry
 
-	// Minimal response to a List request. Returned when ListOptions.Minimal is true.
-	Minimal map[uint32]MinimalRepoListEntry
+	// ReposMap is set when ListOptions.Field is RepoListFieldReposMap.
+	ReposMap map[uint32]MinimalRepoListEntry
+
+	Crashes int
 
 	// Stats response to a List request.
 	// This is the aggregate RepoStats of all repos matching the input query.
 	Stats RepoStats
-}
-
-// MarshalBinary implements a specialized encoder for FileNameSet.
-func (q *RepoList) MarshalBinary() ([]byte, error) {
-	return stringSetEncode(q.Minimal)
-}
-
-// UnmarshalBinary implements a specialized decoder for RepoList.
-func (q *RepoList) UnmarshalBinary(b []byte) error {
-	var err error
-	q.Minimal, err = stringSetDecode(b)
-	return err
 }
 
 type Searcher interface {
@@ -793,9 +800,35 @@ type Searcher interface {
 	String() string
 }
 
+type RepoListField int
+
+const (
+	RepoListFieldRepos    RepoListField = 0
+	RepoListFieldMinimal                = 1
+	RepoListFieldReposMap               = 2
+)
+
 type ListOptions struct {
 	// Return only Minimal data per repo that Sourcegraph frontend needs.
+	//
+	// Deprecated: use Field
 	Minimal bool
+
+	// Field decides which field to populate in RepoList response.
+	Field RepoListField
+}
+
+func (o *ListOptions) GetField() (RepoListField, error) {
+	if o == nil {
+		return RepoListFieldRepos, nil
+	}
+	if o.Field < 0 || o.Field > RepoListFieldReposMap {
+		return 0, fmt.Errorf("unknown RepoListField %d", o.Field)
+	}
+	if o.Minimal == true {
+		return RepoListFieldMinimal, nil
+	}
+	return o.Field, nil
 }
 
 func (o *ListOptions) String() string {

--- a/api.go
+++ b/api.go
@@ -757,14 +757,14 @@ type MinimalRepoListEntry struct {
 type ReposMap map[uint32]MinimalRepoListEntry
 
 // MarshalBinary implements a specialized encoder for ReposMap.
-func (q ReposMap) MarshalBinary() ([]byte, error) {
-	return stringSetEncode(q)
+func (q *ReposMap) MarshalBinary() ([]byte, error) {
+	return reposMapEncode(*q)
 }
 
 // UnmarshalBinary implements a specialized decoder for ReposMap.
 func (q *ReposMap) UnmarshalBinary(b []byte) error {
 	var err error
-	(*q), err = stringSetDecode(b)
+	(*q), err = reposMapDecode(b)
 	return err
 }
 
@@ -779,7 +779,7 @@ type RepoList struct {
 	Minimal map[uint32]*MinimalRepoListEntry
 
 	// ReposMap is set when ListOptions.Field is RepoListFieldReposMap.
-	ReposMap map[uint32]MinimalRepoListEntry
+	ReposMap ReposMap
 
 	Crashes int
 

--- a/api.go
+++ b/api.go
@@ -762,7 +762,7 @@ type RepoList struct {
 	Crashes int
 
 	// Minimal response to a List request. Returned when ListOptions.Minimal is true.
-	Minimal map[uint32]*MinimalRepoListEntry
+	Minimal map[uint32]MinimalRepoListEntry
 
 	// Stats response to a List request.
 	// This is the aggregate RepoStats of all repos matching the input query.

--- a/eval.go
+++ b/eval.go
@@ -611,7 +611,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 
 	minimal := opts != nil && opts.Minimal
 	if minimal {
-		l.Minimal = make(map[uint32]*MinimalRepoListEntry, len(d.repoListEntry))
+		l.Minimal = make(map[uint32]MinimalRepoListEntry, len(d.repoListEntry))
 	} else {
 		l.Repos = make([]*RepoListEntry, 0, len(d.repoListEntry))
 	}
@@ -627,7 +627,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 
 		l.Stats.Add(&rle.Stats)
 		if id := rle.Repository.ID; id != 0 && minimal {
-			l.Minimal[id] = &MinimalRepoListEntry{
+			l.Minimal[id] = MinimalRepoListEntry{
 				HasSymbols: rle.Repository.HasSymbols,
 				Branches:   rle.Repository.Branches,
 			}

--- a/index_test.go
+++ b/index_test.go
@@ -1766,7 +1766,7 @@ func TestListRepos(t *testing.T) {
 		}
 
 		want := &RepoList{
-			Minimal: map[uint32]MinimalRepoListEntry{
+			Minimal: map[uint32]*MinimalRepoListEntry{
 				repo.ID: {
 					HasSymbols: repo.HasSymbols,
 					Branches:   repo.Branches,

--- a/index_test.go
+++ b/index_test.go
@@ -1766,7 +1766,7 @@ func TestListRepos(t *testing.T) {
 		}
 
 		want := &RepoList{
-			Minimal: map[uint32]*MinimalRepoListEntry{
+			Minimal: map[uint32]MinimalRepoListEntry{
 				repo.ID: {
 					HasSymbols: repo.HasSymbols,
 					Branches:   repo.Branches,

--- a/marshal.go
+++ b/marshal.go
@@ -23,7 +23,7 @@ import (
 //     str(b.Version)
 
 // stringSetEncode implements an efficient encoder for map[string]struct{}.
-func stringSetEncode(minimal map[uint32]*MinimalRepoListEntry) ([]byte, error) {
+func stringSetEncode(minimal map[uint32]MinimalRepoListEntry) ([]byte, error) {
 	var b bytes.Buffer
 	var enc [binary.MaxVarintLen64]byte
 	varint := func(n int) {
@@ -78,7 +78,7 @@ func stringSetEncode(minimal map[uint32]*MinimalRepoListEntry) ([]byte, error) {
 }
 
 // stringSetDecode implements an efficient decoder for map[string]struct{}.
-func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
+func stringSetDecode(b []byte) (map[uint32]MinimalRepoListEntry, error) {
 	// binaryReader returns strings pointing into b to avoid allocations. We
 	// don't own b, so we create a copy of it.
 	r := binaryReader{b: append([]byte{}, b...)}
@@ -90,7 +90,7 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 
 	// Length
 	l := r.uvarint()
-	m := make(map[uint32]*MinimalRepoListEntry, l)
+	m := make(map[uint32]MinimalRepoListEntry, l)
 	allBranches := make([]RepositoryBranch, 0, l)
 
 	for i := 0; i < l; i++ {
@@ -104,7 +104,7 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 			})
 		}
 		branches := allBranches[len(allBranches)-lb:]
-		m[uint32(repoID)] = &MinimalRepoListEntry{
+		m[uint32(repoID)] = MinimalRepoListEntry{
 			HasSymbols: hasSymbols,
 			Branches:   branches,
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -25,6 +25,10 @@ import (
 
 // reposMapEncode implements an efficient encoder for ReposMap.
 func reposMapEncode(minimal ReposMap) ([]byte, error) {
+	if minimal == nil {
+		return nil, nil
+	}
+
 	var b bytes.Buffer
 	var enc [binary.MaxVarintLen64]byte
 	varint := func(n int) {
@@ -90,6 +94,11 @@ func reposMapEncode(minimal ReposMap) ([]byte, error) {
 
 // reposMapDecode implements an efficient decoder for map[string]struct{}.
 func reposMapDecode(b []byte) (ReposMap, error) {
+	// nil input
+	if len(b) == 0 {
+		return nil, nil
+	}
+
 	// binaryReader returns strings pointing into b to avoid allocations. We
 	// don't own b, so we create a copy of it.
 	r := binaryReader{b: append([]byte{}, b...)}

--- a/marshal.go
+++ b/marshal.go
@@ -1,0 +1,167 @@
+package zoekt
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/RoaringBitmap/roaring"
+)
+
+// Wire-format of map[uint32]*MinimalRepoListEntry is pretty straightforward:
+//
+// byte(1) version
+// uvarint(len(minimal))
+// for repoID, entry in minimal:
+//   uvarint(repoID)
+//   byte(entry.HasSymbols)
+//   uvarint(len(entry.Branches))
+//   for b in entry.Branches:
+//     str(b.Name)
+//     str(b.Version)
+
+// stringSetEncode implements an efficient encoder for map[string]struct{}.
+func stringSetEncode(minimal map[uint32]*MinimalRepoListEntry) ([]byte, error) {
+	var b bytes.Buffer
+	var enc [binary.MaxVarintLen64]byte
+	varint := func(n int) {
+		m := binary.PutUvarint(enc[:], uint64(n))
+		b.Write(enc[:m])
+	}
+	str := func(s string) {
+		varint(len(s))
+		b.WriteString(s)
+	}
+	strSize := func(s string) int {
+		return binary.PutUvarint(enc[:], uint64(len(s))) + len(s)
+	}
+
+	// Calculate size
+	size := 1 // version
+	size += binary.PutUvarint(enc[:], uint64(len(minimal)))
+	for repoID, entry := range minimal {
+		size += binary.PutUvarint(enc[:], uint64(repoID))
+		size += 1 // HasSymbols
+		size += binary.PutUvarint(enc[:], uint64(len(entry.Branches)))
+		for _, b := range entry.Branches {
+			size += strSize(b.Name)
+			size += strSize(b.Version)
+		}
+	}
+	b.Grow(size)
+
+	// Version
+	b.WriteByte(1)
+
+	// Length
+	varint(len(minimal))
+
+	for repoID, entry := range minimal {
+		varint(int(repoID))
+
+		hasSymbols := byte(1)
+		if !entry.HasSymbols {
+			hasSymbols = 0
+		}
+		b.WriteByte(hasSymbols)
+
+		varint(len(entry.Branches))
+		for _, b := range entry.Branches {
+			str(b.Name)
+			str(b.Version)
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+// stringSetDecode implements an efficient decoder for map[string]struct{}.
+func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
+	// binaryReader returns strings pointing into b to avoid allocations. We
+	// don't own b, so we create a copy of it.
+	r := binaryReader{b: append([]byte{}, b...)}
+
+	// Version
+	if v := r.byt(); v != 1 {
+		return nil, fmt.Errorf("unsupported stringSet encoding version %d", v)
+	}
+
+	// Length
+	l := r.uvarint()
+	m := make(map[uint32]*MinimalRepoListEntry, l)
+
+	for i := 0; i < l; i++ {
+		repoID := r.uvarint()
+		hasSymbols := r.byt() == 1
+		lb := r.uvarint()
+		branches := make([]RepositoryBranch, lb)
+		for i := range branches {
+			branches[i].Name = r.str()
+			branches[i].Version = r.str()
+		}
+		m[uint32(repoID)] = &MinimalRepoListEntry{
+			HasSymbols: hasSymbols,
+			Branches:   branches,
+		}
+	}
+
+	return m, r.err
+}
+
+type binaryReader struct {
+	b   []byte
+	err error
+}
+
+func (b *binaryReader) uvarint() int {
+	x, n := binary.Uvarint(b.b)
+	if n < 0 {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return 0
+	}
+	b.b = b.b[n:]
+	return int(x)
+}
+
+func (b *binaryReader) str() string {
+	l := b.uvarint()
+	if l > len(b.b) {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return ""
+	}
+	s := b2s(b.b[:l])
+	b.b = b.b[l:]
+	return s
+}
+
+func (b *binaryReader) bitmap() *roaring.Bitmap {
+	l := b.uvarint()
+	if l > len(b.b) {
+		b.b = nil
+		b.err = errors.New("malformed BranchRepos")
+		return nil
+	}
+	r := roaring.New()
+	_, b.err = r.FromBuffer(b.b[:l])
+	b.b = b.b[l:]
+	return r
+}
+
+func (b *binaryReader) byt() byte {
+	if len(b.b) < 1 {
+		b.b = nil
+		b.err = errors.New("malformed RepoBranches")
+		return 0
+	}
+	x := b.b[0]
+	b.b = b.b[1:]
+	return x
+}
+
+func b2s(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/marshal.go
+++ b/marshal.go
@@ -91,16 +91,19 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 	// Length
 	l := r.uvarint()
 	m := make(map[uint32]*MinimalRepoListEntry, l)
+	allBranches := make([]RepositoryBranch, 0, l)
 
 	for i := 0; i < l; i++ {
 		repoID := r.uvarint()
 		hasSymbols := r.byt() == 1
 		lb := r.uvarint()
-		branches := make([]RepositoryBranch, lb)
-		for i := range branches {
-			branches[i].Name = r.str()
-			branches[i].Version = r.str()
+		for i := 0; i < lb; i++ {
+			allBranches = append(allBranches, RepositoryBranch{
+				Name:    r.str(),
+				Version: r.str(),
+			})
 		}
+		branches := allBranches[len(allBranches)-lb:]
 		m[uint32(repoID)] = &MinimalRepoListEntry{
 			HasSymbols: hasSymbols,
 			Branches:   branches,

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -65,7 +65,7 @@ func TestRepoList_Marshal(t *testing.T) {
 		}
 
 		if diff := cmp.Diff(want, &got); diff != "" {
-			t.Fatalf("mismatch for set size %d (-want +got):\n%s", i, diff)
+			t.Fatalf("mismatch for reposmap size %d (-want +got):\n%s", i, diff)
 		}
 	}
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -71,9 +71,9 @@ func TestRepoList_Marshal(t *testing.T) {
 }
 
 func genRepoList(size int) *RepoList {
-	set := make(map[uint32]*MinimalRepoListEntry, size)
+	set := make(map[uint32]MinimalRepoListEntry, size)
 	for i := 0; i < size; i++ {
-		set[uint32(i)] = &MinimalRepoListEntry{
+		set[uint32(i)] = MinimalRepoListEntry{
 			HasSymbols: true,
 			Branches: []RepositoryBranch{{
 				Name:    "HEAD",

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,0 +1,94 @@
+package zoekt
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func BenchmarkRepoList_Encode(b *testing.B) {
+	set := genRepoList(1000)
+
+	// do one write to amortize away the cost of gob registration
+	w := &countWriter{}
+	enc := gob.NewEncoder(w)
+	if err := enc.Encode(set); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.ReportMetric(float64(w.n), "bytes")
+
+	for n := 0; n < b.N; n++ {
+		if err := enc.Encode(set); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRepoList_Decode(b *testing.B) {
+	set := genRepoList(1000)
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(set); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		// We need to include gob.NewDecoder cost to avoid measuring encoding.
+		var repoBranches RepoList
+		if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&repoBranches); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestRepoList_Marshal(t *testing.T) {
+	for i := range []int{0, 1, 10, 100} {
+		want := genRepoList(i)
+
+		var buf bytes.Buffer
+		if err := gob.NewEncoder(&buf).Encode(want); err != nil {
+			t.Fatal(err)
+		}
+
+		var got RepoList
+		if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(want, &got); diff != "" {
+			t.Fatalf("mismatch for set size %d (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
+func genRepoList(size int) *RepoList {
+	set := make(map[uint32]*MinimalRepoListEntry, size)
+	for i := 0; i < size; i++ {
+		set[uint32(i)] = &MinimalRepoListEntry{
+			HasSymbols: true,
+			Branches: []RepositoryBranch{{
+				Name:    "HEAD",
+				Version: "c301e5c82b6e1632dce5c39902691c359559852e",
+			}},
+		}
+	}
+	return &RepoList{Minimal: set}
+}
+
+type countWriter struct {
+	n int
+}
+
+func (w *countWriter) Write(b []byte) (int, error) {
+	w.n += len(b)
+	return len(b), nil
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -71,9 +71,9 @@ func TestRepoList_Marshal(t *testing.T) {
 }
 
 func genRepoList(size int) *RepoList {
-	set := make(map[uint32]MinimalRepoListEntry, size)
+	m := make(ReposMap, size)
 	for i := 0; i < size; i++ {
-		set[uint32(i)] = MinimalRepoListEntry{
+		m[uint32(i)] = MinimalRepoListEntry{
 			HasSymbols: true,
 			Branches: []RepositoryBranch{{
 				Name:    "HEAD",
@@ -81,7 +81,7 @@ func genRepoList(size int) *RepoList {
 			}},
 		}
 	}
-	return &RepoList{Minimal: set}
+	return &RepoList{ReposMap: m}
 }
 
 type countWriter struct {

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/internal/mockSearcher"
 	"github.com/sourcegraph/zoekt/query"
@@ -61,8 +63,8 @@ func TestClientServer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(l, mock.RepoList) {
-		t.Fatalf("got %+v, want %+v", l, mock.RepoList)
+	if d := cmp.Diff(mock.RepoList, l, cmpopts.IgnoreUnexported(zoekt.Repository{})); d != "" {
+		t.Fatalf("unexpected RepoList (-want, +got):\n%s", d)
 	}
 
 	// Test closing a client we never dial.

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -920,7 +920,7 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 
 	agg := zoekt.RepoList{
 		Crashes: stillLoadingCrashes,
-		Minimal: map[uint32]*zoekt.MinimalRepoListEntry{},
+		Minimal: map[uint32]zoekt.MinimalRepoListEntry{},
 	}
 
 	uniq := map[string]*zoekt.RepoListEntry{}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -919,8 +919,9 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 	}
 
 	agg := zoekt.RepoList{
-		Crashes: stillLoadingCrashes,
-		Minimal: map[uint32]zoekt.MinimalRepoListEntry{},
+		Crashes:  stillLoadingCrashes,
+		Minimal:  map[uint32]*zoekt.MinimalRepoListEntry{},
+		ReposMap: zoekt.ReposMap{},
 	}
 
 	uniq := map[string]*zoekt.RepoListEntry{}
@@ -950,6 +951,10 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 				agg.Minimal[id] = r
 			}
 		}
+
+		for id, r := range r.rl.ReposMap {
+			agg.ReposMap[id] = r
+		}
 	}
 
 	agg.Repos = make([]*zoekt.RepoListEntry, 0, len(uniq))
@@ -957,8 +962,7 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 		agg.Repos = append(agg.Repos, r)
 	}
 
-	isMinimal := opts != nil && opts.Minimal
-	if isAll && !isMinimal {
+	if isAll && len(agg.Repos) > 0 {
 		reportListAllMetrics(agg.Repos)
 	}
 

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -453,7 +453,7 @@ func TestShardedSearcher_List(t *testing.T) {
 						Stats:      stats,
 					},
 				},
-				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+				Minimal: map[uint32]zoekt.MinimalRepoListEntry{
 					repos[0].ID: {
 						HasSymbols: repos[0].HasSymbols,
 						Branches:   repos[0].Branches,

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -453,7 +453,62 @@ func TestShardedSearcher_List(t *testing.T) {
 						Stats:      stats,
 					},
 				},
-				Minimal: map[uint32]zoekt.MinimalRepoListEntry{
+				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+					repos[0].ID: {
+						HasSymbols: repos[0].HasSymbols,
+						Branches:   repos[0].Branches,
+					},
+				},
+				Stats: aggStats,
+			},
+		},
+		{
+			name: "field=repos",
+			opts: &zoekt.ListOptions{Field: zoekt.RepoListFieldRepos},
+			want: &zoekt.RepoList{
+				Repos: []*zoekt.RepoListEntry{
+					{
+						Repository: *repos[0],
+						Stats:      stats,
+					},
+					{
+						Repository: *repos[1],
+						Stats:      stats,
+					},
+				},
+				Stats: aggStats,
+			},
+		},
+		{
+			name: "field=minimal",
+			opts: &zoekt.ListOptions{Field: zoekt.RepoListFieldMinimal},
+			want: &zoekt.RepoList{
+				Repos: []*zoekt.RepoListEntry{
+					{
+						Repository: *repos[1],
+						Stats:      stats,
+					},
+				},
+				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+					repos[0].ID: {
+						HasSymbols: repos[0].HasSymbols,
+						Branches:   repos[0].Branches,
+					},
+				},
+				Stats: aggStats,
+			},
+		},
+		{
+			name: "field=reposmap",
+			opts: &zoekt.ListOptions{Field: zoekt.RepoListFieldReposMap},
+			want: &zoekt.RepoList{
+				Repos: []*zoekt.RepoListEntry{
+					{
+						Repository: *repos[1],
+						Stats:      stats,
+					},
+				},
+				ReposMap: zoekt.ReposMap{
 					repos[0].ID: {
 						HasSymbols: repos[0].HasSymbols,
 						Branches:   repos[0].Branches,


### PR DESCRIPTION
Currently taking up 90% of object allocations for sg. This commit reduces that by 90%. The next step we can take is instead of returning a map we use a slice.

```
name               old time/op    new time/op    delta
RepoList_Encode-8     166µs ± 4%      84µs ± 3%    -49.12%  (p=0.000 n=10+10)
RepoList_Decode-8     519µs ± 2%     148µs ± 1%    -71.46%  (p=0.000 n=10+10)

name               old bytes      new bytes      delta
RepoList_Encode-8    57.8kB ± 0%    51.1kB ± 0%    -11.66%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
RepoList_Encode-8    4.06kB ± 0%   57.34kB ± 0%  +1311.02%  (p=0.000 n=10+10)
RepoList_Decode-8     316kB ± 0%     259kB ± 0%    -17.96%  (p=0.000 n=10+7)

name               old allocs/op  new allocs/op  delta
RepoList_Encode-8     1.00k ± 0%     0.00k ± 0%    -99.90%  (p=0.000 n=10+10)
RepoList_Decode-8     6.59k ± 0%     0.59k ± 0%    -91.09%  (p=0.000 n=10+10)
```

Test Plan: go test

Co-authored-by: @burmudar
Co-authored-by: @camdencheek 