### PR TITLE
matchtree: disable word search optimization for symbol search

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -169,7 +169,7 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *SearchOptions) 
 
 	q = query.Map(q, query.ExpandFileContent)
 
-	mt, err := d.newMatchTree(q)
+	mt, err := d.newMatchTree(q, matchTreeOpt{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this change case sensitive symbol searches of the form \bLITERAL\b would result in the error message

```
found *zoekt.andMatchTree inside query.Symbol
```

The root cause is the symbol search code is pretty janky. It constructs a matchtree and then pulls out either the regex matchtree or the substr matchtree, then creates a specific symbol searcher for those. It feels like it could be more generic rather than a bunch of hard to follow copy pasta. For now this was a more straightforward fix than creating a word search for symbols.

Test Plan: expanded the unit tests to cover word search more often. Additionally run zoekt-webserver and checked that a search like the following works now:

```
sym:\bnewMatchTree\b case:yes
```

Fixes https://github.com/sourcegraph/sourcegraph/issues/49892