### PR TITLE
fix typo (Github -> GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Zoekt comes with a small service management program:
     go install github.com/sourcegraph/zoekt/cmd/zoekt-indexserver
 
     cat << EOF > config.json
-    [{"GithubUser": "username"},
-     {"GithubOrg": "org"},
+    [{"GitHubUser": "username"},
+     {"GitHubOrg": "org"},
      {"GitilesURL": "https://gerrit.googlesource.com", "Name": "zoekt" }
     ]
     EOF

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -84,7 +84,7 @@ supported by all projects.
 
 ## What about the search on `github.com`?
 
-Github's search has great coverage, but unfortunately, its search
+GitHub's search has great coverage, but unfortunately, its search
 functionality doesn't support arbitrary substrings. For example, a
 query [for part of my
 surname](https://github.com/search?utf8=%E2%9C%93&q=nienhuy&type=Code)


### PR DESCRIPTION


[_Created by Sourcegraph batch change `sqs/github-case`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/github-case)