### PR TITLE
zoekt: read posting offset from disk

### DIFF
--- a/read.go
+++ b/read.go
@@ -516,10 +516,9 @@ func (d *indexData) newBtreeIndex(toc *indexTOC) (btreeIndex, error) {
 
 	bi.bt = bt
 
+	// hold on to simple sections (8 bytes each)
 	bi.ngramSec = toc.ngramText
-
-	bi.postingOffsets = toc.postings.offsets
-	bi.postingDataSentinelOffset = toc.postings.data.off + toc.postings.data.sz
+	bi.postingIndex = toc.postings.index
 
 	return bi, nil
 }


### PR DESCRIPTION
The btree still referenced the offsets to the posting lists which had a big impact on the heap usage of webserver.

<img width="2467" alt="Screenshot 2023-02-03 at 14 06 53" src="https://user-images.githubusercontent.com/26413131/216611039-4e3d349c-4f96-4afd-b31a-618e1c56ac15.png">


With this change we just hold on to the simple section pointing to the offsets IE we read offsets lazily and therfore incur another disk access.

I added a unit test for ngramIndex.Get, because there wasn't really a good test so far that captured the expected size of a posting list. (Note: the new test passes for the current implementation as well as for the btree)

In total, after this change, the retrieval of a posting list for a given ngram via the btree requires 2 disk accesses (1 for getting the bucket of ngrams and 1 for getting the offset to the posting list).

If this turns out to be too costly with regards to latency, we should consider storing the offset together with the ngrams in the bucket, which would, however, require a reindex.