### PR TITLE
set b-tree as default

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -1775,7 +1775,7 @@ func TestListRepos(t *testing.T) {
 			Stats: RepoStats{
 				Shards:                     1,
 				Documents:                  4,
-				IndexBytes:                 300,
+				IndexBytes:                 412,
 				ContentBytes:               68,
 				NewLinesCount:              4,
 				DefaultBranchNewLinesCount: 2,

--- a/ngramoffset.go
+++ b/ngramoffset.go
@@ -15,7 +15,6 @@
 package zoekt
 
 import (
-	"encoding/binary"
 	"sort"
 )
 
@@ -399,63 +398,4 @@ func (n fileNameNgrams) SizeBytes() int {
 		return 12 * len(n.m)
 	}
 	return n.bt.SizeBytes()
-}
-
-type binarySearchNgram struct {
-	// ngramText is the bytes at indexTOC.ngramText
-	//
-	// It is a sorted ngramSlice marshalled as list of bigendian uint64s.
-	ngramText []byte
-	// postingIndex is the index section of the compoundSection for the posting
-	// lists.
-	//
-	// It is a list of offsets in the a order corresponding with ngramText. It
-	// is marshalled as a list of bigendian uint32s.
-	postingOffsets []uint32
-	// postingDataSentinelOffset is where postingData ends in the index file.
-	// This is used to calculate the size of the last posting.
-	postingDataSentinelOffset uint32
-}
-
-func (b binarySearchNgram) Get(gram ngram) (ss simpleSection) {
-	getNGram := func(i int) ngram {
-		i *= ngramEncoding
-		return ngram(binary.BigEndian.Uint64(b.ngramText[i : i+ngramEncoding]))
-	}
-
-	size := len(b.ngramText) / ngramEncoding
-	if size == 0 {
-		return simpleSection{}
-	}
-	x := sort.Search(size, func(i int) bool { return gram <= getNGram(i) })
-	if x >= size || getNGram(x) != gram {
-		return simpleSection{}
-	}
-
-	if x+1 < size {
-		return simpleSection{
-			off: b.postingOffsets[x],
-			sz:  b.postingOffsets[x+1] - b.postingOffsets[x],
-		}
-	} else {
-		return simpleSection{
-			off: b.postingOffsets[x],
-			sz:  b.postingDataSentinelOffset - b.postingOffsets[x],
-		}
-	}
-}
-
-func (b binarySearchNgram) DumpMap() map[ngram]simpleSection {
-	ngramText := b.ngramText
-	m := make(map[ngram]simpleSection, len(ngramText)/ngramEncoding)
-	for len(ngramText) > 0 {
-		gram := ngram(binary.BigEndian.Uint64(ngramText))
-		ngramText = ngramText[ngramEncoding:]
-		m[gram] = b.Get(gram)
-	}
-	return m
-}
-
-func (b binarySearchNgram) SizeBytes() int {
-	return 0 // binarySearch only uses mmaped data.
 }

--- a/read.go
+++ b/read.go
@@ -480,19 +480,6 @@ func (d *indexData) readNgrams(toc *indexTOC) (combinedNgramOffset, error) {
 	return makeCombinedNgramOffset(ngrams, postingsIndex), nil
 }
 
-func (d *indexData) readBinarySearchNgrams(toc *indexTOC) (binarySearchNgram, error) {
-	ngramText, err := d.readSectionBlob(toc.ngramText)
-	if err != nil {
-		return binarySearchNgram{}, err
-	}
-
-	return binarySearchNgram{
-		ngramText:                 ngramText,
-		postingOffsets:            toc.postings.offsets,
-		postingDataSentinelOffset: toc.postings.data.off + toc.postings.data.sz,
-	}, nil
-}
-
 func (d *indexData) newBtreeIndex(ngramSec simpleSection, postings compoundSection) (btreeIndex, error) {
 	bi := btreeIndex{file: d.file}
 

--- a/read.go
+++ b/read.go
@@ -288,24 +288,18 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	if os.Getenv("ZOEKT_ENABLE_BTREE") != "" {
-		bt, err := d.newBtreeIndex(toc.ngramText, toc.postings)
-		if err != nil {
-			return nil, err
-		}
-		d.ngrams = bt
-	} else if os.Getenv("ZOEKT_ENABLE_NGRAM_BS") != "" {
-		bsMap, err := d.readBinarySearchNgrams(toc)
-		if err != nil {
-			return nil, err
-		}
-		d.ngrams = bsMap
-	} else {
+	if os.Getenv("ZOEKT_DISABLE_BTREE") != "" {
 		offsetMap, err := d.readNgrams(toc)
 		if err != nil {
 			return nil, err
 		}
 		d.ngrams = offsetMap
+	} else {
+		bt, err := d.newBtreeIndex(toc.ngramText, toc.postings)
+		if err != nil {
+			return nil, err
+		}
+		d.ngrams = bt
 	}
 
 	d.fileBranchMasks, err = readSectionU64(d.file, toc.branchMasks)
@@ -320,10 +314,10 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 
 	d.fileNameIndex = toc.fileNames.relativeIndex()
 
-	if os.Getenv("ZOEKT_ENABLE_BTREE_NAME") != "" {
-		d.fileNameNgrams.bt, err = d.newBtreeIndex(toc.nameNgramText, toc.namePostings)
-	} else {
+	if os.Getenv("ZOEKT_DISABLE_BTREE") != "" {
 		d.fileNameNgrams.m, err = d.readFileNameNgrams(toc)
+	} else {
+		d.fileNameNgrams.bt, err = d.newBtreeIndex(toc.nameNgramText, toc.namePostings)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The use of a b-tree has proven to be successful. Webserver's heap for a production instance of Sourcegraph shrank by 45% without a noticable impact on latency. Hence we set the b-tree as default. It can be disabled by setting `ZOEKT_DISABLE_BTREE=true` for webserver.

At the same time we remove `binarySearchNgram`, because it uses more disk accesses than the b-tree and keeps a reference to the posting offsets.

Once the b-tree has proven itself over a longer period of time, I will remove the alternative code path (`combinedNgramOffset`) and clean up the temporary structs and interfaces I created.

Test plan: 
- the b-tree is used in production for almost 2 weeks now without issue.
- all existing tests, except the one modified in this PR, pass.