### PR TITLE
Fix /api/search endpoint JSON encoding error

### DIFF
--- a/api.go
+++ b/api.go
@@ -479,7 +479,10 @@ func (p *Progress) sizeBytes() uint64 {
 // SearchResult contains search matches and extra data
 type SearchResult struct {
 	Stats
-	Progress
+
+	// Do not encode this as we cannot encode -Inf in JSON
+	Progress `json:"-"`
+
 	Files []FileMatch
 
 	// RepoURLs holds a repo => template string map.

--- a/json/json.go
+++ b/json/json.go
@@ -91,7 +91,12 @@ func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	json.NewEncoder(w).Encode(jsonSearchReply{searchResult})
+	err = json.NewEncoder(w).Encode(jsonSearchReply{searchResult})
+
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 }
 
 func jsonError(w http.ResponseWriter, statusCode int, err string) {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -83,6 +84,38 @@ func TestClientServer(t *testing.T) {
 	}
 	if !reflect.DeepEqual(listResult.List, mock.RepoList) {
 		t.Fatalf("got %+v, want %+v", listResult, mock.RepoList)
+	}
+}
+
+func TestProgressNotEncodedInSearch(t *testing.T) {
+	searchQuery := "hello"
+	mock := &mockSearcher.MockSearcher{
+		WantSearch: mustParse(searchQuery),
+		SearchResult: &zoekt.SearchResult{
+			// Validate that Progress is ignored as we cannot encode -Inf
+			Progress: zoekt.Progress{
+				Priority:           math.Inf(-1),
+				MaxPendingPriority: math.Inf(-1),
+			},
+			Files: []zoekt.FileMatch{},
+		},
+	}
+
+	ts := httptest.NewServer(zjson.JSONServer(mock))
+	defer ts.Close()
+
+	searchBody, err := json.Marshal(struct{ Q string }{Q: searchQuery})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := http.Post(ts.URL+"/search", "application/json", bytes.NewBuffer(searchBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r.StatusCode != 200 {
+		body, _ := io.ReadAll(r.Body)
+		t.Fatalf("Got status code %d, err %s", r.StatusCode, string(body))
 	}
 }
 


### PR DESCRIPTION
Previously this endpoint was always returning an empty response for valid requests. This is because the last line failed to encode the SearchResult as JSON. After some investigation I can see that this is because we [default the Progress fields to `-Inf`](https://github.com/sourcegraph/zoekt/blob/0d86a863a2e214ca4d3d8aac2471a1abddff8c72/stream/stream.go#L124). Since these progress fields only seem to be applicable for streaming use cases, that use RPC, and don't encode as JSON then it seemed like the best fix was to simply omit them in the JSON response.

This change also adds error handling to the JSON encoding so that these errors will be simpler to debug in future. A test is also included that reproduces the issue.

You can reproduce this issue and the fix locally by just curling the search endpoint like:

```bash
curl -XPOST -d '{"Q":"a.*"}' 'http://127.0.0.1:6070/api/search' -i
```