### PR TITLE
chore: remove check for ZOEKT_ENABLE_NGRAM_BS

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"regexp/syntax"
 	"strings"

--- a/index_test.go
+++ b/index_test.go
@@ -1783,10 +1783,6 @@ func TestListRepos(t *testing.T) {
 			},
 		}
 
-		if os.Getenv("ZOEKT_ENABLE_NGRAM_BS") != "" {
-			want.Stats.IndexBytes = 228
-		}
-
 		if diff := cmp.Diff(want, res); diff != "" {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}


### PR DESCRIPTION
I removed the code for binary search ngrams in #540, so this check is not needed anymore.