### PR TITLE
Ranking: increase contribution of repo rank

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -468,7 +468,7 @@ const (
 	// equal weight with the query-dependent signals.
 	scoreFileRankFactor  = 9000.0
 	scoreFileOrderFactor = 10.0
-	scoreShardRankFactor = 20.0
+	scoreRepoRankFactor  = 20.0
 
 	// Used for ordering line and chunk matches within a file.
 	scoreLineOrderFactor = 1.0

--- a/eval.go
+++ b/eval.go
@@ -385,7 +385,7 @@ nextFileMatch:
 		}
 
 		fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(nextDoc)/float64(len(d.boundaries))), opts.DebugScore)
-		fileMatch.addScore("shard-order", scoreShardRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
+		fileMatch.addScore("repo-rank", scoreRepoRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
 
 		fileMatch.Branches = d.gatherBranches(nextDoc, mt, known)
 		sortMatchesByScore(fileMatch.LineMatches)

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -202,10 +202,10 @@ func TestShardedSearcher_Ranking(t *testing.T) {
 		nextShardNum++
 	}
 
-	addShard("weekend-project", 0.25, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
-	addShard("moderately-popular", 0.5, zoekt.Document{Name: "f3", Content: []byte("foo bar")})
-	addShard("weekend-project-2", 0.25, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
-	addShard("super-star", 0.9, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})
+	addShard("weekend-project", 20, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
+	addShard("moderately-popular", 500, zoekt.Document{Name: "f3", Content: []byte("foo bar")})
+	addShard("weekend-project-2", 20, zoekt.Document{Name: "f2", Content: []byte("foo bas")})
+	addShard("super-star", 5000, zoekt.Document{Name: "f1", Content: []byte("foo bar bas")})
 
 	want := []string{
 		"super-star",
@@ -244,10 +244,10 @@ func TestShardedSearcher_DocumentRanking(t *testing.T) {
 		nextShardNum++
 	}
 
-	addShard("weekend-project", 0.25, zoekt.Document{Name: "f1", Content: []byte("foobar")})
-	addShard("moderately-popular", 0.4, zoekt.Document{Name: "f2", Content: []byte("foobaz")})
-	addShard("weekend-project-2", 0.25, zoekt.Document{Name: "f3", Content: []byte("foo bar")})
-	addShard("super-star", 0.9, zoekt.Document{Name: "f4", Content: []byte("foo baz")},
+	addShard("weekend-project", 20, zoekt.Document{Name: "f1", Content: []byte("foobar")})
+	addShard("moderately-popular", 500, zoekt.Document{Name: "f2", Content: []byte("foobaz")})
+	addShard("weekend-project-2", 20, zoekt.Document{Name: "f3", Content: []byte("foo bar")})
+	addShard("super-star", 5000, zoekt.Document{Name: "f4", Content: []byte("foo baz")},
 		zoekt.Document{Name: "f5", Content: []byte("fooooo")})
 
 	// Run a stream search and gather the results


### PR DESCRIPTION
The file score includes a "repo rank" signal, which is based on the repository's number of stars. Previously, we were aggressively normalizing the number of stars, which made the repo ranks small and close together. This PR changes the normalization to spread it out better over the full range. This increases its contribution to the score.

This would address a couple complaints we got about ranking. Here's an example where the `llvm/llvm-project` should be the first result:
![Screenshot 2023-02-24 at 7 24 58 PM](https://user-images.githubusercontent.com/7461306/221333770-67680556-cff1-47cf-9622-ea0379b1e58d.png)

Now, `llvm/llvm-project` will have repo rank 15.68, pushing it above the first result with repo rank 0.82.