### PR TITLE
Update "ci" worflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,9 @@ jobs:
 
   # We build a shared docker image called "zoekt". This is not pushed, but is
   # used for creating the indexserver and webserver images.
+  # 
+  # While we run this job on main and PRs, the actual push is only done on the main branch.
   docker:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
       - "test"
@@ -92,31 +93,57 @@ jobs:
         id: version
         run: .github/workflows/docker-version.sh
 
-      - name: build-zoekt
-        uses: docker/build-push-action@v1
+      - name: docker-meta-webserver
+        id: meta-webserver
+        uses: docker/metadata-action@v3
         with:
-          repository: zoekt
-          tags: "latest"
-          add_git_labels: "true"
+          images: |
+            sourcegraph/zoekt-webserver
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+      - name: docker-meta-indexserver
+        id: meta-indexserver
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            sourcegraph/zoekt-indexserver
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: build-zoekt
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          tags: "zoekt:latest"
           push: "false"
-          build_args: VERSION=${{ steps.version.outputs.value }}
+          build-args: VERSION=${{ steps.version.outputs.value }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: build-push-webserver
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v4
         with:
-          repository: sourcegraph/zoekt-webserver
-          tags: ${{ steps.version.outputs.value }},latest
-          dockerfile: Dockerfile.webserver
-          add_git_labels: "true"
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          context: .
+          tags: sourcegraph/zoekt-webserver:${{ steps.version.outputs.value }}, ${{ steps.meta-webserver.outputs.tags }}, sourcegraph/zoekt-webserver:latest
+          file: Dockerfile.webserver
+          cache-from: sourcegraph/zoekt-webserver:latest
+          push : "${{ github.branch == 'main' }}"
 
       - name: build-push-indexserver
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v4
         with:
-          repository: sourcegraph/zoekt-indexserver
-          tags: ${{ steps.version.outputs.value }},latest
-          dockerfile: Dockerfile.indexserver
-          add_git_labels: "true"
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          context: .
+          tags: sourcegraph/zoekt-indexserver:${{ steps.version.outputs.value }}, ${{ steps.meta-indexserver.outputs.tags }}, sourcegraph/zoekt-indexserver:latest
+          file: Dockerfile.indexserver
+          cache-from: sourcegraph/zoekt-indexserver:latest
+          push : "${{ github.branch == 'main' }}"


### PR DESCRIPTION
The various actions that this worklfow was using were outdated, so I went ahead and migrated those to their newest variant. 

The `set-output` part is still deprecated, but at least the workflow is now working as intended. Also, instead of using `DOCKER_*` secrets, this now uses `DOCKERHUB_*` and the password is a proper token. 

I also took that opportunity to improve the flow, so PRs are building images fully, but will not push them until the same workflow is built on main. The `cache-from` key on should also speed up the process. 

Before: 

```
[sourcegraph/zoekt-webserver:0.0.0-20230519150519-d6d1e686095e sourcegraph/zoekt-webserver:latest]
```

After:

```
#14 naming to docker.io/sourcegraph/zoekt-indexserver:0.0.0-20230524100124-1a361296b6bb done
#14 naming to docker.io/sourcegraph/zoekt-indexserver:jh-hotfix-gha done
#14 naming to docker.io/sourcegraph/zoekt-indexserver:sha-1a36129 done
#14 naming to docker.io/sourcegraph/zoekt-indexserver:latest done
```

You probably want to adjust the tagging, I simply went ahead with the migration guide provided by https://github.com/docker/build-push-action/blob/releases/v2/UPGRADE.md#simple-workflow which seems to add more tags than what `git_tags: true` did before. 


Test plan: many test runs, see the actions history. 

PS: we all agree that the workflow is not very nice, with some kind of bloated yaml, but I just went it in and followed the README for the build-push step blindly as I didn't want to spend too much time on this. 