### PR TITLE
Bump git version

### DIFF
--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine:3.15.4
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git jansson && \
+    apk add --no-cache ca-certificates bind-tools tini 'git>=2.38.5-r0' jansson && \
     apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0'
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).


### PR DESCRIPTION
This patches [CVE-2023-25652](https://nvd.nist.gov/vuln/detail/CVE-2023-25652) and [2023-29007](https://nvd.nist.gov/vuln/detail/CVE-2023-29007).