### PR TITLE
Update the zoekt config for a repo every mirror_interval, even

### DIFF
--- a/gitindex/clone.go
+++ b/gitindex/clone.go
@@ -16,6 +16,7 @@ package gitindex
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -59,7 +60,11 @@ func CloneRepo(destDir, name, cloneURL string, settings map[string]string) (stri
 
 	repoDest := filepath.Join(parent, filepath.Base(name)+".git")
 	if _, err := os.Lstat(repoDest); err == nil {
-		return "", updateZoektGitConfig(repoDest, settings)
+		// Repository exists, ensure settings are in sync
+		if err := updateZoektGitConfig(repoDest, settings); err != nil {
+			return "", fmt.Errorf("failed to update repository settings: %w", err)
+		}
+		return "", nil
 	}
 
 	var keys []string


### PR DESCRIPTION
after the initial clone. 

This fixes an issue where repo settings like archived wouldn't get updated by the indexserver after the initial clone.