### PR TITLE
eval: fix gatherBranches

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -563,41 +563,37 @@ func (d *indexData) branchIndex(docID uint32) int {
 	return -1
 }
 
-// gatherBranches returns a list of branch names.
+// gatherBranches returns a list of branch names taking into account any branch
+// filters in the query. If the query contains a branch filter, it returns all
+// branches containing the docID and matching the branch filter. Otherwise, it
+// returns all branches containing docID.
 func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTree]bool) []string {
 	repoIdx := d.repos[docID]
 
-	gather := func(mask uint64) []string {
-		var branches []string
-		id := uint32(1)
-		for mask != 0 {
-			if mask&0x1 != 0 {
-				branches = append(branches, d.branchNames[repoIdx][uint(id)])
-			}
-			id <<= 1
-			mask >>= 1
-		}
-
-		return branches
-	}
-
-	foundBranchQuery := false
-	var branches []string
+	var mask uint64
 	visitMatches(mt, known, func(mt matchTree) {
 		bq, ok := mt.(*branchQueryMatchTree)
 		if !ok {
 			return
 		}
-		foundBranchQuery = true
-		mask := bq.masks[repoIdx] & bq.fileMasks[docID]
-		branches = append(branches, gather(mask)...)
+
+		// bq.masks[repoIdx]: the branches we are filtering on
+		// bq.branchMask(): the branches of the current file
+		mask = mask | (bq.masks[repoIdx] & bq.branchMask())
 	})
 
-	// If the query doesn't contain a "branch:" filter, we return all branches for
-	// docID.
-	if !foundBranchQuery {
-		mask := d.fileBranchMasks[docID]
-		branches = gather(mask)
+	if mask == 0 {
+		mask = d.fileBranchMasks[docID]
+	}
+
+	var branches []string
+	id := uint32(1)
+	for mask != 0 {
+		if mask&0x1 != 0 {
+			branches = append(branches, d.branchNames[repoIdx][uint(id)])
+		}
+		id <<= 1
+		mask >>= 1
 	}
 
 	return branches

--- a/matchtree.go
+++ b/matchtree.go
@@ -181,6 +181,10 @@ type branchQueryMatchTree struct {
 	docID     uint32
 }
 
+func (t *branchQueryMatchTree) branchMask() uint64 {
+	return t.fileMasks[t.docID]
+}
+
 type symbolRegexpMatchTree struct {
 	matchTree
 	regexp *regexp.Regexp
@@ -672,7 +676,7 @@ func (t *orMatchTree) matches(cp *contentProvider, cost int, known map[matchTree
 }
 
 func (t *branchQueryMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) (bool, bool) {
-	return t.fileMasks[t.docID]&t.masks[t.repos[t.docID]] != 0, true
+	return t.branchMask()&t.masks[t.repos[t.docID]] != 0, true
 }
 
 func (t *regexpMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) (bool, bool) {


### PR DESCRIPTION
fixes #561

The display behavior is now as follows:
- If the query doesn't contain a "branch:" filter, we list all branches that contain the file next to the filename.
- If a "branch:" filter is specified, we only list the branches that match the filter and not all branches that contain the file.

Test plan:
- new unit test
- created a dummy repo with two branches to reproduce the issue and verfied that this PR fixes the bug.