### PR TITLE
query: handle parse function not consuming all of input

### DIFF
--- a/query/parse.go
+++ b/query/parse.go
@@ -76,9 +76,13 @@ func isSpace(c byte) bool {
 func Parse(qStr string) (Q, error) {
 	b := []byte(qStr)
 
-	qs, _, err := parseExprList(b)
+	qs, n, err := parseExprList(b)
 	if err != nil {
 		return nil, err
+	}
+
+	if n != len(b) {
+		return nil, fmt.Errorf("query: extra tokens found at end input: %q", b[n:])
 	}
 
 	q, err := parseOperators(qs)

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -125,7 +125,27 @@ func TestParseQuery(t *testing.T) {
 		{"or abc", nil},
 		{"def or or abc", nil},
 
+		// unbalanced parentheses
+		{"(", nil},
+		{"((", nil},
+		{"(((", nil},
+		{")", nil},
+		{"))", nil},
+		{")))", nil},
+		{"foo)", nil},
+		{"foo))", nil},
+		{"foo)))", nil},
+		{"(foo", nil},
+		{"((foo", nil},
+		{"(((foo", nil},
+		{"(foo))", nil},
+		{"(((foo))", nil},
+
 		{"", &Const{Value: true}},
+
+		// whitespace
+		{"  (  )  ", &Const{Value: true}},
+		{"  ( foo )  ", &Substring{Pattern: "foo"}},
 	} {
 		got, err := Parse(c.in)
 		if (c.want == nil) != (err != nil) {


### PR DESCRIPTION
Previously we silently ignored it. For example a search like `(foo))`
would just work since we would only parse `(foo)`. We now report back to
the user the problem.

Note: we already had special handling for unbalanced parenthesis like
this `((foo)`.

Test Plan: added more test cases. Especially tried to explore areas we
could validly not consume the whole input but couldn't find one.

Fixes https://github.com/sourcegraph/zoekt/issues/547