### PR TITLE
Tracing: fix panic

### DIFF
--- a/trace/middleware.go
+++ b/trace/middleware.go
@@ -24,7 +24,7 @@ type spanContextKey struct{}
 
 // SpanContextFromContext retrieves the opentracing.SpanContext set on the context by Middleware
 func SpanContextFromContext(ctx context.Context) opentracing.SpanContext {
-	if v := ctx.Value(spanContextKey{}); v == nil {
+	if v := ctx.Value(spanContextKey{}); v != nil {
 		return v.(opentracing.SpanContext)
 	}
 	return nil


### PR DESCRIPTION
This fixes a panic introduced in https://github.com/sourcegraph/zoekt/pull/599 where we would cast `nil` to an interface. I'm honestly not sure how this got through my manual tests. It was panicking on every call.

Screenshot showing spans being connected locally. 

<img width="1151" alt="Screenshot 2023-06-19 at 09 23 04" src="https://github.com/sourcegraph/zoekt/assets/12631702/d5598352-b4e0-450e-b431-b8a7d178ac64">
