### PR TITLE
Add RepoIds filter to /api/search based on new RepoIds query primitive

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -83,6 +83,10 @@ func (d *indexData) simplify(in query.Q) query.Q {
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Set[repo.Name]
 			})
+		case *query.RepoIds:
+			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
+				return r.Repos.Contains(repo.ID)
+			})
 		case *query.Language:
 			_, has := d.metaData.LanguageMap[r.Language]
 			if !has && d.metaData.IndexFeatureVersion < 12 {

--- a/eval.go
+++ b/eval.go
@@ -83,7 +83,7 @@ func (d *indexData) simplify(in query.Q) query.Q {
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Set[repo.Name]
 			})
-		case *query.RepoIds:
+		case *query.RepoIDs:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Repos.Contains(repo.ID)
 			})

--- a/eval_test.go
+++ b/eval_test.go
@@ -212,11 +212,11 @@ func TestSimplifyRepoSet(t *testing.T) {
 	}
 }
 
-func TestSimplifyRepoIds(t *testing.T) {
+func TestSimplifyRepoIDs(t *testing.T) {
 	d := compoundReposShard(t, "foo", "bar")
-	all := &query.RepoIds{Repos: roaring.BitmapOf(hash("foo"), hash("bar"))}
-	some := &query.RepoIds{Repos: roaring.BitmapOf(hash("foo"), hash("banana"))}
-	none := &query.RepoIds{Repos: roaring.BitmapOf(hash("banana"))}
+	all := &query.RepoIDs{Repos: roaring.BitmapOf(hash("foo"), hash("bar"))}
+	some := &query.RepoIDs{Repos: roaring.BitmapOf(hash("foo"), hash("banana"))}
+	none := &query.RepoIDs{Repos: roaring.BitmapOf(hash("banana"))}
 
 	tr := cmp.Transformer("", func(b *roaring.Bitmap) []uint32 { return b.ToArray() })
 

--- a/json/json.go
+++ b/json/json.go
@@ -28,7 +28,7 @@ type jsonSearcher struct {
 
 type jsonSearchArgs struct {
 	Q       string
-	RepoIDs []uint32
+	RepoIDs *[]uint32
 	Opts    *zoekt.SearchOptions
 }
 
@@ -74,11 +74,8 @@ func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: We need to distinguish empty array from unset. An empty array
-	// should return no results for security reasons, whereas unset is the
-	// default behaviour without filtering.
-	if len(searchArgs.RepoIDs) != 0 {
-		q = query.NewAnd(q, query.NewRepoIDs(searchArgs.RepoIDs...))
+	if searchArgs.RepoIDs != nil {
+		q = query.NewAnd(q, query.NewRepoIDs(*searchArgs.RepoIDs...))
 	}
 
 	// Set a timeout if the user hasn't specified one.

--- a/json/json.go
+++ b/json/json.go
@@ -27,8 +27,9 @@ type jsonSearcher struct {
 }
 
 type jsonSearchArgs struct {
-	Q    string
-	Opts *zoekt.SearchOptions
+	Q       string
+	RepoIds []uint32
+	Opts    *zoekt.SearchOptions
 }
 
 type jsonSearchReply struct {
@@ -67,10 +68,17 @@ func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 		searchArgs.Opts = &zoekt.SearchOptions{}
 	}
 
-	query, err := query.Parse(searchArgs.Q)
+	q, err := query.Parse(searchArgs.Q)
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
+	}
+
+	// TODO: We need to distinguish empty array from unset. An empty array
+	// should return no results for security reasons, whereas unset is the
+	// default behaviour without filtering.
+	if len(searchArgs.RepoIds) != 0 {
+		q = query.NewAnd(q, query.NewRepoIds(searchArgs.RepoIds...))
 	}
 
 	// Set a timeout if the user hasn't specified one.
@@ -80,12 +88,12 @@ func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 		defer cancel()
 	}
 
-	if err := CalculateDefaultSearchLimits(ctx, query, s.Searcher, searchArgs.Opts); err != nil {
+	if err := CalculateDefaultSearchLimits(ctx, q, s.Searcher, searchArgs.Opts); err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
-	searchResult, err := s.Searcher.Search(ctx, query, searchArgs.Opts)
+	searchResult, err := s.Searcher.Search(ctx, q, searchArgs.Opts)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/json/json.go
+++ b/json/json.go
@@ -28,7 +28,7 @@ type jsonSearcher struct {
 
 type jsonSearchArgs struct {
 	Q       string
-	RepoIds []uint32
+	RepoIDs []uint32
 	Opts    *zoekt.SearchOptions
 }
 
@@ -77,8 +77,8 @@ func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 	// TODO: We need to distinguish empty array from unset. An empty array
 	// should return no results for security reasons, whereas unset is the
 	// default behaviour without filtering.
-	if len(searchArgs.RepoIds) != 0 {
-		q = query.NewAnd(q, query.NewRepoIds(searchArgs.RepoIds...))
+	if len(searchArgs.RepoIDs) != 0 {
+		q = query.NewAnd(q, query.NewRepoIDs(searchArgs.RepoIDs...))
 	}
 
 	// Set a timeout if the user hasn't specified one.

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -87,10 +87,10 @@ func TestClientServer(t *testing.T) {
 	}
 }
 
-func TestClientServerWithRepoIdsProvided(t *testing.T) {
+func TestClientServerWithRepoIDsProvided(t *testing.T) {
 	searchQuery := "hello"
 	expectedSearch := mustParse(searchQuery)
-	expectedSearch = query.NewAnd(expectedSearch, query.NewRepoIds(1, 3, 5, 7))
+	expectedSearch = query.NewAnd(expectedSearch, query.NewRepoIDs(1, 3, 5, 7))
 	mock := &mockSearcher.MockSearcher{
 		WantSearch: expectedSearch,
 		SearchResult: &zoekt.SearchResult{
@@ -103,7 +103,7 @@ func TestClientServerWithRepoIdsProvided(t *testing.T) {
 	ts := httptest.NewServer(zjson.JSONServer(mock))
 	defer ts.Close()
 
-	searchBody := "{\"Q\":\"hello\",\"RepoIds\":[1,3,5,7]}"
+	searchBody := "{\"Q\":\"hello\",\"RepoIDs\":[1,3,5,7]}"
 
 	r, err := http.Post(ts.URL+"/search", "application/json", bytes.NewBufferString(searchBody))
 	if err != nil {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -124,6 +124,43 @@ func TestClientServerWithRepoIDsProvided(t *testing.T) {
 	}
 }
 
+func TestClientServerWithEmptyRepoIDsProvided(t *testing.T) {
+	searchQuery := "hello"
+	expectedSearch := mustParse(searchQuery)
+	expectedSearch = query.NewAnd(expectedSearch, query.NewRepoIDs())
+	mock := &mockSearcher.MockSearcher{
+		WantSearch: expectedSearch,
+		SearchResult: &zoekt.SearchResult{
+			Files: []zoekt.FileMatch{
+				{FileName: "bin.go"},
+			},
+		},
+	}
+
+	ts := httptest.NewServer(zjson.JSONServer(mock))
+	defer ts.Close()
+
+	searchBody := "{\"Q\":\"hello\",\"RepoIDs\":[]}"
+
+	r, err := http.Post(ts.URL+"/search", "application/json", bytes.NewBufferString(searchBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.StatusCode != 200 {
+		body, _ := io.ReadAll(r.Body)
+		t.Fatalf("Got status code %d, err %s", r.StatusCode, string(body))
+	}
+
+	var searchResult struct{ Result *zoekt.SearchResult }
+	err = json.NewDecoder(r.Body).Decode(&searchResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(searchResult.Result, mock.SearchResult) {
+		t.Fatalf("\na %+v\nb %+v", searchResult.Result, mock.SearchResult)
+	}
+}
+
 func TestProgressNotEncodedInSearch(t *testing.T) {
 	searchQuery := "hello"
 	mock := &mockSearcher.MockSearcher{

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -87,6 +87,43 @@ func TestClientServer(t *testing.T) {
 	}
 }
 
+func TestClientServerWithRepoIdsProvided(t *testing.T) {
+	searchQuery := "hello"
+	expectedSearch := mustParse(searchQuery)
+	expectedSearch = query.NewAnd(expectedSearch, query.NewSingleBranchesRepos("HEAD", 1, 3, 5, 7))
+	mock := &mockSearcher.MockSearcher{
+		WantSearch: expectedSearch,
+		SearchResult: &zoekt.SearchResult{
+			Files: []zoekt.FileMatch{
+				{FileName: "bin.go"},
+			},
+		},
+	}
+
+	ts := httptest.NewServer(zjson.JSONServer(mock))
+	defer ts.Close()
+
+	searchBody := "{\"Q\":\"hello\",\"RepoIds\":[1,3,5,7]}"
+
+	r, err := http.Post(ts.URL+"/search", "application/json", bytes.NewBufferString(searchBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.StatusCode != 200 {
+		body, _ := io.ReadAll(r.Body)
+		t.Fatalf("Got status code %d, err %s", r.StatusCode, string(body))
+	}
+
+	var searchResult struct{ Result *zoekt.SearchResult }
+	err = json.NewDecoder(r.Body).Decode(&searchResult)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(searchResult.Result, mock.SearchResult) {
+		t.Fatalf("\na %+v\nb %+v", searchResult.Result, mock.SearchResult)
+	}
+}
+
 func TestProgressNotEncodedInSearch(t *testing.T) {
 	searchQuery := "hello"
 	mock := &mockSearcher.MockSearcher{

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -90,7 +90,7 @@ func TestClientServer(t *testing.T) {
 func TestClientServerWithRepoIdsProvided(t *testing.T) {
 	searchQuery := "hello"
 	expectedSearch := mustParse(searchQuery)
-	expectedSearch = query.NewAnd(expectedSearch, query.NewSingleBranchesRepos("HEAD", 1, 3, 5, 7))
+	expectedSearch = query.NewAnd(expectedSearch, query.NewRepoIds(1, 3, 5, 7))
 	mock := &mockSearcher.MockSearcher{
 		WantSearch: expectedSearch,
 		SearchResult: &zoekt.SearchResult{

--- a/matchtree.go
+++ b/matchtree.go
@@ -965,6 +965,21 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			},
 		}, nil
 
+	case *query.RepoIds:
+		reposWant := make([]bool, len(d.repoMetaData))
+		for repoIdx, r := range d.repoMetaData {
+			if s.Repos.Contains(r.ID) {
+				reposWant[repoIdx] = true
+			}
+		}
+		return &docMatchTree{
+			reason:  "RepoIds",
+			numDocs: d.numDocs(),
+			predicate: func(docID uint32) bool {
+				return reposWant[d.repos[docID]]
+			},
+		}, nil
+
 	case *query.Repo:
 		reposWant := make([]bool, len(d.repoMetaData))
 		for repoIdx, r := range d.repoMetaData {

--- a/matchtree.go
+++ b/matchtree.go
@@ -965,7 +965,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			},
 		}, nil
 
-	case *query.RepoIds:
+	case *query.RepoIDs:
 		reposWant := make([]bool, len(d.repoMetaData))
 		for repoIdx, r := range d.repoMetaData {
 			if s.Repos.Contains(r.ID) {
@@ -973,7 +973,7 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			}
 		}
 		return &docMatchTree{
-			reason:  "RepoIds",
+			reason:  "RepoIDs",
 			numDocs: d.numDocs(),
 			predicate: func(docID uint32) bool {
 				return reposWant[d.repos[docID]]

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -306,3 +306,26 @@ func TestBranchesRepos(t *testing.T) {
 		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
 	}
 }
+
+func TestRepoIds(t *testing.T) {
+	d := &indexData{
+		repoMetaData:    []Repository{{Name: "r0", ID: 0}, {Name: "r1", ID: 1}, {Name: "r2", ID: 2}, {Name: "r3", ID: 3}},
+		fileBranchMasks: []uint64{1, 1, 1, 1, 1, 1},
+		repos:           []uint16{0, 0, 1, 2, 3, 3},
+	}
+	mt, err := d.newMatchTree(&query.RepoIds{Repos: roaring.BitmapOf(1, 3, 99)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []uint32{2, 4, 5}
+	for i := 0; i < len(want); i++ {
+		nextDoc := mt.nextDoc()
+		if nextDoc != want[i] {
+			t.Fatalf("want %d, got %d", want[i], nextDoc)
+		}
+		mt.prepare(nextDoc)
+	}
+	if mt.nextDoc() != maxUInt32 {
+		t.Fatalf("expected %d document, but got at least 1 more", len(want))
+	}
+}

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -307,13 +307,13 @@ func TestBranchesRepos(t *testing.T) {
 	}
 }
 
-func TestRepoIds(t *testing.T) {
+func TestRepoIDs(t *testing.T) {
 	d := &indexData{
 		repoMetaData:    []Repository{{Name: "r0", ID: 0}, {Name: "r1", ID: 1}, {Name: "r2", ID: 2}, {Name: "r3", ID: 3}},
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 2, 3, 3},
 	}
-	mt, err := d.newMatchTree(&query.RepoIds{Repos: roaring.BitmapOf(1, 3, 99)})
+	mt, err := d.newMatchTree(&query.RepoIDs{Repos: roaring.BitmapOf(1, 3, 99)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -231,7 +231,7 @@ func (q *BranchesRepos) String() string {
 	return sb.String()
 }
 
-// NewSingleRepoIds is a helper for creating a RepoIds which
+// NewRepoIds is a helper for creating a RepoIds which
 // searches only the matched repos.
 func NewRepoIds(ids ...uint32) *RepoIds {
 	return &RepoIds{Repos: roaring.BitmapOf(ids...)}
@@ -242,7 +242,11 @@ func (q *RepoIds) String() string {
 
 	sb.WriteString("(repoids ")
 
-	sb.WriteString(q.Repos.String())
+	if size := q.Repos.GetCardinality(); size > 1 {
+		sb.WriteString("count:" + strconv.FormatUint(size, 10))
+	} else {
+		sb.WriteString("repoid=" + q.Repos.String())
+	}
 
 	sb.WriteString(")")
 	return sb.String()

--- a/query/query.go
+++ b/query/query.go
@@ -231,13 +231,13 @@ func (q *BranchesRepos) String() string {
 	return sb.String()
 }
 
-// NewRepoIds is a helper for creating a RepoIds which
+// NewRepoIDs is a helper for creating a RepoIDs which
 // searches only the matched repos.
-func NewRepoIds(ids ...uint32) *RepoIds {
-	return &RepoIds{Repos: roaring.BitmapOf(ids...)}
+func NewRepoIDs(ids ...uint32) *RepoIDs {
+	return &RepoIDs{Repos: roaring.BitmapOf(ids...)}
 }
 
-func (q *RepoIds) String() string {
+func (q *RepoIDs) String() string {
 	var sb strings.Builder
 
 	sb.WriteString("(repoids ")
@@ -272,7 +272,7 @@ type BranchRepos struct {
 
 // Similar to BranchRepos but will be used to match only by repoid and
 // therefore matches all branches
-type RepoIds struct {
+type RepoIDs struct {
 	Repos *roaring.Bitmap
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -231,6 +231,23 @@ func (q *BranchesRepos) String() string {
 	return sb.String()
 }
 
+// NewSingleRepoIds is a helper for creating a RepoIds which
+// searches only the matched repos.
+func NewRepoIds(ids ...uint32) *RepoIds {
+	return &RepoIds{Repos: roaring.BitmapOf(ids...)}
+}
+
+func (q *RepoIds) String() string {
+	var sb strings.Builder
+
+	sb.WriteString("(repoids ")
+
+	sb.WriteString(q.Repos.String())
+
+	sb.WriteString(")")
+	return sb.String()
+}
+
 // MarshalBinary implements a specialized encoder for BranchesRepos.
 func (q BranchesRepos) MarshalBinary() ([]byte, error) {
 	return branchesReposEncode(q.List)
@@ -247,6 +264,12 @@ func (q *BranchesRepos) UnmarshalBinary(b []byte) (err error) {
 type BranchRepos struct {
 	Branch string
 	Repos  *roaring.Bitmap
+}
+
+// Similar to BranchRepos but will be used to match only by repoid and
+// therefore matches all branches
+type RepoIds struct {
+	Repos *roaring.Bitmap
 }
 
 // RepoSet is a list of repos to match. It is a Sourcegraph addition and only

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -143,7 +143,7 @@ func RegisterGob() {
 		gobRegister(&query.Regexp{})
 		gobRegister(&query.RepoRegexp{})
 		gobRegister(&query.RepoSet{})
-		gobRegister(&query.RepoIds{})
+		gobRegister(&query.RepoIDs{})
 		gobRegister(&query.Repo{})
 		gobRegister(&query.Substring{})
 		gobRegister(&query.Symbol{})

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -143,6 +143,7 @@ func RegisterGob() {
 		gobRegister(&query.Regexp{})
 		gobRegister(&query.RepoRegexp{})
 		gobRegister(&query.RepoSet{})
+		gobRegister(&query.RepoIds{})
 		gobRegister(&query.Repo{})
 		gobRegister(&query.Substring{})
 		gobRegister(&query.Symbol{})

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -388,7 +388,7 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
 				return setQuery.Set[repo.Name]
 			})
-		case *query.RepoIds:
+		case *query.RepoIDs:
 			setSize = int(setQuery.Repos.GetCardinality())
 			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
 				return setQuery.Repos.Contains(repo.ID)
@@ -450,7 +450,7 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 			and.Children[i] = &query.Const{Value: true}
 			return filtered, query.Simplify(and)
 
-		case *query.RepoIds:
+		case *query.RepoIDs:
 			and.Children[i] = &query.Const{Value: true}
 			return filtered, query.Simplify(and)
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -388,6 +388,11 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
 				return setQuery.Set[repo.Name]
 			})
+		case *query.RepoIds:
+			setSize = int(setQuery.Repos.GetCardinality())
+			hasRepos = hasReposForPredicate(func(repo *zoekt.Repository) bool {
+				return setQuery.Repos.Contains(repo.ID)
+			})
 		case *query.BranchesRepos:
 			for _, br := range setQuery.List {
 				setSize += int(br.Repos.GetCardinality())
@@ -442,6 +447,10 @@ func selectRepoSet(shards []*rankedShard, q query.Q) ([]*rankedShard, query.Q) {
 		// (content baz). This work can be done now once, rather than per shard.
 		switch c := c.(type) {
 		case *query.RepoSet:
+			and.Children[i] = &query.Const{Value: true}
+			return filtered, query.Simplify(and)
+
+		case *query.RepoIds:
 			and.Children[i] = &query.Const{Value: true}
 			return filtered, query.Simplify(and)
 

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -226,25 +226,25 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 	}
 }
 
-func TestFilteringShardsByRepoSetOrBranchesReposRepoIds(t *testing.T) {
+func TestFilteringShardsByRepoSetOrBranchesReposRepoIDs(t *testing.T) {
 	ss := newShardedSearcher(1)
 
 	repoSetNames := []string{}
-	repoIds := []uint32{}
+	repoIDs := []uint32{}
 	n := 10 * runtime.GOMAXPROCS(0)
 	for i := 0; i < n; i++ {
 		shardName := fmt.Sprintf("shard%d", i)
 		repoName := fmt.Sprintf("repository%.3d", i)
-		repoId := hash(repoName)
+		repoID := hash(repoName)
 
 		if i%3 == 0 {
 			repoSetNames = append(repoSetNames, repoName)
-			repoIds = append(repoIds, repoId)
+			repoIDs = append(repoIDs, repoID)
 		}
 
 		ss.replace(map[string]zoekt.Searcher{
 			shardName: &rankSearcher{
-				repo: &zoekt.Repository{ID: repoId, Name: repoName},
+				repo: &zoekt.Repository{ID: repoID, Name: repoName},
 				rank: uint16(n - i),
 			},
 		})
@@ -269,7 +269,7 @@ func TestFilteringShardsByRepoSetOrBranchesReposRepoIds(t *testing.T) {
 	set := query.NewRepoSet(repoSetNames...)
 	sub := &query.Substring{Pattern: "bla"}
 
-	repoIdsQuery := query.NewRepoIds(repoIds...)
+	repoIDsQuery := query.NewRepoIDs(repoIDs...)
 
 	queries := []query.Q{
 		query.NewAnd(set, sub),
@@ -280,9 +280,9 @@ func TestFilteringShardsByRepoSetOrBranchesReposRepoIds(t *testing.T) {
 		// Test with the same repoBranches with IDs again
 		query.NewAnd(branchesRepos, sub),
 
-		query.NewAnd(repoIdsQuery, sub),
-		// Test with the same repoIds again
-		query.NewAnd(repoIdsQuery, sub),
+		query.NewAnd(repoIDsQuery, sub),
+		// Test with the same repoIDs again
+		query.NewAnd(repoIDsQuery, sub),
 	}
 
 	for _, q := range queries {

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -226,7 +226,7 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 	}
 }
 
-func TestFilteringShardsByRepoSetOrBranchesReposRepoIDs(t *testing.T) {
+func TestFilteringShardsByRepoSetOrBranchesReposOrRepoIDs(t *testing.T) {
 	ss := newShardedSearcher(1)
 
 	repoSetNames := []string{}


### PR DESCRIPTION
This is a new parameter that can be passed in the request body to filter searches to a list of repositories by `repoid`. This makes use of a new `ReposIds` query primitive. This is very similar to the existing `BranchesRepos` except it doesn't care about branch name and only filters by repoid. This is a nicer API for projects like GitLab which will only be indexing 1 branch per repo.