### PR TITLE
Add / route for healthcheck in zoekt-dynamic-indexserver

### DIFF
--- a/cmd/zoekt-dynamic-indexserver/main.go
+++ b/cmd/zoekt-dynamic-indexserver/main.go
@@ -128,6 +128,10 @@ type indexServer struct {
 	opts Options
 }
 
+func (s *indexServer) serveHealthCheck(w http.ResponseWriter, r *http.Request) {
+	// Nothing to do. Just return 200
+}
+
 func (s *indexServer) serveIndex(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
@@ -190,6 +194,7 @@ func respondWithError(w http.ResponseWriter, err error) {
 }
 
 func (s *indexServer) startIndexingApi() {
+	http.HandleFunc("/", s.serveHealthCheck)
 	http.HandleFunc("/index", s.serveIndex)
 	http.HandleFunc("/truncate", s.serveTruncate)
 


### PR DESCRIPTION
After trying to run this in K8s I realise we need a URL that will respond to `GET` and return 200 and the other 2 operations are both not safe to run as a health check.

It seemed easiest to have a `/` route. We could later add some help content or static JSON or HTML here but for now this seems like it's probably good enough.