### PR TITLE
Add Dockerfile for dynamic indexserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,13 @@ jobs:
           add_git_labels: "true"
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: build-push-dynamic-indexserver
+        uses: docker/build-push-action@v1
+        with:
+          repository: sourcegraph/zoekt-dynamic-indexserver
+          tags: ${{ steps.version.outputs.value }},latest
+          dockerfile: Dockerfile.dynamic-indexserver
+          add_git_labels: "true"
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile.dynamic-indexserver
+++ b/Dockerfile.dynamic-indexserver
@@ -1,0 +1,26 @@
+FROM alpine:3.16.2
+
+RUN apk update --no-cache && apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates bind-tools tini git jansson && \
+    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0'
+
+# Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
+RUN mkdir -p /home/sourcegraph
+RUN addgroup -S sourcegraph && adduser -S -G sourcegraph -h /home/sourcegraph sourcegraph && mkdir -p /data && chown -R sourcegraph:sourcegraph /data
+USER sourcegraph
+WORKDIR /home/sourcegraph
+
+ENV REPO_DIR /data/repo
+ENV DATA_DIR /data/index
+RUN mkdir -p ${DATA_DIR}
+RUN mkdir -p ${REPO_DIR}
+
+COPY --from=zoekt \
+    /usr/local/bin/universal-* \
+    /usr/local/bin/zoekt-dynamic-indexserver \
+    /usr/local/bin/zoekt-git-clone \
+    /usr/local/bin/zoekt-git-index \
+    /usr/local/bin/
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD zoekt-dynamic-indexserver -repo_dir $REPO_DIR -index_dir $DATA_DIR

--- a/cmd/zoekt-dynamic-indexserver/main.go
+++ b/cmd/zoekt-dynamic-indexserver/main.go
@@ -53,12 +53,11 @@ type Options struct {
 	indexTimeout time.Duration
 	repoDir      string
 	indexDir     string
-	repoDir      string
 	listen       string
 }
 
 func (o *Options) createMissingDirectories() {
-	for _, s := range []string{o.repoDir, o.indexDir, o.repoDir} {
+	for _, s := range []string{o.repoDir, o.indexDir} {
 		if err := os.MkdirAll(s, 0o755); err != nil {
 			log.Fatalf("MkdirAll %s: %v", s, err)
 		}
@@ -239,7 +238,6 @@ func parseOptions() Options {
 
 	return Options{
 		repoDir:      *repoDir,
-		repoDir:      filepath.Join(*repoDir, "repos"),
 		indexDir:     *indexDir,
 		indexTimeout: *timeout,
 		listen:       *listen,

--- a/cmd/zoekt-dynamic-indexserver/main.go
+++ b/cmd/zoekt-dynamic-indexserver/main.go
@@ -51,14 +51,14 @@ func loggedRun(cmd *exec.Cmd) error {
 
 type Options struct {
 	indexTimeout time.Duration
-	dataDir      string
+	repoDir      string
 	indexDir     string
 	repoDir      string
 	listen       string
 }
 
 func (o *Options) createMissingDirectories() {
-	for _, s := range []string{o.dataDir, o.indexDir, o.repoDir} {
+	for _, s := range []string{o.repoDir, o.indexDir, o.repoDir} {
 		if err := os.MkdirAll(s, 0o755); err != nil {
 			log.Fatalf("MkdirAll %s: %v", s, err)
 		}
@@ -222,23 +222,24 @@ func emptyDirectory(dir string) error {
 }
 
 func parseOptions() Options {
-	dataDir := flag.String("data_dir", "", "directory holding all data.")
-	indexDir := flag.String("index_dir", "", "directory holding index shards. Defaults to $data_dir/index/")
-	timeout := flag.Duration("index_timeout", time.Hour, "kill index job after this much time")
+	repoDir := flag.String("repo_dir", "", "directory holding cloned repos.")
+	indexDir := flag.String("index_dir", "", "directory holding index shards.")
+	timeout := flag.Duration("index_timeout", time.Hour, "kill index job after this much time.")
 	listen := flag.String("listen", ":6060", "listen on this address.")
 	flag.Parse()
 
-	if *dataDir == "" {
-		log.Fatal("must set -data_dir")
+	if *repoDir == "" {
+		log.Fatal("must set -repo_dir")
 	}
 
 	if *indexDir == "" {
-		*indexDir = filepath.Join(*dataDir, "index")
+		log.Fatal("must set -index_dir")
+		*indexDir = filepath.Join(*repoDir, "index")
 	}
 
 	return Options{
-		dataDir:      *dataDir,
-		repoDir:      filepath.Join(*dataDir, "repos"),
+		repoDir:      *repoDir,
+		repoDir:      filepath.Join(*repoDir, "repos"),
 		indexDir:     *indexDir,
 		indexTimeout: *timeout,
 		listen:       *listen,


### PR DESCRIPTION
This adds a new docker image for the `zoekt-dynamic-indexserver`. It
also follows the existing convention of using the username
`sourcegraph`. Ideally we'd be using the username `zoekt` but changing
this at this point may cause compatibility issues for others. From what I can research the sourcegraph chart is just mainly [depending on uid 100 and gid 101](https://github.com/sourcegraph/deploy-sourcegraph-helm/blob/8610892509ad8db7507ba979fd6d7dc41f3c1f44/charts/sourcegraph/values.yaml#L513-L514) but I'm not sure if there might be other compatibility issues.

This PR also changes the `data_dir` argument of `zoekt-dynamic-indexserver`. This is to avoid confusion where `DATA_DIR` is being used in `Dockerfile.webserver` as the index dir. This will cause confusion
because we are adding a new `Dockerfile.dynamic-indexserver`. In that
case we'll want to use consistent env var names and it will be confusing
that `$DATA_DIR` is being passed as `index_dir` and not `data_dir`. So
to avoid that confusion we remove the concept of `data_dir` argument
altogether and rename it to `repo_dir` since it is only used for cloning
repos anyway.