### PR TITLE
Ranking: adapt to new ranking service API

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -1175,7 +1175,7 @@ func TestScoringWithDocumentRanks(t *testing.T) {
 
 	cases := []struct {
 		name                string
-		documentRanks       []float64
+		documentRank        float64
 		documentRanksWeight float64
 		wantScore           float64
 	}{
@@ -1185,17 +1185,17 @@ func TestScoringWithDocumentRanks(t *testing.T) {
 			wantScore: 7012.00,
 		},
 		{
-			name:          "score with document ranks",
-			documentRanks: []float64{0, 0, 0, 0, 0.8, 0, 0},
-			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word match) + 7200 (file rank) + 10 (file order)
-			wantScore: 14212.00,
+			name:         "score with document ranks",
+			documentRank: 0.8,
+			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word match) + 225 (file rank) + 10 (file order)
+			wantScore: 7237.00,
 		},
 		{
 			name:                "score with custom document ranks weight",
-			documentRanks:       []float64{0, 0, 0, 0, 0.8, 0, 0},
+			documentRank:        0.8,
 			documentRanksWeight: 1000.0,
-			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word match) + 800 (file rank) + 10 (file order)
-			wantScore: 7812.00,
+			// 5500 (partial symbol at boundary) + 1000 (Java class) + 500 (word match) + 25.00 (file rank) + 10 (file order)
+			wantScore: 7037.00,
 		},
 	}
 
@@ -1206,7 +1206,7 @@ func TestScoringWithDocumentRanks(t *testing.T) {
 				t.Fatalf("NewBuilder: %v", err)
 			}
 
-			err = b.Add(zoekt.Document{Name: "example.java", Content: exampleJava, Ranks: c.documentRanks})
+			err = b.Add(zoekt.Document{Name: "example.java", Content: exampleJava, Ranks: []float64{c.documentRank}})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -78,11 +78,16 @@ type Sourcegraph interface {
 	// GetDocumentRanks returns a map from paths within the given repo to their
 	// rank vectors. Paths are assumed to be ordered by each pairwise component of
 	// the resulting vector, higher ranks coming earlier
-	GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error)
+	GetDocumentRanks(ctx context.Context, repoName string) (RepoPathRanks, error)
 
 	// UpdateIndexStatus sends a request to Sourcegraph to confirm that the
 	// given repositories have been indexed.
 	UpdateIndexStatus(repositories []indexStatus) error
+}
+
+type RepoPathRanks struct {
+	MeanRank float64            `json:"mean_reference_count"`
+	Paths    map[string]float64 `json:"paths"`
 }
 
 func newSourcegraphClient(rootURL *url.URL, hostname string, batchSize int) *sourcegraphClient {
@@ -166,34 +171,20 @@ func (s *sourcegraphClient) GetRepoRank(ctx context.Context, repoName string) ([
 
 // GetDocumentRanks asks Sourcegraph for a mapping of file paths to rank
 // vectors.
-func (s *sourcegraphClient) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
+func (s *sourcegraphClient) GetDocumentRanks(ctx context.Context, repoName string) (RepoPathRanks, error) {
 	u := s.Root.ResolveReference(&url.URL{
 		Path: "/.internal/ranks/" + strings.Trim(repoName, "/") + "/documents",
 	})
 
 	b, err := s.get(ctx, u)
 	if err != nil {
-		return nil, err
+		return RepoPathRanks{}, err
 	}
 
-	ranks := make(map[string][]float64)
+	ranks := RepoPathRanks{}
 	err = json.Unmarshal(b, &ranks)
 	if err != nil {
-		return nil, err
-	}
-
-	// Invariant: All rank vectors have the same length.
-	first := true
-	wantLen := -1
-	for _, v := range ranks {
-		if first {
-			first = false
-			wantLen = len(v)
-			continue
-		}
-		if len(v) != wantLen {
-			return nil, fmt.Errorf("found rank vectors of different length %d<>%d\n", wantLen, len(v))
-		}
+		return RepoPathRanks{}, err
 	}
 
 	return ranks, nil
@@ -517,28 +508,35 @@ func (sf sourcegraphFake) GetRepoRank(ctx context.Context, repoName string) ([]f
 }
 
 // GetDocumentRanks expects a file where each line has the following format:
-// path<tab>rank... where rank is a float64 in [0,1]. Multiple ranks are
-// separated by a comma. Each line must have the same number of ranks.
-func (sf sourcegraphFake) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
+// path<tab>rank... where rank is a float64.
+func (sf sourcegraphFake) GetDocumentRanks(ctx context.Context, repoName string) (RepoPathRanks, error) {
 	dir := filepath.Join(sf.RootDir, filepath.FromSlash(repoName))
 
 	fd, err := os.Open(filepath.Join(dir, "SG_DOCUMENT_RANKS"))
 	if err != nil {
-		return nil, err
+		return RepoPathRanks{}, err
 	}
 
-	ranks := make(map[string][]float64)
+	ranks := RepoPathRanks{}
 
+	sum := 0.0
+	count := 0
 	scanner := bufio.NewScanner(fd)
 	for scanner.Scan() {
 		s := scanner.Text()
 		pathRanks := strings.Split(s, "\t")
-		ranks[pathRanks[0]] = floats64(pathRanks[1])
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+		if rank, err := strconv.ParseFloat(pathRanks[1], 64); err == nil {
+			ranks.Paths[pathRanks[0]] = rank
+			sum += rank
+			count++
+		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return RepoPathRanks{}, err
+	}
+
+	ranks.MeanRank = sum / float64(count)
 	return ranks, nil
 }
 
@@ -790,8 +788,8 @@ func (s sourcegraphNop) GetRepoRank(ctx context.Context, repoName string) ([]flo
 	return nil, nil
 }
 
-func (s sourcegraphNop) GetDocumentRanks(ctx context.Context, repoName string) (map[string][]float64, error) {
-	return nil, nil
+func (s sourcegraphNop) GetDocumentRanks(ctx context.Context, repoName string) (RepoPathRanks, error) {
+	return RepoPathRanks{}, nil
 }
 
 func (s sourcegraphNop) UpdateIndexStatus(repositories []indexStatus) error {

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -494,7 +494,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 		return fmt.Errorf("build.NewBuilder: %w", err)
 	}
 
-	var ranks map[string][]float64
+	var ranks repoPathRanks
 	if opts.BuildOptions.DocumentRanksPath != "" {
 		data, err := os.ReadFile(opts.BuildOptions.DocumentRanksPath)
 		if err != nil {
@@ -554,18 +554,31 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 			if err != nil {
 				return err
 			}
+
+			var pathRank []float64
+			if rank, ok := ranks.Paths[keyFullPath]; ok {
+				pathRank = []float64{rank}
+			}
+			fmt.Printf("path: %s, ranks length: %d", keyFullPath, len(pathRank))
+
 			if err := builder.Add(zoekt.Document{
 				SubRepositoryPath: key.SubRepoPath,
 				Name:              keyFullPath,
 				Content:           contents,
 				Branches:          brs,
-				Ranks:             ranks[keyFullPath],
+				Ranks:             pathRank,
 			}); err != nil {
 				return fmt.Errorf("error adding document with name %s: %w", keyFullPath, err)
 			}
 		}
 	}
+
 	return builder.Finish()
+}
+
+type repoPathRanks struct {
+	MeanRank float64            `json:"mean_reference_count"`
+	Paths    map[string]float64 `json:"paths"`
 }
 
 func newIgnoreMatcher(tree *object.Tree) (*ignore.Matcher, error) {


### PR DESCRIPTION
We are updating the ranking service API to only return a single rank representing the log of each file's reference counts. This PR adapts zoekt-indexserver to the new API shape, and updates the normalization strategy. For now, it doesn't change the on-disk format to keep the change simple.