### PR TITLE
matchtree: capture Stats before pruning

### DIFF
--- a/matchiter.go
+++ b/matchiter.go
@@ -63,6 +63,10 @@ type matchIterator interface {
 	docIterator
 
 	candidates() []*candidateMatch
+
+	// updateStats is called twice. After matchtree construction and after
+	// searching is done. Implementations must take care to not report
+	// statistics twice.
 	updateStats(*Stats)
 }
 
@@ -150,6 +154,7 @@ func (i *ngramDocIterator) prepare(nextDoc uint32) {
 func (i *ngramDocIterator) updateStats(s *Stats) {
 	i.iter.updateStats(s)
 	s.NgramMatches += i.matchCount
+	i.matchCount = 0
 }
 
 func (i *ngramDocIterator) candidates() []*candidateMatch {

--- a/matchtree.go
+++ b/matchtree.go
@@ -520,6 +520,16 @@ func visitMatchTree(t matchTree, f func(matchTree)) {
 	}
 }
 
+// updateMatchTreeStats calls updateStats on all atoms in mt which have that
+// function defined.
+func updateMatchTreeStats(mt matchTree, stats *Stats) {
+	visitMatchTree(mt, func(mt matchTree) {
+		if atom, ok := mt.(interface{ updateStats(*Stats) }); ok {
+			atom.updateStats(stats)
+		}
+	})
+}
+
 // visitMatches visits all atoms which can contribute matches. Note: This
 // skips noVisitMatchTree.
 func visitMatches(t matchTree, known map[matchTree]bool, f func(matchTree)) {


### PR DESCRIPTION
We now call updateStats upto twice per shard search. The intention of this is to capture statistics before pruning the matchtree. Previously we would of done work in creating a matchtree but would then prune those items away and would then never capture those statistics.

In practice that work was reading just one or two varint (the size of a posting list) so likely had minimal impact on the reported statistics. However, in the next commit we want to introduce a statistic which is recorded even if we generate a noMatchTree.

The main technical part of this commit is ensuring all existing updateStats functions can be called twice without overcounting.

Test Plan: go test

Part of https://github.com/sourcegraph/sourcegraph/issues/54950