### PR TITLE
zoekt-indexserver: Prevent invalid config from causing an NPE

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -260,6 +260,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 				cmd.Args = append(cmd.Args, "-active")
 			}
 			cmd.Args = append(cmd.Args, c.GerritApiURL)
+		} else {
+			log.Printf("executeMirror: ignoring config, because it does not contain any valid repository definition: %q", c)
+			continue
 		}
 
 		stdout, _ := loggedRun(cmd)


### PR DESCRIPTION
When the user specifies an invalid mirror config that contains an entry without any of the GithubUser / GithubOrg / ... repository definitions, zoekt-indexserver would crash, because `cmd` stays `nil` and causes a SIGSEGV when it is later accessed in `main.executeMirror`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0xb0ddba]
goroutine 10 [running]:
main.loggedRun(0x0)
        /home/philwo/go/pkg/mod/github.com/sourcegraph/zoekt@v0.0.0-20230711133754-25c1ea5177fb/cmd/zoekt-indexserver/main.go:45 +0x5a
main.executeMirror({0xc000d5a000?, 0x16?, 0x0?}, {0xc000246dc0, 0xc}, 0x0?)
        /home/philwo/go/pkg/mod/github.com/sourcegraph/zoekt@v0.0.0-20230711133754-25c1ea5177fb/cmd/zoekt-indexserver/config.go:265 +0x1dbd
main.periodicMirrorFile({0xc000246dc0, 0xc}, 0xc000283dc0, 0x0?)
        /home/philwo/go/pkg/mod/github.com/sourcegraph/zoekt@v0.0.0-20230711133754-25c1ea5177fb/cmd/zoekt-indexserver/config.go:150 +0x256
created by main.main
        /home/philwo/go/pkg/mod/github.com/sourcegraph/zoekt@v0.0.0-20230711133754-25c1ea5177fb/cmd/zoekt-indexserver/main.go:294 +0x685
```

Example config how to trigger this:

```
[
  {
    "CredentialPath": "/zoekt/etc/github-token"
  },
  ...
]
```