### PR TITLE
Add prometheus metrics to zoekt-dynamic-indexserver

### DIFF
--- a/cmd/zoekt-dynamic-indexserver/main.go
+++ b/cmd/zoekt-dynamic-indexserver/main.go
@@ -130,29 +130,21 @@ func indexRepository(opts Options, req indexRequest) (map[string]any, error) {
 }
 
 type indexServer struct {
-	opts Options
+	opts                 Options
+	promRegistry         *prometheus.Registry
+	metricsRequestsTotal *prometheus.CounterVec
 }
 
 func (s *indexServer) serveHealthCheck(w http.ResponseWriter, r *http.Request) {
 	// Nothing to do. Just return 200
 }
 
-var (
-	promRegistry        = prometheus.NewRegistry()
-	metricRequestsTotal = promauto.With(promRegistry).NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "zoekt_dynamic_indexserver_requests_total",
-			Help: "Total number of HTTP requests by status code, method, and path.",
-		},
-		[]string{"method", "path", "code"},
-	)
-)
-
 func (s *indexServer) serveMetrics(w http.ResponseWriter, r *http.Request) {
-	promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{Registry: promRegistry}).ServeHTTP(w, r)
+	promhttp.HandlerFor(s.promRegistry, promhttp.HandlerOpts{Registry: s.promRegistry}).ServeHTTP(w, r)
 }
 
 func (s *indexServer) serveIndex(w http.ResponseWriter, r *http.Request) {
+	route := "index"
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	var req indexRequest
@@ -166,23 +158,24 @@ func (s *indexServer) serveIndex(w http.ResponseWriter, r *http.Request) {
 
 	response, err := indexRepository(s.opts, req)
 	if err != nil {
-		respondWithError(w, r, err)
+		s.respondWithError(w, r.Method, route, err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response)
 
-	incrementRequestsTotal(r, http.StatusOK)
+	s.incrementRequestsTotal(r.Method, route, http.StatusOK)
 }
 
 func (s *indexServer) serveTruncate(w http.ResponseWriter, r *http.Request) {
+	route := "truncate"
 	err := emptyDirectory(s.opts.repoDir)
 
 	if err != nil {
 		err = fmt.Errorf("Failed to empty repoDir repoDir: %v with error: %v", s.opts.repoDir, err)
 
-		respondWithError(w, r, err)
+		s.respondWithError(w, r.Method, route, err)
 		return
 	}
 
@@ -191,7 +184,7 @@ func (s *indexServer) serveTruncate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		err = fmt.Errorf("Failed to empty repoDir indexDir: %v with error: %v", s.opts.repoDir, err)
 
-		respondWithError(w, r, err)
+		s.respondWithError(w, r.Method, route, err)
 		return
 	}
 
@@ -201,18 +194,14 @@ func (s *indexServer) serveTruncate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(response)
 
-	incrementRequestsTotal(r, http.StatusOK)
+	s.incrementRequestsTotal(r.Method, route, http.StatusOK)
 }
 
-func incrementRequestsTotal(r *http.Request, responseCode int) {
-	metricRequestsTotal.With(prometheus.Labels{"code": strconv.Itoa(responseCode), "method": r.Method, "path": r.URL.Path}).Inc()
-}
-
-func respondWithError(w http.ResponseWriter, r *http.Request, err error) {
+func (s *indexServer) respondWithError(w http.ResponseWriter, method, route string, err error) {
 	responseCode := http.StatusInternalServerError
 
 	log.Print(err)
-	incrementRequestsTotal(r, responseCode)
+	s.incrementRequestsTotal(method, route, responseCode)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(responseCode)
@@ -224,13 +213,29 @@ func respondWithError(w http.ResponseWriter, r *http.Request, err error) {
 	_ = json.NewEncoder(w).Encode(response)
 }
 
-func (s *indexServer) startIndexingApi() {
+func (s *indexServer) incrementRequestsTotal(method, route string, responseCode int) {
+	s.metricsRequestsTotal.With(prometheus.Labels{"code": strconv.Itoa(responseCode), "method": method, "route": route}).Inc()
+}
+
+func (s *indexServer) initMetrics() {
+	s.promRegistry = prometheus.NewRegistry()
+
 	// Add go runtime metrics and process collectors.
-	promRegistry.MustRegister(
+	s.promRegistry.MustRegister(
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
 	)
 
+	s.metricsRequestsTotal = promauto.With(s.promRegistry).NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "zoekt_dynamic_indexserver_requests_total",
+			Help: "Total number of HTTP requests by status code, method, and route.",
+		},
+		[]string{"method", "route", "code"},
+	)
+}
+
+func (s *indexServer) startIndexingApi() {
 	http.HandleFunc("/", s.serveHealthCheck)
 	http.HandleFunc("/metrics", s.serveMetrics)
 	http.HandleFunc("/index", s.serveIndex)
@@ -291,5 +296,6 @@ func main() {
 		opts: opts,
 	}
 
+	server.initMetrics()
 	server.startIndexingApi()
 }

--- a/cmd/zoekt-dynamic-indexserver/main_test.go
+++ b/cmd/zoekt-dynamic-indexserver/main_test.go
@@ -55,6 +55,20 @@ func TestLoggedRunFailure(t *testing.T) {
 	}
 }
 
+func TestInitMetrics(t *testing.T) {
+	server := indexServer{}
+
+	server.initMetrics()
+
+	if server.promRegistry == nil {
+		t.Errorf("promRegistry shouldn't be nil")
+	}
+
+	if server.metricsRequestsTotal == nil {
+		t.Errorf("metricsRequestsTotal shouldn't be nil")
+	}
+}
+
 func TestIndexRepository(t *testing.T) {
 	var cmdHistory [][]string
 


### PR DESCRIPTION
This PR adds `/metrics` endpoint to `zoekt-dynamic-indexserver` with go runtime metrics as well as one custom metric called `zoekt_dynamic_indexserver_requests_total`.

This is a gist with an example response: https://gist.github.com/dgruzd/73ef2336f1058b2f7ddad02e5dcf5d2c