### PR TITLE
reduce allocations by using values rather than pointers

### DIFF
--- a/api.go
+++ b/api.go
@@ -762,7 +762,7 @@ type RepoList struct {
 	Crashes int
 
 	// Minimal response to a List request. Returned when ListOptions.Minimal is true.
-	Minimal map[uint32]*MinimalRepoListEntry
+	Minimal map[uint32]MinimalRepoListEntry
 
 	// Stats response to a List request.
 	// This is the aggregate RepoStats of all repos matching the input query.

--- a/eval.go
+++ b/eval.go
@@ -611,7 +611,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 
 	minimal := opts != nil && opts.Minimal
 	if minimal {
-		l.Minimal = make(map[uint32]*MinimalRepoListEntry, len(d.repoListEntry))
+		l.Minimal = make(map[uint32]MinimalRepoListEntry, len(d.repoListEntry))
 	} else {
 		l.Repos = make([]*RepoListEntry, 0, len(d.repoListEntry))
 	}
@@ -627,7 +627,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 
 		l.Stats.Add(&rle.Stats)
 		if id := rle.Repository.ID; id != 0 && minimal {
-			l.Minimal[id] = &MinimalRepoListEntry{
+			l.Minimal[id] = MinimalRepoListEntry{
 				HasSymbols: rle.Repository.HasSymbols,
 				Branches:   rle.Repository.Branches,
 			}

--- a/index_test.go
+++ b/index_test.go
@@ -1766,7 +1766,7 @@ func TestListRepos(t *testing.T) {
 		}
 
 		want := &RepoList{
-			Minimal: map[uint32]*MinimalRepoListEntry{
+			Minimal: map[uint32]MinimalRepoListEntry{
 				repo.ID: {
 					HasSymbols: repo.HasSymbols,
 					Branches:   repo.Branches,

--- a/marshal.go
+++ b/marshal.go
@@ -23,7 +23,7 @@ import (
 //     str(b.Version)
 
 // stringSetEncode implements an efficient encoder for map[string]struct{}.
-func stringSetEncode(minimal map[uint32]*MinimalRepoListEntry) ([]byte, error) {
+func stringSetEncode(minimal map[uint32]MinimalRepoListEntry) ([]byte, error) {
 	var b bytes.Buffer
 	var enc [binary.MaxVarintLen64]byte
 	varint := func(n int) {
@@ -78,7 +78,7 @@ func stringSetEncode(minimal map[uint32]*MinimalRepoListEntry) ([]byte, error) {
 }
 
 // stringSetDecode implements an efficient decoder for map[string]struct{}.
-func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
+func stringSetDecode(b []byte) (map[uint32]MinimalRepoListEntry, error) {
 	// binaryReader returns strings pointing into b to avoid allocations. We
 	// don't own b, so we create a copy of it.
 	r := binaryReader{b: append([]byte{}, b...)}
@@ -90,7 +90,7 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 
 	// Length
 	l := r.uvarint()
-	m := make(map[uint32]*MinimalRepoListEntry, l)
+	m := make(map[uint32]MinimalRepoListEntry, l)
 	allBranches := make([]RepositoryBranch, 0, l)
 
 	for i := 0; i < l; i++ {
@@ -104,7 +104,7 @@ func stringSetDecode(b []byte) (map[uint32]*MinimalRepoListEntry, error) {
 			})
 		}
 		branches := allBranches[len(allBranches)-lb:]
-		m[uint32(repoID)] = &MinimalRepoListEntry{
+		m[uint32(repoID)] = MinimalRepoListEntry{
 			HasSymbols: hasSymbols,
 			Branches:   branches,
 		}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -71,9 +71,9 @@ func TestRepoList_Marshal(t *testing.T) {
 }
 
 func genRepoList(size int) *RepoList {
-	set := make(map[uint32]*MinimalRepoListEntry, size)
+	set := make(map[uint32]MinimalRepoListEntry, size)
 	for i := 0; i < size; i++ {
-		set[uint32(i)] = &MinimalRepoListEntry{
+		set[uint32(i)] = MinimalRepoListEntry{
 			HasSymbols: true,
 			Branches: []RepositoryBranch{{
 				Name:    "HEAD",

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -920,7 +920,7 @@ func (ss *shardedSearcher) List(ctx context.Context, r query.Q, opts *zoekt.List
 
 	agg := zoekt.RepoList{
 		Crashes: stillLoadingCrashes,
-		Minimal: map[uint32]*zoekt.MinimalRepoListEntry{},
+		Minimal: map[uint32]zoekt.MinimalRepoListEntry{},
 	}
 
 	uniq := map[string]*zoekt.RepoListEntry{}

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -453,7 +453,7 @@ func TestShardedSearcher_List(t *testing.T) {
 						Stats:      stats,
 					},
 				},
-				Minimal: map[uint32]*zoekt.MinimalRepoListEntry{
+				Minimal: map[uint32]zoekt.MinimalRepoListEntry{
 					repos[0].ID: {
 						HasSymbols: repos[0].HasSymbols,
 						Branches:   repos[0].Branches,


### PR DESCRIPTION
This reduces allocations even further by using values of MinimalRepoListEntry in the map rather than pointers. This reduces the number of allocations for decoding by another 76%. It slightly increases the allocated bytes because we copy the structs rather than pointers, and the structs are slightly larger.

Note that this is a change to the public API, so it is not an invisible change to the client. We would need to make a parallel change in Sourcegraph to consume the new minimal list type.

Stacked on #499. The benchmarks are relative to #499. 

```
❯ benchstat -alpha 0.05 /tmp/before.txt /tmp/after.txt
name                               old time/op    new time/op    delta
MinimalRepoListEncodings/slice-10    1.17ms ± 0%    1.19ms ± 1%   +1.52%  (p=0.000 n=10+10)
MinimalRepoListEncodings/map-10      1.48ms ± 0%    1.49ms ± 1%   +0.92%  (p=0.000 n=10+10)
RepoList_Encode-10                   55.5µs ± 0%    55.4µs ± 0%     ~     (p=0.063 n=9+9)
RepoList_Decode-10                   85.5µs ± 0%    74.7µs ± 1%  -12.68%  (p=0.000 n=10+9)

name                               old bytes      new bytes      delta
MinimalRepoListEncodings/slice-10     754kB ± 0%     754kB ± 0%     ~     (all equal)
MinimalRepoListEncodings/map-10       741kB ± 0%     741kB ± 0%     ~     (all equal)
RepoList_Encode-10                   50.9kB ± 0%    50.9kB ± 0%     ~     (all equal)

name                               old alloc/op   new alloc/op   delta
MinimalRepoListEncodings/slice-10    1.47kB ± 0%    1.49kB ± 0%   +1.27%  (p=0.000 n=9+9)
MinimalRepoListEncodings/map-10      53.8kB ± 0%    53.9kB ± 0%   +0.03%  (p=0.013 n=10+10)
RepoList_Encode-10                   57.3kB ± 0%    57.3kB ± 0%     ~     (all equal)
RepoList_Decode-10                    224kB ± 0%     249kB ± 0%  +11.32%  (p=0.000 n=10+10)

name                               old allocs/op  new allocs/op  delta
MinimalRepoListEncodings/slice-10      0.00           0.00          ~     (all equal)
MinimalRepoListEncodings/map-10       13.0k ± 0%     13.0k ± 0%     ~     (all equal)
RepoList_Encode-10                     1.00 ± 0%      1.00 ± 0%     ~     (all equal)
RepoList_Decode-10                    1.31k ± 0%     0.31k ± 0%  -76.16%  (p=0.000 n=10+10)
```