### PR TITLE
nix: use flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1676110339,
+        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "The Zoekt developer environment Nix Flake";
+
+  inputs = { nixpkgs.url = "nixpkgs/nixos-unstable"; };
+
+  outputs = { self, nixpkgs }: {
+    devShells = nixpkgs.lib.genAttrs [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.ctags ];
+        };
+      in { default = import ./shell.nix { inherit pkgs; }; });
+    # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
+    overlays.ctags = self: super: rec {
+      universal-ctags = super.universal-ctags.overrideAttrs (old: {
+        version = "5.9.20220403.0";
+        src = super.fetchFromGitHub {
+          owner = "universal-ctags";
+          repo = "ctags";
+          rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
+          sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
+        };
+        # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
+        doCheck = false;
+        checkFlags = [ ];
+      });
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,45 +1,22 @@
+{ pkgs }:
 let
-  # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
-  ctags-overlay = (self: super: {
-    universal-ctags = super.universal-ctags.overrideAttrs (old: {
-      version = "5.9.20220403.0";
-      src = super.fetchFromGitHub {
-        owner = "universal-ctags";
-        repo = "ctags";
-        rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
-        sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
-      };
-      # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
-      doCheck = false;
-      checkFlags = [ ];
-    });
-  });
-  # Pin a specific version of nixpkgs to ensure we get the same packages.
- pkgs = import
-    (fetchTarball {
-      url =
-        "https://github.com/NixOS/nixpkgs/archive/6f38b43c8c84c800f93465b2241156419fd4fd52.tar.gz";
-      sha256 = "0xw3y3jx1bcnwsc0imacbp5m8f51b66s9h8kk8qnfbckwv67dhgd";
-    })
-    { overlays = [ ctags-overlay ]; };
   # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
   # like zoekt expects.
-  ctagsWrapper = pkgs.writeScriptBin "universal-ctags" ''
+  universal-ctags = pkgs.writeScriptBin "universal-ctags" ''
     #!${pkgs.stdenv.shell}
     exec ${pkgs.universal-ctags}/bin/ctags "$@"
   '';
-
-in pkgs.mkShell {
+in
+pkgs.mkShell {
   name = "zoekt";
 
   nativeBuildInputs = [
-    pkgs.go_1_19
+    pkgs.go_1_20
 
     # zoekt-git-index
     pkgs.git
 
     # Used to index symbols
-    ctagsWrapper
-    pkgs.universal-ctags
+    universal-ctags
   ];
 }


### PR DESCRIPTION
This copies how we do it in the Sourcegraph repo, using the same lock file to ensure we are using the same versions.

Test Plan: nix develop