### PR TITLE
Add experimental option for keyword scoring

### DIFF
--- a/api.go
+++ b/api.go
@@ -888,6 +888,11 @@ type SearchOptions struct {
 	// will be used. This option is temporary and is only exposed for testing/ tuning purposes.
 	DocumentRanksWeight float64
 
+	// EXPERIMENTAL. If true, use keyword-style scoring instead of the default scoring formula.
+	// Currently, this treats each match in a file as a term and computes an approximation to BM25.
+	// When enabled, all other scoring signals are ignored, including document ranks.
+	UseKeywordScoring bool
+
 	// Trace turns on opentracing for this request if true and if the Jaeger address was provided as
 	// a command-line flag
 	Trace bool


### PR DESCRIPTION
This PR adds an experimental option `UseKeywordScoring` for scoring file matches using [BM25](https://opensourceconnections.com/blog/2015/10/16/bm25-the-next-generation-of-lucene-relevation/), the most common approach in keyword search. It treats each match in a file as a term and uses term frequencies to compute an approximation to BM25.

For now, it makes several simplifications:
* We drop inverse document frequency (idf) from the formula, since we don't have access to global term statistics
* There is no special handling for case sensitivity, filename matches, or symbols
* It ignores all other scoring signals, since BM25 is not normalized and it can be hard to combine it with other signals

Addresses https://github.com/sourcegraph/sourcegraph/issues/50786