### PR TITLE
sort ngrams before looking them up

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "@com_github_rs_xid//:xid",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/timestamppb",
+        "@org_golang_x_exp//slices",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/bits.go
+++ b/bits.go
@@ -106,10 +106,9 @@ func (n ngram) String() string {
 }
 
 type runeNgramOff struct {
-	ngram    ngram
-	byteSize uint32 // size of ngram
-	byteOff  uint32
-	runeOff  uint32
+	ngram ngram
+	// index is the original index inside of the returned array of splitNGrams
+	index uint32
 }
 
 func splitNGrams(str []byte) []runeNgramOff {
@@ -120,9 +119,7 @@ func splitNGrams(str []byte) []runeNgramOff {
 	result := make([]runeNgramOff, 0, len(str))
 	var i uint32
 
-	chars := -1
 	for len(str) > 0 {
-		chars++
 		r, sz := utf8.DecodeRune(str)
 		str = str[sz:]
 		runeGram[0] = runeGram[1]
@@ -139,10 +136,8 @@ func splitNGrams(str []byte) []runeNgramOff {
 
 		ng := runesToNGram(runeGram)
 		result = append(result, runeNgramOff{
-			ngram:    ng,
-			byteSize: i - off[0],
-			byteOff:  off[0],
-			runeOff:  uint32(chars),
+			ngram: ng,
+			index: uint32(len(result)),
 		})
 	}
 	return result

--- a/deps.bzl
+++ b/deps.bzl
@@ -2633,8 +2633,8 @@ def go_dependencies():
         name = "org_golang_x_exp",
         build_file_proto_mode = "disable_global",
         importpath = "golang.org/x/exp",
-        sum = "h1:A1gGSx58LAGVHUUsOf7IiR0u8Xb6W51gRwfDBhkdcaw=",
-        version = "v0.0.0-20191030013958-a1ab85dbe136",
+        sum = "h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=",
+        version = "v0.0.0-20230713183714-613f0c0eb8a1",
     )
     go_repository(
         name = "org_golang_x_image",

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/automaxprocs v1.5.2
+	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 	golang.org/x/net v0.11.0
 	golang.org/x/oauth2 v0.9.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20191030013958-a1ab85dbe136/go.mod h1:JXzH8nQsPlswgeRAPE3MuO9GYsAcnJvJ4vnMwN/5qkY=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
+golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/indexdata.go
+++ b/indexdata.go
@@ -23,6 +23,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/sourcegraph/zoekt/query"
+	"golang.org/x/exp/slices"
 )
 
 // indexData holds the pattern-independent data that we have to have
@@ -388,6 +389,11 @@ func (d *indexData) iterateNgrams(query *query.Substring) (*ngramIterationResult
 
 	// Find the 2 least common ngrams from the string.
 	ngramOffs := splitNGrams([]byte(query.Pattern))
+	// PERF: Sort to increase the chances adjacent checks are in the same btree
+	// bucket (which can cause disk IO).
+	slices.SortFunc(ngramOffs, func(a, b runeNgramOff) bool {
+		return a.ngram < b.ngram
+	})
 	frequencies := make([]uint32, 0, len(ngramOffs))
 	ngramLookups := 0
 	for _, o := range ngramOffs {
@@ -415,18 +421,22 @@ func (d *indexData) iterateNgrams(query *query.Substring) (*ngramIterationResult
 
 		frequencies = append(frequencies, freq)
 	}
-	firstI := firstMinarg(frequencies)
-	frequencies[firstI] = maxUInt32
-	lastI := lastMinarg(frequencies)
-	if firstI > lastI {
-		lastI, firstI = firstI, lastI
+
+	var first, last runeNgramOff
+	{
+		firstI := firstMinarg(frequencies)
+		frequencies[firstI] = maxUInt32
+		lastI := lastMinarg(frequencies)
+		first = ngramOffs[firstI]
+		last = ngramOffs[lastI]
+		if first.index > last.index {
+			last, first = first, last
+		}
 	}
 
-	firstNG := ngramOffs[firstI].ngram
-	lastNG := ngramOffs[lastI].ngram
 	iter := &ngramDocIterator{
-		leftPad:      firstI,
-		rightPad:     uint32(utf8.RuneCountInString(str)) - firstI,
+		leftPad:      first.index,
+		rightPad:     uint32(utf8.RuneCountInString(str)) - first.index,
 		ngramLookups: ngramLookups,
 	}
 	if query.FileName {
@@ -435,15 +445,16 @@ func (d *indexData) iterateNgrams(query *query.Substring) (*ngramIterationResult
 		iter.ends = d.fileEndRunes
 	}
 
-	if firstI != lastI {
-		i, err := d.newDistanceTrigramIter(firstNG, lastNG, lastI-firstI, query.CaseSensitive, query.FileName)
+	if first != last {
+		runeDist := last.index - first.index
+		i, err := d.newDistanceTrigramIter(first.ngram, last.ngram, runeDist, query.CaseSensitive, query.FileName)
 		if err != nil {
 			return nil, err
 		}
 
 		iter.iter = i
 	} else {
-		hitIter, err := d.trigramHitIterator(lastNG, query.CaseSensitive, query.FileName)
+		hitIter, err := d.trigramHitIterator(last.ngram, query.CaseSensitive, query.FileName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We believe this will improve performance of the btree lookups. We are investigating this to make it faster to rule out a shard (when freq==0). Testing locally on a large corpus we halved the time spent in IO.

Locally Sort shows up in the profiles significantly, but there are two facts mitigating that:
- Locally my file page cache is primed so IO rarely is going to disk.
- We likely will implement an IR for Zoekt which will amortize the Sort to once per search rather than once per shard.

Test Plan: go test ./... and performance profiling via via ./cmd/zoekt.

Part of https://github.com/sourcegraph/sourcegraph/issues/54950

Co-authored-by: @stefanhengl 