### PR TITLE
indexserver: new root page

### DIFF
--- a/debugserver/debug.go
+++ b/debugserver/debug.go
@@ -28,7 +28,7 @@ var debugTmpl = template.Must(template.New("name").Parse(`
 		</style>
 	</head>
 	<body>
-		/debug<br>
+    <a href="/">/<a/><span style="margin:2px">debug</span><br>
 		<br>
 		<a class="debug-page" href="vars">Vars</a><br>
 		{{if .EnablePprof}}<a class="debug-page" href="debug/pprof/">PProf</a>{{else}}PProf disabled{{end}}<br>


### PR DESCRIPTION
The repos are now hidden by default. If visible they are rendered as html table instead of buttons inside a form.

Note that we also remove the headless mode, because we don't use it anymore. 

![Kapture 2022-12-16 at 13 59 19](https://user-images.githubusercontent.com/26413131/208103785-0fafcf8a-99a3-4b74-96f9-c2b7ac9530f3.gif)
