### PR TITLE
reduce branch allocations

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -91,16 +91,19 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 	// Length
 	l := r.uvarint()
 	m := make(map[uint32]*MinimalRepoListEntry, l)
+	allBranches := make([]RepositoryBranch, 0, l)
 
 	for i := 0; i < l; i++ {
 		repoID := r.uvarint()
 		hasSymbols := r.byt() == 1
 		lb := r.uvarint()
-		branches := make([]RepositoryBranch, lb)
-		for i := range branches {
-			branches[i].Name = r.str()
-			branches[i].Version = r.str()
+		for i := 0; i < lb; i++ {
+			allBranches = append(allBranches, RepositoryBranch{
+				Name:    r.str(),
+				Version: r.str(),
+			})
 		}
+		branches := allBranches[len(allBranches)-lb:]
 		m[uint32(repoID)] = &MinimalRepoListEntry{
 			HasSymbols: hasSymbols,
 			Branches:   branches,


### PR DESCRIPTION
This reduces allocations for the branch lists by collecting all branches into the same slice, then creating MinimalRepoListEntry with a subslices of that. This reduces the number of allocations for branches from one per repo to roughly two for all repos. For the benchmark, this comes out to a 43% decrease in the number of allocations.

The minimal increase in allocated bytes probably comes from the fact that we will likely slightly overallocate the `allBranches` slice when it grows. Previously, we would allocate exactly the right number of bytes because we knew the size of the branches slices exactly as we were allocating.

Stacked on #498. Benchmarks are relative to #498.

```
❯ benchstat -alpha 0.05 /tmp/before.txt /tmp/after.txt
name                old time/op    new time/op    delta
RepoList_Decode-10     100µs ± 0%      86µs ± 1%  -14.51%  (p=0.000 n=9+9)

name                old alloc/op   new alloc/op   delta
RepoList_Decode-10     223kB ± 0%     224kB ± 0%   +0.34%  (p=0.000 n=10+8)

name                old allocs/op  new allocs/op  delta
RepoList_Decode-10     2.31k ± 0%     1.31k ± 0%  -43.21%  (p=0.000 n=10+10)
```