### PR TITLE
fix team reviewer

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
           branch: 'zoekt/update'
           delete-branch: 'true'
-          team-reviewers: 'sourcegraph/search-team'
+          team-reviewers: 'search-team'
           base: 'main'
 
       - name: 'Check PR outputs'


### PR DESCRIPTION
update team reviewers due to github changes

Github recently changed their API, which no longer allows(reqiures) the org prefix on team reviewers.

Response from github:

I took a look and it does seem like we made changes to the API endpoint about the time the report was first made in the https://github.com/peter-evans/create-pull-request/issues/1638(Feb 15).

Before then, we return a 201 response also when the requested reviewer or team is non-existent. This response is incorrect, as we should be returning a 422 -- the change on the endpoint was targeted at fixing that behavior.
and full issue

https://github.com/peter-evans/create-pull-request/issues/1638

Test plan
Tested on feature branch

https://github.com/sourcegraph/sourcegraph/actions/runs/4577519273/jobs/8083025675