### PR TITLE
monitoring: add metric that tracks the total number of search requests

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -448,6 +448,7 @@ func (s *loggedSearcher) Search(
 		s.log(ctx, q, opts, stats, err)
 	}()
 
+	metricSearchRequestsTotal.Inc()
 	return s.Streamer.Search(ctx, q, opts)
 }
 
@@ -460,6 +461,8 @@ func (s *loggedSearcher) StreamSearch(
 	var (
 		stats zoekt.Stats
 	)
+
+	metricSearchRequestsTotal.Inc()
 	err := s.Streamer.StreamSearch(ctx, q, opts, stream.SenderFunc(func(event *zoekt.SearchResult) {
 		stats.Add(event.Stats)
 		sender.Send(event)
@@ -551,6 +554,10 @@ var (
 	metricWatchdogErrorsTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "zoekt_webserver_watchdog_errors_total",
 		Help: "The total number of errors from zoekt watchdog.",
+	})
+	metricSearchRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "zoekt_search_requests_total",
+		Help: "The total number of search requests that zoekt received",
 	})
 )
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -56,6 +56,10 @@ var (
 		Name: "zoekt_search_running",
 		Help: "The number of concurrent search requests running",
 	})
+	metricSearchRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "zoekt_search_requests_total",
+		Help: "The total number of search requests",
+	})
 	metricSearchShardRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "zoekt_search_shard_running",
 		Help: "The number of concurrent search requests in a shard running",
@@ -598,6 +602,7 @@ func streamSearch(ctx context.Context, proc *process, q query.Q, opts *zoekt.Sea
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %+v", opts)
 	overallStart := time.Now()
+	metricSearchRequestsTotal.Inc()
 	metricSearchRunning.Inc()
 	defer func() {
 		metricSearchRunning.Dec()

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -56,10 +56,6 @@ var (
 		Name: "zoekt_search_running",
 		Help: "The number of concurrent search requests running",
 	})
-	metricSearchRequestsTotal = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "zoekt_search_requests_total",
-		Help: "The total number of search requests",
-	})
 	metricSearchShardRunning = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "zoekt_search_shard_running",
 		Help: "The number of concurrent search requests in a shard running",
@@ -602,7 +598,6 @@ func streamSearch(ctx context.Context, proc *process, q query.Q, opts *zoekt.Sea
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %+v", opts)
 	overallStart := time.Now()
-	metricSearchRequestsTotal.Inc()
 	metricSearchRunning.Inc()
 	defer func() {
 		metricSearchRunning.Dec()


### PR DESCRIPTION
While @gl-srgr and I were talking this morning, we realized that we didn't have a metric tracks queries per second (QPS).  (or put another way, the job arrival rate). This PR adds a new metric `zoekt_search_requests_total`, that fixes that.

Notes:

- While the existing `zoekt_search_duration_seconds` metric can be used to track the total number of requests, the fact that it only does observations at the _end_ of a search request can skew the distribution (long-running requests will only be recorded long after their arrival). 
- The `zoekt_search_running` metric conflates both the job arrival rate and job completion rate in the same metric, so it's unsuitable for determing _solely_ the arrival rate. 
- I put the logic for the metric inside of `loggedSearcher`, since I wanted to ensure that the rate of observations wasn't limited by the `interactive` semaphore - loggedSearcher was at the topmost level. 