### PR TITLE
chore: fix failing sync task

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
           branch: 'zoekt/update'
           delete-branch: 'true'
-          team-reviewers: 'search-core'
+          team-reviewers: 'sourcegraph/search-team'
           base: 'main'
 
       - name: 'Check PR outputs'


### PR DESCRIPTION
The search-core team has been renamed to search-team, resulting in the failure of the sync job.