### PR TITLE
zoekt: use b-tree for filenames

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -291,7 +291,9 @@ type btreeIndex struct {
 
 func (b btreeIndex) SizeBytes() (sz int) {
 	// btree
-	sz += int(pointerSize) + b.bt.sizeBytes()
+	if b.bt != nil {
+		sz += int(pointerSize) + b.bt.sizeBytes()
+	}
 	// ngramSec
 	sz += 8
 	// postingIndex
@@ -308,6 +310,10 @@ func (b btreeIndex) SizeBytes() (sz int) {
 // 3. Binary search the bucket (in MEM)
 // 4. Return the simple section pointing to the posting list (in MEM)
 func (b btreeIndex) Get(ng ngram) (ss simpleSection) {
+	if b.bt == nil {
+		return simpleSection{}
+	}
+
 	// find bucket
 	bucketIndex, postingIndexOffset := b.bt.find(ng)
 
@@ -396,6 +402,10 @@ func (b btreeIndex) getBucket(bucketIndex int) (off uint32, sz uint32) {
 }
 
 func (b btreeIndex) DumpMap() map[ngram]simpleSection {
+	if b.bt == nil {
+		return nil
+	}
+
 	m := make(map[ngram]simpleSection, b.ngramSec.sz/ngramEncoding)
 
 	b.bt.visit(func(no node) {

--- a/hititer.go
+++ b/hititer.go
@@ -122,7 +122,10 @@ func (d *indexData) trigramHitIterator(ng ngram, caseSensitive, fileName bool) (
 	iters := make([]hitIterator, 0, len(variants))
 	for _, v := range variants {
 		if fileName {
-			blob := d.fileNameNgrams[v]
+			blob, err := d.fileNameNgrams.GetBlob(v)
+			if err != nil {
+				return nil, err
+			}
 			if len(blob) > 0 {
 				iters = append(iters, newCompressedPostingIterator(blob, v))
 			}

--- a/indexdata.go
+++ b/indexdata.go
@@ -56,7 +56,7 @@ type indexData struct {
 
 	fileNameContent []byte
 	fileNameIndex   []uint32
-	fileNameNgrams  map[ngram][]byte
+	fileNameNgrams  fileNameNgrams
 
 	// fileEndSymbol[i] is the index of the first symbol for document i.
 	fileEndSymbol []uint32
@@ -317,7 +317,7 @@ func (d *indexData) memoryUse() int {
 	if d.ngrams != nil {
 		sz += d.ngrams.SizeBytes()
 	}
-	sz += 12 * len(d.fileNameNgrams) // these slices reference mmap-ed memory
+	sz += d.fileNameNgrams.SizeBytes()
 	return sz
 }
 
@@ -349,7 +349,7 @@ func lastMinarg(xs []uint32) uint32 {
 
 func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
 	if filename {
-		return uint32(len(data.fileNameNgrams[ng]))
+		return uint32(data.fileNameNgrams.Frequency(ng))
 	}
 
 	if data.ngrams == nil {

--- a/indexdata.go
+++ b/indexdata.go
@@ -349,7 +349,7 @@ func lastMinarg(xs []uint32) uint32 {
 
 func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
 	if filename {
-		return uint32(data.fileNameNgrams.Frequency(ng))
+		return data.fileNameNgrams.Frequency(ng)
 	}
 
 	if data.ngrams == nil {

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -364,6 +364,43 @@ type ngramIndex interface {
 	SizeBytes() int
 }
 
+// This is a temporary type to wrap two very different implementations of the
+// inverted index for the purpose of feature-flagging. We will remove this after
+// we enable the b-tree permanently.
+//
+// Alternatively we could have adapted/extended the interface "ngramIndex".
+// However, adapting the existing implementations and their tests to match the
+// access pattern of map[ngram][]byte seems more cumbersome than this makeshift
+// wrapper. In the end, both ngramIndex and this wrapper will be replaced by a
+// concrete type.
+type fileNameNgrams struct {
+	m  map[ngram][]byte
+	bt btreeIndex
+}
+
+func (n fileNameNgrams) GetBlob(ng ngram) ([]byte, error) {
+	if n.m != nil {
+		return n.m[ng], nil
+	}
+	sec := n.bt.Get(ng)
+	return n.bt.file.Read(sec.off, sec.sz)
+}
+
+func (n fileNameNgrams) Frequency(ng ngram) uint32 {
+	if n.m != nil {
+		return uint32(len(n.m[ng]))
+	}
+	return n.bt.Get(ng).sz
+}
+
+func (n fileNameNgrams) SizeBytes() int {
+	if n.m != nil {
+		// these slices reference mmap-ed memory
+		return 12 * len(n.m)
+	}
+	return n.bt.SizeBytes()
+}
+
 type binarySearchNgram struct {
 	// ngramText is the bytes at indexTOC.ngramText
 	//

--- a/read_test.go
+++ b/read_test.go
@@ -116,7 +116,13 @@ func TestReadWriteNames(t *testing.T) {
 	if !reflect.DeepEqual([]uint32{0, 4}, data.fileNameIndex) {
 		t.Errorf("got index %v, want {0,4}", data.fileNameIndex)
 	}
-	if got := data.fileNameNgrams[stringToNGram("bCd")]; !reflect.DeepEqual(got, []byte{1}) {
+
+	gotBlob, err := data.fileNameNgrams.GetBlob(stringToNGram("bCd"))
+	if err != nil {
+		t.Fatalf("fileNameNgrams.GetBlob: %v", err)
+	}
+
+	if !reflect.DeepEqual(gotBlob, []byte{1}) {
 		t.Errorf("got trigram bcd at bits %v, want sz 2", data.fileNameNgrams)
 	}
 }


### PR DESCRIPTION
With this change we use the b-tree for filnames just like we do for content. Based on heap profiles from production instances, we anticipate a reduction of the heap by 15-20%. The change is behind the feature flag "ZOEKT_ENABLE_BTREE_NAME". 

For now, we use a makeshift wrapper just for the feature-flag (see comments in code). This is all temporary because I expect us to use the concrete type `btreeIndex` in indexdata as soon as we have validated the new code.

Test plan:
- With the exception of trivial tests for sizeBytes, all tests pass with and without the feature flag.  
- pprof

started webserver on a corpus of ~630 repos with and without ZOEKT_ENABLE_BTREE_NAME="1" 

```
ZOEKT_ENABLE_BTREE_NAME="1" ZOEKT_ENABLE_BTREE="1"  go run . --pprof --index ~/corpus/index
```

and compared the heap profiles, especially w.r.t. zoekt.(*indexdata).readFileNameNgrams

```
go tool pprof  -http=localhost:6073 http://localhost:6070/debug/pprof/heap
```

before:
<img width="1665" alt="Screenshot 2023-02-08 at 17 51 35" src="https://user-images.githubusercontent.com/26413131/217597679-4a0ba0fe-0f71-4158-9b1e-d72a32e76cdb.png">

after:
<img width="1663" alt="Screenshot 2023-02-08 at 17 51 26" src="https://user-images.githubusercontent.com/26413131/217597995-2576a672-f0de-4050-aa03-10c99eda65c7.png">




