### PR TITLE
Update to Go 1.19.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: CI
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: alpine:edge # go1.18 needs > alpine 3.15
+    container: alpine:edge # go1.19 needs > alpine 3.15
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.3
+golang 1.19.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-alpine3.16 AS builder
+FROM golang:1.19.6-alpine3.16 AS builder
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Update to 1.19.6 because it fixes a bunch of CVEs.

[_Created by Sourcegraph batch change `jhchabran/update-to-go-1.19.6`._](https://sourcegraph.sourcegraph.com/users/jhchabran/batch-changes/update-to-go-1.19.6)