### PR TITLE
maximise distance between ngrams

### DIFF
--- a/indexdata.go
+++ b/indexdata.go
@@ -16,6 +16,7 @@ package zoekt
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"log"
@@ -402,6 +403,12 @@ func (d *indexData) iterateNgrams(query *query.Substring) (*ngramIterationResult
 
 	// Find the 2 least common ngrams from the string.
 	ngramOffs := splitNGrams([]byte(query.Pattern))
+
+	// protect against accidental searching of empty strings
+	if len(ngramOffs) == 0 {
+		return nil, errors.New("iterateNgrams needs non empty string")
+	}
+
 	// PERF: Sort to increase the chances adjacent checks are in the same btree
 	// bucket (which can cause disk IO).
 	slices.SortFunc(ngramOffs, func(a, b runeNgramOff) bool {

--- a/indexdata_test.go
+++ b/indexdata_test.go
@@ -1,0 +1,79 @@
+package zoekt
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"golang.org/x/exp/slices"
+)
+
+const exampleQuery = "const data: Event = { ...JSON.parse(message.data), type: message.event }"
+
+func genFrequencies(ngramOffs []runeNgramOff, max int) []uint32 {
+	seen := map[ngram]uint32{}
+	var frequencies []uint32
+	for _, n := range ngramOffs {
+		freq, ok := seen[n.ngram]
+		if !ok {
+			freq = uint32(rand.Intn(max))
+			seen[n.ngram] = freq
+		}
+		frequencies = append(frequencies, freq)
+	}
+	return frequencies
+}
+
+func BenchmarkMinFrequencyNgramOffsets(b *testing.B) {
+	ngramOffs := splitNGrams([]byte(exampleQuery))
+	slices.SortFunc(ngramOffs, func(a, b runeNgramOff) bool {
+		return a.ngram < b.ngram
+	})
+	frequencies := genFrequencies(ngramOffs, 100)
+	for i := 0; i < b.N; i++ {
+		x0, x1 := minFrequencyNgramOffsets(ngramOffs, frequencies)
+		if x0 == x1 {
+			b.Fatal("should not be the same")
+		}
+	}
+}
+
+func TestMinFrequencyNgramOffsets(t *testing.T) {
+	// Our implementation has ill-defined tie breaks when the 2nd smallest
+	// frequency can be tied with others. Fixing that would make the CPU perf
+	// worse, so what we do instead is just validate that what we get back is
+	// acceptable.
+	if err := quick.Check(func(s string, maxFreq uint16) bool {
+		ngramOffs := splitNGrams([]byte(s))
+		if len(ngramOffs) == 0 {
+			return true
+		}
+
+		slices.SortFunc(ngramOffs, func(a, b runeNgramOff) bool {
+			return a.ngram < b.ngram
+		})
+		frequencies := genFrequencies(ngramOffs, int(maxFreq))
+		x0, x1 := minFrequencyNgramOffsets(ngramOffs, frequencies)
+
+		if x0.index > x1.index {
+			t.Log("x0 should be before x1")
+			return false
+		}
+
+		if len(ngramOffs) <= 1 {
+			return true
+		}
+
+		// Now we just assert that we found two items with the smallest
+		// frequencies.
+		idx0 := slices.Index[runeNgramOff](ngramOffs, x0)
+		idx1 := slices.Index[runeNgramOff](ngramOffs, x1)
+		start := []uint32{frequencies[idx0], frequencies[idx1]}
+		slices.Sort(start)
+		slices.Sort(frequencies)
+		return reflect.DeepEqual(start, frequencies[:2])
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is a first take on re-introducing the optimization which ensured if two ngrams had the same frequency, we maximsed distance between them. I still think the code is a bit tricky, will see if I can improve it further and hopefully we end up in a case better than we originally had.

Follow-up from https://github.com/sourcegraph/zoekt/pull/617#discussion_r1264996804