### PR TITLE
Fix no-shards-loaded being reported as crashes

### DIFF
--- a/shards/shards.go
+++ b/shards/shards.go
@@ -270,6 +270,12 @@ func (tl *loader) load(keys ...string) {
 	// finished running shardedSearcher will be ready.
 	defer tl.ss.markReady()
 
+	if len(keys) == 0 {
+		// If there's nothing to load, we exit early here, but we want to mark
+		// ourselves as ready.
+		return
+	}
+
 	var (
 		mu           sync.Mutex     // synchronizes writes to the shards map
 		wg           sync.WaitGroup // used to wait for all shards to load

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -181,11 +181,6 @@ func (s *DirectoryWatcher) scan() error {
 	}
 
 	s.loader.drop(toDrop...)
-
-	if len(toLoad) == 0 {
-		return nil
-	}
-
 	s.loader.load(toLoad...)
 
 	return nil


### PR DESCRIPTION
Full debug context here: https://sourcegraph.slack.com/archives/C023ELQLV7F/p1672835804462349

Commit 9899a9b3f475ef066ed70c395f8b303268f5d00c changed what the response looks like when Zoekt has never loaded a shard: it now reports a `Crashes = 1`, even if everything's fine.

That leads to upstream errors where we show an error message in the Sourcegraph admin UI because the customer hasn't added any repositories to their instance yet.

The fix here changes the `loader` to also mark the `shardedSearcher` as ready if there was nothing to load. Previously the `markReady` was skipped, the searcher wasn't marked as "ready" and every search query was replied to with a `Crashes = 1`