### PR TITLE
RFC: introduce stats in return from ngramIndex.Get

### DIFF
--- a/hititer.go
+++ b/hititer.go
@@ -132,7 +132,8 @@ func (d *indexData) trigramHitIterator(ng ngram, caseSensitive, fileName bool) (
 			continue
 		}
 
-		sec := d.ngrams.Get(v)
+		sec, statsTODO := d.ngrams.Get(v)
+		_ = statsTODO
 		blob, err := d.readSectionBlob(sec)
 		if err != nil {
 			return nil, err

--- a/indexdata.go
+++ b/indexdata.go
@@ -356,7 +356,9 @@ func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
 		return 0
 	}
 
-	return data.ngrams.Get(ng).sz
+	sec, statsTODO := data.ngrams.Get(ng)
+	_ = statsTODO
+	return sec.sz
 }
 
 type ngramIterationResults struct {

--- a/matchiter.go
+++ b/matchiter.go
@@ -69,6 +69,9 @@ type matchIterator interface {
 // noMatchTree is both matchIterator and matchTree that matches nothing.
 type noMatchTree struct {
 	Why string
+
+	// Stats captures the work done to create the noMatchTree.
+	//Stats *Stats
 }
 
 func (t *noMatchTree) String() string {
@@ -89,7 +92,11 @@ func (t *noMatchTree) matches(cp *contentProvider, cost int, known map[matchTree
 	return false, true
 }
 
-func (t *noMatchTree) updateStats(*Stats) {}
+func (t *noMatchTree) updateStats(s *Stats) {
+	//if t.Stats != nil {
+	//	s.Add(*(t.Stats))
+	//}
+}
 
 func (m *candidateMatch) String() string {
 	return fmt.Sprintf("%d:%d", m.file, m.runeOffset)

--- a/ngramoffset_test.go
+++ b/ngramoffset_test.go
@@ -96,16 +96,16 @@ func TestMakeCombinedNgramOffset(t *testing.T) {
 
 	for i, ng := range ngrams {
 		want := simpleSection{offsets[i], offsets[i+1] - offsets[i]}
-		got := m.Get(ng)
+		got, _ := m.Get(ng)
 		if want != got {
 			t.Errorf("#%d: Get(%q) got %v, want %v", i, ng, got, want)
 		}
 		failn := ngram(uint64(ng - 1))
-		if getFail := m.Get(failn); !ngramMap[failn] && getFail != (simpleSection{}) {
+		if getFail, _ := m.Get(failn); !ngramMap[failn] && getFail != (simpleSection{}) {
 			t.Errorf("#%d: Get(%q) got %v, want zero", i, failn, getFail)
 		}
 		failn = ngram(uint64(ng + 1))
-		if getFail := m.Get(failn); !ngramMap[failn] && getFail != (simpleSection{}) {
+		if getFail, _ := m.Get(failn); !ngramMap[failn] && getFail != (simpleSection{}) {
 			t.Errorf("#%d: Get(%q) got %v, want zero", i, failn, getFail)
 		}
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -78,7 +78,7 @@ func TestReadWrite(t *testing.T) {
 		t.Fatalf("got ngrams %v, want 3 ngrams", data.ngrams)
 	}
 
-	if sec := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
+	if sec, _ := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
 		t.Errorf("found ngram bcq (%v) in %v", uint64(stringToNGram("bcq")), data.ngrams)
 	}
 }
@@ -193,7 +193,7 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.ng, func(t *testing.T) {
-			havePostingList := id.ngrams.Get(stringToNGram(tt.ng))
+			havePostingList, _ := id.ngrams.Get(stringToNGram(tt.ng))
 			if !reflect.DeepEqual(tt.wantPostingList, havePostingList) {
 				t.Fatalf("\nwant:%+v\ngot: %+v", tt.wantPostingList, havePostingList)
 			}
@@ -421,7 +421,7 @@ func TestBackwardsCompat(t *testing.T) {
 					t.Fatalf("got ngrams %v, want 3 ngrams", data.ngrams)
 				}
 
-				if sec := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
+				if sec, _ := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
 					t.Errorf("found ngram bcd in %v", data.ngrams)
 				}
 			},


### PR DESCRIPTION
We want to start tracking the work done by the btree. This field introduces a stats type with the btree in mind that will be returned anytime it is asked to do work. The intention is aggregate these values inside of the work done by our ngram iterator construction.

This is a little different to how we do it with iterators which instead are created per shard search and are then asked to updateStats. That might be a nice future design, introduce a per request accessor to indexData which can record stats. But that is a much larger change.

Note: this change has some commented out code such that noMatchTree will also update stats. The intention is when we rule a tree out we can capture the stats. There is still a complication around how we integrate that with pruneMatchTree.