### PR TITLE
add interface for inverted index

### DIFF
--- a/hititer.go
+++ b/hititer.go
@@ -110,6 +110,10 @@ func (d *indexData) newDistanceTrigramIter(ng1, ng2 ngram, dist uint32, caseSens
 }
 
 func (d *indexData) trigramHitIterator(ng ngram, caseSensitive, fileName bool) (hitIterator, error) {
+	if d.ngrams == nil {
+		return nil, fmt.Errorf("trigramHitIterator: ngrams=nil")
+	}
+
 	variants := []ngram{ng}
 	if !caseSensitive {
 		variants = generateCaseNgrams(ng)

--- a/indexdata.go
+++ b/indexdata.go
@@ -33,7 +33,7 @@ type indexData struct {
 
 	file IndexFile
 
-	ngrams ngramMap
+	ngrams ngramIndex
 
 	newlinesStart uint32
 	newlinesIndex []uint32
@@ -314,7 +314,9 @@ func (d *indexData) memoryUse() int {
 	}
 	sz += 8 * len(d.runeDocSections)
 	sz += 8 * len(d.fileBranchMasks)
-	sz += d.ngrams.SizeBytes()
+	if d.ngrams != nil {
+		sz += d.ngrams.SizeBytes()
+	}
 	sz += 12 * len(d.fileNameNgrams) // these slices reference mmap-ed memory
 	return sz
 }
@@ -348,6 +350,10 @@ func lastMinarg(xs []uint32) uint32 {
 func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
 	if filename {
 		return uint32(len(data.fileNameNgrams[ng]))
+	}
+
+	if data.ngrams == nil {
+		return 0
 	}
 
 	return data.ngrams.Get(ng).sz

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -358,35 +358,10 @@ func (a *asciiNgramOffset) SizeBytes() int {
 	return 4*len(a.entries) + 4*len(a.chunkOffsets)
 }
 
-// ngramMap is an transient type while we investigate the performance of
-// combinedNgramOffset (established) vs binarySearch (new).
-//
-// It is like an interface, but we do the drudgery so we still get a useful
-// zero value (instead of nil panics in tests).
-type ngramMap struct {
-	offsetMap combinedNgramOffset
-	bsMap     binarySearchNgram
-}
-
-func (m ngramMap) Get(gram ngram) simpleSection {
-	if m.offsetMap.asc != nil {
-		return m.offsetMap.Get(gram)
-	}
-	return m.bsMap.Get(gram)
-}
-
-func (m ngramMap) DumpMap() map[ngram]simpleSection {
-	if m.offsetMap.asc != nil {
-		return m.offsetMap.DumpMap()
-	}
-	return m.bsMap.DumpMap()
-}
-
-func (m ngramMap) SizeBytes() int {
-	if m.offsetMap.asc != nil {
-		return m.offsetMap.SizeBytes()
-	}
-	return 0 // binarySearch only uses mmaped data.
+type ngramIndex interface {
+	Get(gram ngram) simpleSection
+	DumpMap() map[ngram]simpleSection
+	SizeBytes() int
 }
 
 type binarySearchNgram struct {
@@ -442,4 +417,8 @@ func (b binarySearchNgram) DumpMap() map[ngram]simpleSection {
 		m[gram] = b.Get(gram)
 	}
 	return m
+}
+
+func (b binarySearchNgram) SizeBytes() int {
+	return 0 // binarySearch only uses mmaped data.
 }

--- a/read.go
+++ b/read.go
@@ -294,13 +294,13 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		if err != nil {
 			return nil, err
 		}
-		d.ngrams = ngramMap{bsMap: bsMap}
+		d.ngrams = bsMap
 	} else {
 		offsetMap, err := d.readNgrams(toc)
 		if err != nil {
 			return nil, err
 		}
-		d.ngrams = ngramMap{offsetMap: offsetMap}
+		d.ngrams = offsetMap
 	}
 
 	d.fileBranchMasks, err = readSectionU64(d.file, toc.branchMasks)
@@ -694,6 +694,10 @@ func PrintNgramStats(r IndexFile) error {
 	id, err := loadIndexData(r)
 	if err != nil {
 		return err
+	}
+
+	if id.ngrams == nil {
+		return fmt.Errorf("PrintNgramStats: ngrams=nil")
 	}
 	var rNgram [3]rune
 	for ngram, ss := range id.ngrams.DumpMap() {


### PR DESCRIPTION
We already have two implementations, combinedNgramOffset and binarySearchNgram, for the inverted index from ngrams to posting lists. With the btree I am working on, a third implementation will follow soon.

The current apporach guarantees a zero-value that won't panic in the tests, however, I don't think we should pile on top of that for the third implementation, but rather handle nil in the code and return an error where it makes sense.