### PR TITLE
pin versions of protoc-gen-go and grpc/go plugins 

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1/buf.gen.yaml
+++ b/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1/buf.gen.yaml
@@ -1,11 +1,11 @@
 # Configuration file for https://buf.build/, which we use for Protobuf code generation.
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/go
+  - plugin: buf.build/protocolbuffers/go:v1.28.1
     out: .
     opt:
       - paths=source_relative
-  - plugin: buf.build/grpc/go
+  - plugin: buf.build/grpc/go:v1.3.0
     out: .
     opt:
       - paths=source_relative


### PR DESCRIPTION
This PR pins the versions of:

 - [protoc-gen-go](https://buf.build/protocolbuffers/go) to `v1.28.1` 
- [grpc/go](https://buf.build/grpc/go) plugins to `v1.3.0`