### PR TITLE
gitindex: set protocol.file.allow just in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
         run: apk add go git
       - name: install ctags
         run: ./install-ctags-alpine.sh
-      # Needed for submodule tests in gitindex
-      - name: git protocol.file.allow
-        run: git config --global --replace-all protocol.file.allow always
       - name: test
         run: go test ./...
 

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -40,7 +40,13 @@ func createSubmoduleRepo(dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	script := `mkdir adir bdir
+	script := `
+# Fix fatal: transport 'file' not allowed
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=protocol.file.allow
+export GIT_CONFIG_VALUE_0=always
+
+mkdir adir bdir
 cd adir
 git init -b master
 mkdir subdir


### PR DESCRIPTION
This makes it so you can run submodule tests without first adjusting your global environment to allow file clones. This was a somewhat recent change in git to require opting in. Previously we would just set the config in CI, but now we just always do it _just_ for that test run.

Test Plan: go test and CI

Fixes https://github.com/sourcegraph/zoekt/issues/567