### PR TITLE
Ranking: handle files with missing ranks

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -757,6 +757,40 @@ func TestFindRepositoryMetadata(t *testing.T) {
 	}
 }
 
+func TestIsLowPriority(t *testing.T) {
+	cases := []string{
+		"builder_test.go",
+		"TestQuery.java",
+		"test/mocks.go",
+		"search/vendor/thirdparty.cc",
+		"search/node_modules/search/index.js",
+		"search.min.js",
+		"internal/search.js.map",
+	}
+
+	for _, tt := range cases {
+		t.Run(tt, func(t *testing.T) {
+			if !IsLowPriority(tt) {
+				t.Errorf("expected file '%s' to be low priority", tt)
+			}
+		})
+	}
+
+	negativeCases := []string{
+		"builder.go",
+		"RoutesTrigger.java",
+		"search.js",
+	}
+
+	for _, tt := range negativeCases {
+		t.Run(tt, func(t *testing.T) {
+			if IsLowPriority(tt) {
+				t.Errorf("did not expect file '%s' to be low priority", tt)
+			}
+		})
+	}
+}
+
 func createTestShard(t *testing.T, indexDir string, r zoekt.Repository, numShards int, optFns ...func(options *Options)) []string {
 	t.Helper()
 

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -695,6 +695,63 @@ func TestIndexDeltaBasic(t *testing.T) {
 	}
 }
 
+func TestRepoPathRanks(t *testing.T) {
+	pathRanks := repoPathRanks{
+		Paths: map[string]float64{
+			"search.go":              10.23,
+			"internal/index.go":      5.5,
+			"internal/scratch.go":    0.0,
+			"backend/search_test.go": 2.1,
+		},
+		MeanRank: 3.3,
+	}
+	cases := []struct {
+		name string
+		path string
+		rank float64
+	}{
+		{
+			name: "rank for standard file",
+			path: "search.go",
+			rank: 10.23,
+		},
+		{
+			name: "file with rank 0",
+			path: "internal/scratch.go",
+			rank: 0.0,
+		},
+		{
+			name: "rank for test file",
+			path: "backend/search_test.go",
+			rank: 2.1,
+		},
+		{
+			name: "file with missing rank",
+			path: "internal/docs.md",
+			rank: 3.3,
+		},
+		{
+			name: "test file with missing rank",
+			path: "backend/index_test.go",
+			rank: 0.0,
+		},
+		{
+			name: "third-party file with missing rank",
+			path: "node_modules/search/index.js",
+			rank: 0.0,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathRanks.rank(tt.path)
+			if got != tt.rank {
+				t.Errorf("expected file '%s' to have rank %f, but got %f", tt.path, tt.rank, got)
+			}
+		})
+	}
+}
+
 func runScript(t *testing.T, cwd string, script string) {
 	err := os.MkdirAll(cwd, 0755)
 	if err != nil {


### PR DESCRIPTION
Even when a repo has ranking data, certain files will not have ranks, like Markdown or yaml files. Currently these have rank 0, which puts them at a big disadvantage and means they're usually ranked last.

This PR proposes to use the mean repo rank instead of 0. The rules:
* If we have a concrete rank for the file, always use it
* If there's no rank, and it's a low priority file like a test, then use rank 0
* Otherwise use the mean rank for the repository