### PR TITLE
GobEncode for query.Repo

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -176,6 +176,16 @@ func (q *Repo) String() string {
 	return fmt.Sprintf("repo:%s", q.Regexp.String())
 }
 
+func (q Repo) GobEncode() ([]byte, error) {
+	return []byte(q.Regexp.String()), nil
+}
+
+func (q *Repo) GobDecode(data []byte) error {
+	var err error
+	q.Regexp, err = regexp.Compile(string(data))
+	return err
+}
+
 // RepoRegexp is a Sourcegraph addition which searches documents where the
 // repository name matches Regexp.
 type RepoRegexp struct {


### PR DESCRIPTION
Allows `repo:whatever` (and/or any query with `query.Repo`) to be used as a query over rpc/Gob 

Fixes #563.