### PR TITLE
query: parse support for `fork:` and `public:`

### DIFF
--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -167,6 +167,7 @@ func main() {
 			"zoekt.gerrit-project": k,
 			"zoekt.gerrit-host":    rootURL.String(),
 			"zoekt.archived":       marshalBool(v.State == "READ_ONLY"),
+			"zoekt.public":         marshalBool(v.State != "HIDDEN"),
 		}
 
 		for _, wl := range v.WebLinks {

--- a/cmd/zoekt-mirror-github/main.go
+++ b/cmd/zoekt-mirror-github/main.go
@@ -296,11 +296,6 @@ func cloneRepos(destDir string, repos []*github.Repository) error {
 			return err
 		}
 
-		archived := false
-		if r.Archived != nil {
-			archived = *r.Archived
-		}
-
 		config := map[string]string{
 			"zoekt.web-url-type": "github",
 			"zoekt.web-url":      *r.HTMLURL,
@@ -311,7 +306,9 @@ func cloneRepos(destDir string, repos []*github.Repository) error {
 			"zoekt.github-subscribers": itoa(r.SubscribersCount),
 			"zoekt.github-forks":       itoa(r.ForksCount),
 
-			"zoekt.archived": marshalBool(archived),
+			"zoekt.archived": marshalBool(r.Archived != nil && *r.Archived),
+			"zoekt.fork":     marshalBool(r.Fork != nil && *r.Fork),
+			"zoekt.public":   marshalBool(r.Private == nil || !*r.Private),
 		}
 		dest, err := gitindex.CloneRepo(destDir, *r.FullName, *r.CloneURL, config)
 		if err != nil {

--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -177,6 +177,8 @@ func fetchProjects(destDir, token string, projects []*gitlab.Project) {
 			"zoekt.gitlab-forks": strconv.Itoa(p.ForksCount),
 
 			"zoekt.archived": marshalBool(p.Archived),
+			"zoekt.fork":     marshalBool(p.ForkedFromProject != nil),
+			"zoekt.public":   marshalBool(p.Public),
 		}
 
 		cloneURL := p.HTTPURLToRepo

--- a/query/parse.go
+++ b/query/parse.go
@@ -134,6 +134,24 @@ func parseExpr(in []byte) (Q, int, error) {
 		default:
 			return nil, 0, fmt.Errorf("query: unknown archived argument %q, want {yes,no}", text)
 		}
+	case tokFork:
+		switch text {
+		case "yes":
+			expr = RawConfig(RcOnlyForks)
+		case "no":
+			expr = RawConfig(RcNoForks)
+		default:
+			return nil, 0, fmt.Errorf("query: unknown fork argument %q, want {yes,no}", text)
+		}
+	case tokPublic:
+		switch text {
+		case "yes":
+			expr = RawConfig(RcOnlyPublic)
+		case "no":
+			expr = RawConfig(RcOnlyPrivate)
+		default:
+			return nil, 0, fmt.Errorf("query: unknown public argument %q, want {yes,no}", text)
+		}
 	case tokBranch:
 		expr = &Branch{Pattern: text}
 	case tokText, tokRegex:
@@ -148,7 +166,6 @@ func parseExpr(in []byte) (Q, int, error) {
 			return nil, 0, err
 		}
 		expr = q
-
 	case tokContent:
 		q, err := RegexpQuery(text, true, false)
 		if err != nil {
@@ -374,6 +391,8 @@ const (
 	tokSym        = 13
 	tokType       = 14
 	tokArchived   = 15
+	tokPublic     = 16
+	tokFork       = 17
 )
 
 var tokNames = map[int]string{
@@ -382,10 +401,12 @@ var tokNames = map[int]string{
 	tokCase:       "Case",
 	tokError:      "Error",
 	tokFile:       "File",
+	tokFork:       "Fork",
 	tokNegate:     "Negate",
 	tokOr:         "Or",
 	tokParenClose: "ParenClose",
 	tokParenOpen:  "ParenOpen",
+	tokPublic:     "Public",
 	tokRegex:      "Regex",
 	tokRepo:       "Repo",
 	tokText:       "Text",
@@ -403,6 +424,8 @@ var prefixes = map[string]int{
 	"content:":  tokContent,
 	"f:":        tokFile,
 	"file:":     tokFile,
+	"fork:":     tokFork,
+	"public:":   tokPublic,
 	"r:":        tokRepo,
 	"regex:":    tokRegex,
 	"repo:":     tokRepo,

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -67,6 +67,10 @@ func TestParseQuery(t *testing.T) {
 		{"((x|y) )", &Regexp{Regexp: mustParseRE("[xy]")}},
 		{"archived:yes", RawConfig(RcOnlyArchived)},
 		{"archived:no", RawConfig(RcNoArchived)},
+		{"fork:yes", RawConfig(RcOnlyForks)},
+		{"fork:no", RawConfig(RcNoForks)},
+		{"public:yes", RawConfig(RcOnlyPublic)},
+		{"public:no", RawConfig(RcOnlyPrivate)},
 		{"file:helpers\\.go byte", NewAnd(
 			&Substring{Pattern: "helpers.go", FileName: true},
 			&Substring{Pattern: "byte"})},

--- a/web/templates.go
+++ b/web/templates.go
@@ -172,6 +172,8 @@ document.onkeydown=function(e){
           <dt><a href="search?q=sym:data">sym:data</a></span></dt><dd>search for symbol definitions containing "data"</dd>
           <dt><a href="search?q=phone+r:droid">phone r:droid</a></dt><dd>search for "phone" in repositories whose name contains "droid"</dd>
           <dt><a href="search?q=phone+archived:no">phone archived:no</a></dt><dd>search for "phone" in repositories that are not archived</dd>
+          <dt><a href="search?q=phone+fork:no">phone fork:no</a></dt><dd>search for "phone" in repositories that are not forks</dd>
+          <dt><a href="search?q=phone+public:no">phone public:no</a></dt><dd>search for "phone" in repositories that are not public</dd>
           <dt><a href="search?q=phone+b:master">phone b:master</a></dt><dd>for Git repos, find "phone" in files in branches whose name contains "master".</dd>
           <dt><a href="search?q=phone+b:HEAD">phone b:HEAD</a></dt><dd>for Git repos, find "phone" in the default ('HEAD') branch.</dd>
         </dl>


### PR DESCRIPTION
Add support for parsing queries for zoekt.fork and zoekt.public.

Closes #549.