### PR TITLE
bazel: update buildfiles

### DIFF
--- a/cmd/zoekt-archive-index/BUILD.bazel
+++ b/cmd/zoekt-archive-index/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
 go_binary(
     name = "zoekt-archive-index",
     embed = [":zoekt-archive-index_lib"],
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/zoekt-git-index/BUILD.bazel
+++ b/cmd/zoekt-git-index/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd",
+        "//ctags",
         "//gitindex",
         "@org_uber_go_automaxprocs//maxprocs",
     ],
@@ -15,5 +16,7 @@ go_library(
 go_binary(
     name = "zoekt-git-index",
     embed = [":zoekt-git-index_lib"],
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:public"],
 )

--- a/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel
+++ b/cmd/zoekt-sourcegraph-indexserver/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//:zoekt",
         "//build",
         "//cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1:configuration",
+        "//ctags",
         "//debugserver",
         "//internal/profiler",
         "@com_github_go_git_go_git_v5//:go-git",
@@ -49,6 +50,8 @@ go_library(
 go_binary(
     name = "zoekt-sourcegraph-indexserver",
     embed = [":zoekt-sourcegraph-indexserver_lib"],
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/zoekt-webserver/BUILD.bazel
+++ b/cmd/zoekt-webserver/BUILD.bazel
@@ -82,5 +82,7 @@ go_library(
 go_binary(
     name = "zoekt-webserver",
     embed = [":zoekt-webserver_lib"],
+    pure = "on",
+    static = "on",
     visibility = ["//visibility:public"],
 )

--- a/ctags/BUILD.bazel
+++ b/ctags/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ctags",
-    srcs = ["json.go"],
+    srcs = [
+        "json.go",
+        "parser_map.go",
+    ],
     importpath = "github.com/sourcegraph/zoekt/ctags",
     visibility = ["//visibility:public"],
     deps = ["@com_github_sourcegraph_go_ctags//:go-ctags"],


### PR DESCRIPTION
update buildfiles for previous commit

```
➜  zoekt git:(dt/update-buildfiles) bazel build //build/...    
INFO: Analyzed 2 targets (0 packages loaded, 1 target configured).
INFO: Found 2 targets...
INFO: Elapsed time: 7.831s, Critical Path: 7.45s
INFO: 37 processes: 1 internal, 36 linux-sandbox.
INFO: Build completed successfully, 37 total actions
➜  zoekt git:(dt/update-buildfiles) 
```