### PR TITLE
indexserver: expose all merge options

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -438,7 +438,7 @@ func (s *Server) vacuum() {
 			continue
 		}
 
-		if info.Size() < s.minSizeBytes {
+		if info.Size() < s.mergeOpts.minSizeBytes {
 			cmd := exec.Command("zoekt-merge-index", "explode", path)
 
 			var b []byte

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1147,7 +1147,7 @@ type rootConfig struct {
 	mergeInterval  time.Duration
 	targetSize     int64
 	minSize        int64
-	ageDays        int
+	minAgeDays     int
 	maxPriority    float64
 
 	// config values related to backoff indexing repos with one or more consecutive failures
@@ -1172,7 +1172,7 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.DurationVar(&rc.mergeInterval, "merge_interval", getEnvWithDefaultDuration("SRC_MERGE_INTERVAL", 8*time.Hour), "run merge this often")
 	fs.Int64Var(&rc.targetSize, "merge_target_size", getEnvWithDefaultInt64("SRC_MERGE_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
 	fs.Int64Var(&rc.minSize, "merge_min_size", getEnvWithDefaultInt64("SRC_MERGE_MIN_SIZE", 1800), "the minimum size of a compound shard in MiB")
-	fs.IntVar(&rc.ageDays, "merge_age", getEnvWithDefaultInt("SRC_MERGE_AGE", 7), "the time since the last commit in days. Shards with newer commits are excluded from merging.")
+	fs.IntVar(&rc.minAgeDays, "merge_min_age", getEnvWithDefaultInt("SRC_MERGE_MIN_AGE", 7), "the time since the last commit in days. Shards with newer commits are excluded from merging.")
 	fs.Float64Var(&rc.maxPriority, "merge_max_priority", getEnvWithDefaultFloat64("SRC_MERGE_MAX_PRIORITY", 100), "the maximum priority a shard can have to be considered for merging.")
 
 }
@@ -1367,7 +1367,7 @@ func newServer(conf rootConfig) (*Server, error) {
 			mergeInterval:   conf.mergeInterval,
 			targetSizeBytes: conf.targetSize * 1024 * 1024,
 			minSizeBytes:    conf.minSize * 1024 * 1024,
-			ageDays:         conf.ageDays,
+			minAgeDays:      conf.minAgeDays,
 			maxPriority:     conf.maxPriority,
 		},
 	}, err

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -196,7 +196,7 @@ type mergeOpts struct {
 	// number of days since the last commit until we consider the shard for
 	// merging. For example, a value of 7 means that only repos that have been
 	// inactive for 7 days will be considered for merging.
-	ageDays int
+	minAgeDays int
 
 	// the MAX priority a shard can have to be considered for merging.
 	maxPriority float64
@@ -226,7 +226,7 @@ func isExcluded(path string, fi os.FileInfo, opts mergeOpts) bool {
 		return true
 	}
 
-	if repos[0].LatestCommitDate.After(time.Now().AddDate(0, 0, -opts.ageDays)) {
+	if repos[0].LatestCommitDate.After(time.Now().AddDate(0, 0, -opts.minAgeDays)) {
 		return true
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -182,15 +182,15 @@ type mergeOpts struct {
 	// degraded search performance.
 	targetSizeBytes int64
 
-	// Compound shards smaller than minSizeBytes will be deleted by vacuum.
+	// compound shards smaller than minSizeBytes will be deleted by vacuum.
 	minSizeBytes int64
 
-	// VacuumInterval is how often indexserver scans compound shards to remove
+	// vacuumInterval is how often indexserver scans compound shards to remove
 	// tombstones.
 	vacuumInterval time.Duration
 
-	// MergeInterval defines how often indexserver runs the merge operation in the index
-	// directory.
+	// mergeInterval defines how often indexserver runs the merge operation in
+	// the index directory.
 	mergeInterval time.Duration
 
 	// number of days since the last commit until we consider the shard for
@@ -198,7 +198,7 @@ type mergeOpts struct {
 	// inactive for 7 days will be considered for merging.
 	ageDays int
 
-	// the MAX maxPriority a sahrd can have to be considered for merging.
+	// the MAX priority a shard can have to be considered for merging.
 	maxPriority float64
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -64,7 +64,7 @@ func TestDoNotDeleteSingleShards(t *testing.T) {
 		t.Errorf("Finish: %v", err)
 	}
 
-	s := &Server{IndexDir: dir, TargetSizeBytes: 2000 * 1024 * 1024}
+	s := &Server{IndexDir: dir, mergeOpts: mergeOpts{targetSizeBytes: 2000 * 1024 * 1024}}
 	s.merge(helperCallMerge)
 
 	_, err = os.Stat(filepath.Join(dir, "test-repo_v16.00000.zoekt"))
@@ -187,8 +187,8 @@ func TestMerge(t *testing.T) {
 			}
 
 			s := &Server{
-				IndexDir:        dir,
-				TargetSizeBytes: tc.targetSizeBytes,
+				IndexDir:  dir,
+				mergeOpts: mergeOpts{targetSizeBytes: tc.targetSizeBytes},
 			}
 
 			s.merge(helperCallMerge)


### PR DESCRIPTION
With this change we expose "the maximum allowed priority" and "the minimum age of the latest commit" as command line flags and ENVs.

At the same time we clean up the "Server" struct a bit and bundle all fields related to shard merging in a dedicated options struct.

The motiviation is to make shard merging fully configurable before rolling it out to all customers.