### PR TITLE
docker: use latest alpine (3.17.3) and go (1.20.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine3.16 AS builder
+FROM golang:1.20.2-alpine3.17 AS builder
 
 RUN apk add --no-cache ca-certificates
 
@@ -13,7 +13,7 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd/...
 
-FROM alpine:3.16.2 AS zoekt
+FROM alpine:3.17.3 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git ca-certificates bind-tools tini jansson wget

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,4 +1,4 @@
-FROM alpine:3.16.4
+FROM alpine:3.17.3
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache ca-certificates bind-tools tini git jansson && \

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,4 +1,4 @@
-FROM alpine:3.16.4
+FROM alpine:3.17.3
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
    apk add --no-cache ca-certificates bind-tools tini


### PR DESCRIPTION
This makes us actually use the latest go for what we deploy, unlike the change in https://github.com/sourcegraph/zoekt/pull/574

Took the opportunity to bump the minor version to 1.20