### PR TITLE
all: use git >= 2.38.5

### DIFF
--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,7 +1,7 @@
 FROM alpine:3.17.3
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini git jansson && \
+    apk add --no-cache ca-certificates bind-tools tini 'git>=2.38.5-r0' jansson && \
     apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0' 'e2fsprogs>=1.46.6-r0'
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676110339,
-        "narHash": "sha256-kOS/L8OOL2odpCOM11IevfHxcUeE0vnZUQ74EOiwXcs=",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5530aba13caff5a4f41713f1265b754dc2abfd8",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {

--- a/gitindex/clone_test.go
+++ b/gitindex/clone_test.go
@@ -26,7 +26,7 @@ func TestSetRemote(t *testing.T) {
 
 	script := `mkdir orig
 cd orig
-git init
+git init -b master
 cd ..
 git clone orig/.git clone.git
 `

--- a/gitindex/ignore_test.go
+++ b/gitindex/ignore_test.go
@@ -22,7 +22,7 @@ func createSourcegraphignoreRepo(dir string) error {
 	}
 	script := `mkdir repo
 cd repo
-git init
+git init -b master
 mkdir subdir
 echo acont > afile
 echo sub-cont > subdir/sub-file
@@ -35,7 +35,7 @@ git branch branchdir/abranch
 
 mkdir .sourcegraph
 echo subdir/ > .sourcegraph/ignore
-git add .sourcegraph/ignore 
+git add .sourcegraph/ignore
 git commit -am "ignore subdir/"
 
 git update-ref refs/meta/config HEAD

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -415,7 +415,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) error {
 				continue
 			}
 
-			return fmt.Errorf("getCommit: %w", err)
+			return fmt.Errorf("getCommit(%q, %q): %w", opts.BranchPrefix, b, err)
 		}
 
 		opts.BuildOptions.RepositoryDescription.Branches = append(opts.BuildOptions.RepositoryDescription.Branches, zoekt.RepositoryBranch{

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -526,7 +526,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 			repositoryDir := t.TempDir()
 
 			// setup: initialize the repository and all of its branches
-			runScript(t, repositoryDir, "git init")
+			runScript(t, repositoryDir, "git init -b master")
 			runScript(t, repositoryDir, fmt.Sprintf("git config user.email %q", "you@example.com"))
 			runScript(t, repositoryDir, fmt.Sprintf("git config user.name %q", "Your Name"))
 

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -261,7 +261,7 @@ func createSymlinkRepo(dir string) error {
 		return err
 	}
 	script := `mkdir adir bdir
-git init
+git init -b master
 git config user.email "you@example.com"
 git config user.name "Your Name"
 


### PR DESCRIPTION
This is to resolve CVE-2023-25652 and CVE-2023-29007.

Additionally we update the gitindex tests to specify the default branch to use. This was to fix local failures I was experiencing.

This is a redo of https://github.com/sourcegraph/zoekt/pull/579 which was accidently targetting our master branch instead of main.

Test Plan: go test inside of nix develop. Additionally ensure the version of git was larger than 2.38.5 when testing.