### PR TITLE
doc: Add a doc/query_syntax.md page

### DIFF
--- a/doc/query_syntax.md
+++ b/doc/query_syntax.md
@@ -1,0 +1,5 @@
+# Query syntax
+
+Query syntax examples can be found on the index page of a running Zoekt webserver.
+These
+[example queries can also be viewed in the corresponding HTML template](../web/templates.go#L158).


### PR DESCRIPTION
This just links to the HTML source where there are already example queries. This will help with discovery and linking people to docs where they aren't running a local Zoekt instance.

I considered adding all these examples to a markdown page but the duplication seemed like it would be unhelpful trying to maintain multiple sets of documentation. Ideally we'd be able to have a rendered markdown list of examples as well as having it in the Zoekt web application and this might be possible but I wasn't sure what is an elegant way to do this other than some kind of hackery where we had the web page loading and rendering from the markdown source.

An alternative I considered which seems more logical to me (since it's easier for linking people) is to have the Zoekt homepage just link to the markdown docs and move all the examples into a markdown page.