### PR TITLE
zoekt: calculate bucket offsets lazily

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -250,7 +250,7 @@ type btreeIndex struct {
 	// We need the index to read buckets into memory.
 	file IndexFile
 
-	// buckets.
+	// buckets
 	ngramSec simpleSection
 
 	postingOffsets            []uint32

--- a/btree.go
+++ b/btree.go
@@ -313,7 +313,7 @@ func (b btreeIndex) Get(ng ngram) (ss simpleSection) {
 	bucketIndex, postingIndexOffset := b.bt.find(ng)
 
 	// read bucket into memory
-	off, sz := b.getBucket(bucketIndex, btreeBucketSize)
+	off, sz := b.getBucket(bucketIndex)
 	bucket, err := b.file.Read(off, sz)
 	if err != nil {
 		return simpleSection{}
@@ -338,9 +338,9 @@ func (b btreeIndex) Get(ng ngram) (ss simpleSection) {
 	return b.getPostingList(postingIndexOffset + x)
 }
 
-func (b btreeIndex) getBucket(bucketIndex int, bucketSize uint32) (off uint32, sz uint32) {
+func (b btreeIndex) getBucket(bucketIndex int) (off uint32, sz uint32) {
 	// All but the rightmost bucket have exactly bucketSize/2 ngrams
-	sz = bucketSize / 2 * ngramEncoding
+	sz = uint32(b.bt.opts.bucketSize / 2 * ngramEncoding)
 	off = b.ngramSec.off + uint32(bucketIndex)*sz
 
 	// Rightmost bucket has size upto the end of the ngramSec.
@@ -358,7 +358,7 @@ func (b btreeIndex) DumpMap() map[ngram]simpleSection {
 		switch n := no.(type) {
 		case *leaf:
 			// read bucket into memory
-			off, sz := b.getBucket(n.bucketIndex, btreeBucketSize)
+			off, sz := b.getBucket(n.bucketIndex)
 			bucket, _ := b.file.Read(off, sz)
 
 			// decode all ngrams in the bucket and fill map

--- a/btree_test.go
+++ b/btree_test.go
@@ -66,7 +66,7 @@ func TestFindBucket(t *testing.T) {
 
 func TestGetBucket(t *testing.T) {
 	var off uint32 = 13
-	var bucketSize uint32 = 4
+	bucketSize := 4
 
 	cases := []struct {
 		nNgrams     int
@@ -133,7 +133,7 @@ func TestGetBucket(t *testing.T) {
 			}
 
 			bt := newBtree(btreeOpts{
-				bucketSize: int(bucketSize),
+				bucketSize: bucketSize,
 				v:          2,
 			})
 			for i := 0; i < tt.nNgrams; i++ {
@@ -143,7 +143,7 @@ func TestGetBucket(t *testing.T) {
 
 			bi.bt = bt
 
-			off, sz := bi.getBucket(tt.bucketIndex, bucketSize)
+			off, sz := bi.getBucket(tt.bucketIndex)
 			if off != tt.wantOff {
 				t.Fatalf("off: want %d, got %d", tt.wantOff, off)
 			}

--- a/btree_test.go
+++ b/btree_test.go
@@ -118,12 +118,32 @@ func TestGetBucket(t *testing.T) {
 			wantOff:     off + 48,
 			wantSz:      32,
 		},
+		{
+			nNgrams:     9,
+			bucketIndex: 3,
+			wantOff:     off + 48,
+			wantSz:      24,
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {
-			bt := btreeIndex{ngramSec: simpleSection{off: off, sz: uint32(tt.nNgrams * ngramEncoding)}}
-			off, sz := bt.getBucket(tt.bucketIndex, bucketSize)
+			bi := btreeIndex{
+				ngramSec: simpleSection{off: off, sz: uint32(tt.nNgrams * ngramEncoding)},
+			}
+
+			bt := newBtree(btreeOpts{
+				bucketSize: int(bucketSize),
+				v:          2,
+			})
+			for i := 0; i < tt.nNgrams; i++ {
+				bt.insert(ngram(i + 1))
+			}
+			bt.freeze()
+
+			bi.bt = bt
+
+			off, sz := bi.getBucket(tt.bucketIndex, bucketSize)
 			if off != tt.wantOff {
 				t.Fatalf("off: want %d, got %d", tt.wantOff, off)
 			}

--- a/btree_test.go
+++ b/btree_test.go
@@ -3,8 +3,6 @@ package zoekt
 import (
 	"fmt"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestBTree_sorted(t *testing.T) {
@@ -66,79 +64,71 @@ func TestFindBucket(t *testing.T) {
 	}
 }
 
-func TestCreateBucketsFromNgramText(t *testing.T) {
-	var ngramTextOff uint32 = 7
-
-	offset := func(i int) uint32 {
-		return ngramTextOff + uint32((i * ngramEncoding))
-	}
+func TestGetBucket(t *testing.T) {
+	var off uint32 = 13
+	var bucketSize uint32 = 4
 
 	cases := []struct {
-		opts        btreeOpts
-		ngrams      []ngram
-		wantOffsets []uint32
+		nNgrams     int
+		bucketIndex int
+		wantOff     uint32
+		wantSz      uint32
 	}{
+		// tiny B-tree with just 1 bucket.
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{},
-			wantOffsets: []uint32{offset(0), offset(0)},
+			nNgrams:     1,
+			bucketIndex: 0,
+			wantOff:     off,
+			wantSz:      8,
 		},
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1},
-			wantOffsets: []uint32{offset(0), offset(1)},
+			nNgrams:     2,
+			bucketIndex: 0,
+			wantOff:     off,
+			wantSz:      16,
 		},
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2},
-			wantOffsets: []uint32{offset(0), offset(2)},
+			nNgrams:     3,
+			bucketIndex: 0,
+			wantOff:     off,
+			wantSz:      24,
+		},
+		// B-tree with 10 ngrams, think 1,2,3,4,5,6,7,8,9,10
+		{
+			nNgrams:     10,
+			bucketIndex: 0,
+			wantOff:     off,
+			wantSz:      16,
 		},
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3},
-			wantOffsets: []uint32{offset(0), offset(3)},
+			nNgrams:     10,
+			bucketIndex: 1,
+			wantOff:     off + 16,
+			wantSz:      16,
 		},
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4},
-			wantOffsets: []uint32{offset(0), offset(4)},
+			nNgrams:     10,
+			bucketIndex: 2,
+			wantOff:     off + 32,
+			wantSz:      16,
 		},
 		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4, 5},
-			wantOffsets: []uint32{offset(0), offset(2), offset(5)},
-		},
-		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4, 5, 6},
-			wantOffsets: []uint32{offset(0), offset(2), offset(6)},
-		},
-		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4, 5, 6, 7},
-			wantOffsets: []uint32{offset(0), offset(2), offset(4), offset(7)},
-		},
-		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4, 5, 6, 7, 8},
-			wantOffsets: []uint32{offset(0), offset(2), offset(4), offset(8)},
-		},
-		{
-			opts:        btreeOpts{v: 2, bucketSize: 4},
-			ngrams:      []ngram{1, 2, 3, 4, 5, 6, 7, 8, 9},
-			wantOffsets: []uint32{offset(0), offset(2), offset(4), offset(6), offset(9)},
+			nNgrams:     10,
+			bucketIndex: 3,
+			wantOff:     off + 48,
+			wantSz:      32,
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run("", func(t *testing.T) {
-			toc := &indexTOC{}
-			toc.ngramText.sz = uint32(len(tt.ngrams) * ngramEncoding)
-			toc.ngramText.off = ngramTextOff
-			haveOffsets := createBucketOffsets(toc.ngramText, tt.opts.bucketSize)
-
-			if d := cmp.Diff(tt.wantOffsets, haveOffsets); d != "" {
-				t.Fatalf("-want,+got\n%s", d)
+			bt := btreeIndex{ngramSec: simpleSection{off: off, sz: uint32(tt.nNgrams * ngramEncoding)}}
+			off, sz := bt.getBucket(tt.bucketIndex, bucketSize)
+			if off != tt.wantOff {
+				t.Fatalf("off: want %d, got %d", tt.wantOff, off)
+			}
+			if sz != tt.wantSz {
+				t.Fatalf("sz: want %d, got %d", tt.wantSz, sz)
 			}
 		})
 	}

--- a/read.go
+++ b/read.go
@@ -512,25 +512,7 @@ func (d *indexData) newBtreeIndex(toc *indexTOC) (btreeIndex, error) {
 		ng := ngram(binary.BigEndian.Uint64(textContent[i : i+ngramEncoding]))
 		bt.insert(ng)
 	}
-
-	// backfill "pointers" to the buckets and posting lists. Instead of
-	// backfilling we could maintain state during insertion, however the
-	// visitor pattern seems more natural and shouldn't be a performance issue,
-	// because, based on the typical number of trigrams (500k) per shard, the
-	// b-trees we construct here only have around 1000 leaf nodes.
-	offset, bucketIndex := 0, 0
-	bt.visit(func(no node) {
-		switch n := no.(type) {
-		case *leaf:
-			n.bucketIndex = bucketIndex
-			bucketIndex++
-
-			n.postingIndexOffset = offset
-			offset += n.bucketSize
-		case *innerNode:
-			return
-		}
-	})
+	bt.freeze()
 
 	bi.bt = bt
 

--- a/read.go
+++ b/read.go
@@ -534,29 +534,12 @@ func (d *indexData) newBtreeIndex(toc *indexTOC) (btreeIndex, error) {
 
 	bi.bt = bt
 
-	bi.bucketOffsets = createBucketOffsets(toc.ngramText, btreeBucketSize)
+	bi.ngramSec = toc.ngramText
 
 	bi.postingOffsets = toc.postings.offsets
 	bi.postingDataSentinelOffset = toc.postings.data.off + toc.postings.data.sz
 
 	return bi, nil
-}
-
-// Because we insert ngrams into the btree in order, we can easily reconstruct
-// the buckets from the ngramText simpleSection just by knowing the bucketSize.
-// The last item of the returned slice is the sentinel value sec.off + sec.sz.
-func createBucketOffsets(sec simpleSection, bucketSize int) []uint32 {
-	step := uint32((bucketSize / 2) * ngramEncoding)
-
-	offsets := make([]uint32, 0, ((sec.sz-1)/step)+1)
-	offsets = append(offsets, sec.off)
-
-	sentinel := sec.off + sec.sz
-	for off := sec.off + step; off+step < sentinel; off = off + step {
-		offsets = append(offsets, off)
-	}
-	offsets = append(offsets, sentinel)
-	return offsets
 }
 
 func (d *indexData) readFileNameNgrams(toc *indexTOC) (map[ngram][]byte, error) {


### PR DESCRIPTION
Instead of creating bucket offsets on read, we calculate the bucket
offset for a given bucket index on the fly.

Why?
Experiments on a larger cluster showed that createBucketOffsets has a
significant impact (>80%) on heap usage. This is still a bit puzzlling, because
I could not reproduce this locally. My intuition tells me this is a bug but while 
I keep debugging we might as well test the approach proposed in this PR.

The potential downside of the lazy buckets is more CPU usage per search.

Test plan:
- All tests, exept tests checking SizeBytes(), pass with `ZOEKT_ENABLE_BTREE=true go test ./...`
- Manually tested search on a corpus of repos
- Inspected heap profiles locally
- Updated units tests