### PR TITLE
Add scip-ctags to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM rust:alpine3.17 AS rust-builder
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git musl-dev>=1.1.24-r10 build-base
 
-RUN git clone https://github.com/sourcegraph/sourcegraph && git reset --hard 6dd16ddde8a02f3bf3fe36165e9724727277d97a
+RUN git clone https://github.com/sourcegraph/sourcegraph && cd sourcegraph && git reset --hard 6dd16ddde8a02f3bf3fe36165e9724727277d97a && cd /
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM rust:alpine3.17 AS rust-builder
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git musl-dev>=1.1.24-r10 build-base
 
-RUN git clone --depth=1 --branch main https://github.com/sourcegraph/sourcegraph
+RUN git clone https://github.com/sourcegraph/sourcegraph && git reset --hard 6dd16ddde8a02f3bf3fe36165e9724727277d97a
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM rust:alpine3.17 AS rust-builder
 RUN apk update --no-cache && apk upgrade --no-cache && \
     apk add --no-cache git wget musl-dev>=1.1.24-r10 build-base
 
-RUN wget -qO- https://github.com/sourcegraph/sourcegraph/archive/6dd16ddde8a02f3bf3fe36165e9724727277d97a.tar.gz | tar xz && mv sourcegraph-* sourcegraph
+RUN wget -qO- https://github.com/sourcegraph/sourcegraph/archive/0c8aa18eece45922a2b56dc0f94e21b1bb533e7d.tar.gz | tar xz && mv sourcegraph-* sourcegraph
 
 ARG TARGETARCH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd/...
 
+FROM rust:alpine3.17 AS rust-builder
+
+RUN git clone --depth=1 --branch main https://github.com/sourcegraph/sourcegraph
+RUN cargo install --path sourcegraph/docker-images/syntax-highlighter --root /syntect_server --bin scip-ctags
+
 FROM alpine:3.17.3 AS zoekt
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
@@ -22,5 +27,6 @@ COPY install-ctags-alpine.sh .
 RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh
 
 COPY --from=builder /go/bin/* /usr/local/bin/
+COPY --from=rust-builder /syntect_server/bin/scip-ctags /usr/local/bin/scip-ctags
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,16 @@ RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd
 
 FROM rust:alpine3.17 AS rust-builder
 
+RUN apk update --no-cache && apk upgrade --no-cache && \
+    apk add --no-cache git musl-dev>=1.1.24-r10 build-base
+
 RUN git clone --depth=1 --branch main https://github.com/sourcegraph/sourcegraph
+
+ARG TARGETARCH
+
+# Because .cargo/config.toml doesnt support triplet-specific env
+RUN cd sourcegraph/docker-images/syntax-highlighter && /sourcegraph/cmd/symbols/cargo-config.sh && cd /
+
 RUN cargo install --path sourcegraph/docker-images/syntax-highlighter --root /syntect_server --bin scip-ctags
 
 FROM alpine:3.17.3 AS zoekt

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd
 FROM rust:alpine3.17 AS rust-builder
 
 RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git musl-dev>=1.1.24-r10 build-base
+    apk add --no-cache git wget musl-dev>=1.1.24-r10 build-base
 
-RUN git clone https://github.com/sourcegraph/sourcegraph && cd sourcegraph && git reset --hard 6dd16ddde8a02f3bf3fe36165e9724727277d97a && cd /
+RUN wget -qO- https://github.com/sourcegraph/sourcegraph/archive/6dd16ddde8a02f3bf3fe36165e9724727277d97a.tar.gz | tar xz && mv sourcegraph-* sourcegraph
 
 ARG TARGETARCH
 

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -15,6 +15,7 @@ RUN mkdir -p ${DATA_DIR}
 
 COPY --from=zoekt \
     /usr/local/bin/universal-* \
+    /usr/local/bin/scip-ctags \
     /usr/local/bin/zoekt-sourcegraph-indexserver \
     /usr/local/bin/zoekt-archive-index \
     /usr/local/bin/zoekt-git-index \


### PR DESCRIPTION
Should probably use a tag for this instead of main.

Decided against using a crate as that significantly increased complexity on the publishing side due to all the non-crates.io dependencies we make use of.

Tested locally, Dockerfile build confirmed working - logic searching for the scip-ctags code _should_ work but I haven't tested it.