### PR TITLE
Fix template documentation comments

### DIFF
--- a/api.go
+++ b/api.go
@@ -555,11 +555,11 @@ type Repository struct {
 	CommitURLTemplate string
 
 	// The repository URL for getting to a file.  Has access to
-	// {{Branch}}, {{Path}}
+	// {{.Version}}, {{.Path}}
 	FileURLTemplate string
 
 	// The URL fragment to add to a file URL for line numbers. has
-	// access to {{LineNumber}}. The fragment should include the
+	// access to {{.LineNumber}}. The fragment should include the
 	// separator, generally '#' or ';'.
 	LineFragmentTemplate string
 

--- a/grpc/v1/webserver.pb.go
+++ b/grpc/v1/webserver.pb.go
@@ -743,10 +743,10 @@ type Repository struct {
 	// URL template to link to the commit of a branch
 	CommitUrlTemplate string `protobuf:"bytes,7,opt,name=commit_url_template,json=commitUrlTemplate,proto3" json:"commit_url_template,omitempty"`
 	// The repository URL for getting to a file.  Has access to
-	// {{Branch}}, {{Path}}
+	// {{.Version}}, {{.Path}}
 	FileUrlTemplate string `protobuf:"bytes,8,opt,name=file_url_template,json=fileUrlTemplate,proto3" json:"file_url_template,omitempty"`
 	// The URL fragment to add to a file URL for line numbers. has
-	// access to {{LineNumber}}. The fragment should include the
+	// access to {{.LineNumber}}. The fragment should include the
 	// separator, generally '#' or ';'.
 	LineFragmentTemplate string `protobuf:"bytes,9,opt,name=line_fragment_template,json=lineFragmentTemplate,proto3" json:"line_fragment_template,omitempty"`
 	// Perf optimization: priority is set when we load the shard. It corresponds to

--- a/grpc/v1/webserver.proto
+++ b/grpc/v1/webserver.proto
@@ -177,11 +177,11 @@ message Repository {
   string commit_url_template = 7;
 
   // The repository URL for getting to a file.  Has access to
-  // {{Branch}}, {{Path}}
+  // {{.Version}}, {{.Path}}
   string file_url_template = 8;
 
   // The URL fragment to add to a file URL for line numbers. has
-  // access to {{LineNumber}}. The fragment should include the
+  // access to {{.LineNumber}}. The fragment should include the
   // separator, generally '#' or ';'.
   string line_fragment_template = 9;
 


### PR DESCRIPTION
The variable is `Version`, not `Branch`, and if we're using the template variable syntax, it should have the leading dot that it needs to.