### PR TITLE
matchtree: special case word search

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -178,6 +178,10 @@ func byteClass(c byte) int {
 	}
 }
 
+func characterClass(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
 func marshalDocSections(secs []DocumentSection) []byte {
 	ints := make([]uint32, 0, len(secs)*2)
 	for _, s := range secs {

--- a/eval.go
+++ b/eval.go
@@ -474,6 +474,9 @@ func gatherMatches(mt matchTree, known map[matchTree]bool, merge bool) []*candid
 		if rmt, ok := mt.(*regexpMatchTree); ok {
 			cands = append(cands, rmt.found...)
 		}
+		if rmt, ok := mt.(*wordMatchTree); ok {
+			cands = append(cands, rmt.found...)
+		}
 		if smt, ok := mt.(*symbolRegexpMatchTree); ok {
 			cands = append(cands, smt.found...)
 		}

--- a/index_test.go
+++ b/index_test.go
@@ -1116,7 +1116,7 @@ func TestBranchVersions(t *testing.T) {
 }
 
 func mustParseRE(s string) *syntax.Regexp {
-	r, err := syntax.Parse(s, 0)
+	r, err := syntax.Parse(s, syntax.Perl)
 	if err != nil {
 		panic(err)
 	}
@@ -3534,5 +3534,74 @@ func TestStats(t *testing.T) {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
 
+	})
+}
+
+// This tests the frequent pattern "\bLITERAL\b".
+func TestWordSearch(t *testing.T) {
+	content := []byte("needle the bla")
+	// ----------------01234567890123
+
+	b := testIndexBuilder(t, nil,
+		Document{
+			Name:    "f1",
+			Content: content,
+		})
+
+	t.Run("LineMatches", func(t *testing.T) {
+		sres := searchForTest(t, b,
+			&query.Regexp{
+				Regexp:        mustParseRE("\\bthe\\b"),
+				CaseSensitive: true,
+				Content:       true,
+			})
+
+		if len(sres.Files) != 1 || len(sres.Files[0].LineMatches) != 1 {
+			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
+		}
+
+		got := sres.Files[0].LineMatches[0]
+		want := LineMatch{
+			LineFragments: []LineFragmentMatch{{
+				LineOffset:  7,
+				Offset:      7,
+				MatchLength: 3,
+			}},
+			Line:       content,
+			FileName:   false,
+			LineNumber: 1,
+			LineStart:  0,
+			LineEnd:    14,
+		}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("ChunkMatches", func(t *testing.T) {
+		sres := searchForTest(t, b,
+			&query.Regexp{
+				Regexp:        mustParseRE("\\bthe\\b"),
+				CaseSensitive: true,
+			}, chunkOpts)
+
+		if len(sres.Files) != 1 || len(sres.Files[0].ChunkMatches) != 1 {
+			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
+		}
+
+		got := sres.Files[0].ChunkMatches[0]
+		want := ChunkMatch{
+			Content:      content,
+			ContentStart: Location{ByteOffset: 0, LineNumber: 1, Column: 1},
+			Ranges: []Range{{
+				Start: Location{ByteOffset: 7, LineNumber: 1, Column: 8},
+				End:   Location{ByteOffset: 10, LineNumber: 1, Column: 11},
+			}},
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatal(diff)
+		}
 	})
 }

--- a/index_test.go
+++ b/index_test.go
@@ -3560,6 +3560,10 @@ func TestWordSearch(t *testing.T) {
 			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
 		}
 
+		if sres.Stats.RegexpsConsidered != 0 {
+			t.Fatal("expected regexp to be skipped")
+		}
+
 		got := sres.Files[0].LineMatches[0]
 		want := LineMatch{
 			LineFragments: []LineFragmentMatch{{

--- a/index_test.go
+++ b/index_test.go
@@ -3594,6 +3594,10 @@ func TestWordSearch(t *testing.T) {
 			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
 		}
 
+		if sres.Stats.RegexpsConsidered != 0 {
+			t.Fatal("expected regexp to be skipped")
+		}
+
 		got := sres.Files[0].ChunkMatches[0]
 		want := ChunkMatch{
 			Content:      content,

--- a/matchtree.go
+++ b/matchtree.go
@@ -23,6 +23,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/grafana/regexp"
+
 	"github.com/sourcegraph/zoekt/query"
 )
 
@@ -729,7 +730,7 @@ func (t *wordMatchTree) matches(cp *contentProvider, cost int, known map[matchTr
 			found = append(found, &candidateMatch{
 				byteOffset:  uint32(offset + idx),
 				byteMatchSz: uint32(len(t.word)),
-				fileName:    false,
+				fileName:    t.fileName,
 			})
 		}
 		offset += idx + len(t.word)

--- a/matchtree.go
+++ b/matchtree.go
@@ -1117,7 +1117,7 @@ func regexpToWordMatchTree(q *query.Regexp) (_ *wordMatchTree, ok bool) {
 	if !q.CaseSensitive || q.Regexp.Flags&syntax.FoldCase != 0 {
 		return nil, false
 	}
-	// We want 3 a regex that looks like Op.Concat[OpWordBoundary OpLiteral OpWordBoundary]
+	// We want a regex that looks like Op.Concat[OpWordBoundary OpLiteral OpWordBoundary]
 	if q.Regexp.Op != syntax.OpConcat || len(q.Regexp.Sub) != 3 {
 		return nil, false
 	}

--- a/matchtree.go
+++ b/matchtree.go
@@ -711,7 +711,6 @@ func (t *wordMatchTree) matches(cp *contentProvider, cost int, known map[matchTr
 		return false, false
 	}
 
-	cp.stats.RegexpsConsidered++
 	data := cp.data(t.fileName)
 	offset := 0
 	found := t.found[:0]

--- a/matchtree.go
+++ b/matchtree.go
@@ -722,8 +722,9 @@ func (t *wordMatchTree) matches(cp *contentProvider, cost int, known map[matchTr
 
 		relStartOffset := offset + idx
 		relEndOffset := relStartOffset + len(t.word)
-		startBoundary := relStartOffset < len(data) && (relStartOffset == 0 || byteClass(data[relStartOffset-1]) != byteClass(data[relStartOffset]))
-		endBoundary := relEndOffset > 0 && (relEndOffset == len(data) || byteClass(data[relEndOffset-1]) != byteClass(data[relEndOffset]))
+
+		startBoundary := relStartOffset < len(data) && (relStartOffset == 0 || !characterClass(data[relStartOffset-1]))
+		endBoundary := relEndOffset > 0 && (relEndOffset == len(data) || !characterClass(data[relEndOffset]))
 		if startBoundary && endBoundary {
 			found = append(found, &candidateMatch{
 				byteOffset:  uint32(offset + idx),


### PR DESCRIPTION
A common search Zoekt gets from Sourcegraph is "\bLITERAL\b".  With this PR we avoid the regex engine for these type of queries and provide something faster.

Local benchmarks show that the new code runs 4.8x faster for select queries.

Co-authored-by: @stefanhengl