### PR TITLE
Resolve dependency CVEs

### DIFF
--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,9 +1,8 @@
-FROM alpine:3.16.2
+FROM alpine:3.16
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson && \
-    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0'
-
+    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0' 'e2fsprogs>=1.46.6-r0'
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph
 RUN addgroup -S sourcegraph && adduser -S -G sourcegraph -h /home/sourcegraph sourcegraph && mkdir -p /data && chown -R sourcegraph:sourcegraph /data

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.16.4
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson && \

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,4 +1,4 @@
-FROM alpine:3.16.2
+FROM alpine:3.16
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
    apk add --no-cache ca-certificates bind-tools tini

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.16.4
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
    apk add --no-cache ca-certificates bind-tools tini


### PR DESCRIPTION
- Use Alpine 3.16 base image
- Force newer version for e2fsprogs

Trivy reports no vulnerabilities. 