### PR TITLE
Check stderr for output, that's where git fetch writes to by default

### DIFF
--- a/cmd/zoekt-indexserver/main.go
+++ b/cmd/zoekt-indexserver/main.go
@@ -130,20 +130,15 @@ func periodicFetch(repoDir, indexDir string, opts *Options, pendingRepos chan<- 
 // update.
 func fetchGitRepo(dir string) bool {
 	cmd := exec.Command("git", "--git-dir", dir, "fetch", "origin")
-	outBuf := &bytes.Buffer{}
-	errBuf := &bytes.Buffer{}
 
-	// Prevent prompting
-	cmd.Stdin = &bytes.Buffer{}
-	cmd.Stderr = errBuf
-	cmd.Stdout = outBuf
-	if err := cmd.Run(); err != nil {
-		log.Printf("command %s failed: %v\nOUT: %s\nERR: %s",
-			cmd.Args, err, outBuf.String(), errBuf.String())
-	} else {
-		return len(errBuf.Bytes()) != 0
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("command %s failed: %v\nCOMBINED_OUT: %s\n",
+			cmd.Args, err, string(output))
+		return false
 	}
-	return false
+	// When fetch found no updates, it prints nothing out
+	return len(output) != 0
 }
 
 // indexPendingRepos consumes the directories on the repos channel and

--- a/cmd/zoekt-indexserver/main.go
+++ b/cmd/zoekt-indexserver/main.go
@@ -141,7 +141,7 @@ func fetchGitRepo(dir string) bool {
 		log.Printf("command %s failed: %v\nOUT: %s\nERR: %s",
 			cmd.Args, err, outBuf.String(), errBuf.String())
 	} else {
-		return len(outBuf.Bytes()) != 0
+		return len(errBuf.Bytes()) != 0
 	}
 	return false
 }


### PR DESCRIPTION
This is another little bugfix I've used for a while and forgot to commit up -

I added some logic in the `periodicFetch` function so that repos were only re-indexed if they had a fetch update, or it'd been `n` hours since a brute-reindex. Then I started noticing that repos that definitely had an update weren't getting re-indexed, traced the problem down and found this. 

It's not a particularly elegant solution, I'm happy to modify it to be nicer. I kept `outBuf` around in case git ever decides to print to it & the cmd errors, in that case it'd probably be useful for debugging.