### PR TITLE
Add initial docs on /api/search endpoint

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,27 @@
+# API
+
+When running `zoekt-webserver` with the `-rpc` option there will be a JSON HTTP API available for searches at `/api/search`:
+
+```
+curl -XPOST -d '{"Q":"needle"}' 'http://127.0.0.1:6070/api/search'
+```
+
+## Filtering by repository IDs
+
+If your projects are indexed with a `repoid` (added automatically by some
+indexers) then you can filter your searches to a subset of repositories
+efficiently using the `RepoIDs` filter:
+
+```
+curl -XPOST -d '{"Q":"needle","RepoIDs":[1234,4567]}' 'http://34.120.239.98/api/search'
+```
+
+## Options
+
+There are multiple options that can be passed under `Opts` which can also be
+found at
+[SearchOptions](https://github.com/sourcegraph/zoekt/blob/58cf4748830ac0eded1517cc8c2454694c531fbd/api.go#L470).
+
+```
+curl -XPOST -d '{"Q":"needle","Opts":{"EstimateDocCount":true,"NumContextLines":10}}' 'http://34.120.239.98/api/search'
+```


### PR DESCRIPTION
There weren't any docs on this API endpoint and since we now have a few options it seemed beneficial to have a couple of simple examples.

I'm actually not sure on the overall strategy for docs in the Zoekt project since there are sparse docs at the moment in `doc/` but I figured adding something was better than nothing here. If keeping docs up to date in this project is not preferable then I'm also OK to just start doing this kind of documentation externally to the Zoekt project so that I have resources I can point people to.