### PR TITLE
Ranking: sort and truncate files while collecting

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -431,8 +431,7 @@ nextFileMatch:
 		}
 	})
 
-	// I am slightly worried about negative interactions with TotalMaxMatchCount
-	// so feature flagging this behaviour behind UseDocumentRanks.
+	// If document ranking is enabled, then we can rank and truncate the files to save memory.
 	if limit := opts.MaxDocDisplayCount; opts.UseDocumentRanks && limit > 0 && limit < len(res.Files) {
 		SortFiles(res.Files)
 		res.Files = res.Files[:limit]


### PR DESCRIPTION
Before, the collector aggregated all file matches before flushing, when it
finally sorted and truncated them. Now we sort and limit while collecting
results, instead of at the end. This can help cut down on memory in the case
there are many shard results. (It won't help with `count: all` queries, where
MaxDocDisplayCount is not set.)

Another tiny benefit is that we obey FlushWallTime more closely. Before, we
might sort a large number of results after the time is already expired.