### PR TITLE
rename ngrams to contentNgrams

### DIFF
--- a/btree.go
+++ b/btree.go
@@ -431,11 +431,3 @@ func (b btreeIndex) DumpMap() map[ngram]simpleSection {
 
 	return m
 }
-
-// GetBlob returns the raw encoded offset list for ng.
-//
-// Note: the returned byte slice is mmap backed normally.
-func (b btreeIndex) GetBlob(ng ngram) ([]byte, error) {
-	sec := b.Get(ng)
-	return b.file.Read(sec.off, sec.sz)
-}

--- a/hititer.go
+++ b/hititer.go
@@ -117,20 +117,9 @@ func (d *indexData) trigramHitIterator(ng ngram, caseSensitive, fileName bool) (
 
 	iters := make([]hitIterator, 0, len(variants))
 	ngramLookups := 0
+	ngrams := d.ngrams(fileName)
 	for _, v := range variants {
-		if fileName {
-			blob, err := d.fileNameNgrams.GetBlob(v)
-			ngramLookups++
-			if err != nil {
-				return nil, err
-			}
-			if len(blob) > 0 {
-				iters = append(iters, newCompressedPostingIterator(blob, v))
-			}
-			continue
-		}
-
-		sec := d.ngrams.Get(v)
+		sec := ngrams.Get(v)
 		ngramLookups++
 		blob, err := d.readSectionBlob(sec)
 		if err != nil {

--- a/indexdata.go
+++ b/indexdata.go
@@ -35,7 +35,7 @@ type indexData struct {
 
 	file IndexFile
 
-	ngrams btreeIndex
+	contentNgrams btreeIndex
 
 	newlinesStart uint32
 	newlinesIndex []uint32
@@ -316,7 +316,7 @@ func (d *indexData) memoryUse() int {
 	}
 	sz += 8 * len(d.runeDocSections)
 	sz += 8 * len(d.fileBranchMasks)
-	sz += d.ngrams.SizeBytes()
+	sz += d.contentNgrams.SizeBytes()
 	sz += d.fileNameNgrams.SizeBytes()
 	return sz
 }
@@ -367,11 +367,11 @@ func minFrequencyNgramOffsets(ngramOffs []runeNgramOff, frequencies []uint32) (f
 	return first, last
 }
 
-func (data *indexData) ngramFrequency(ng ngram, filename bool) uint32 {
+func (data *indexData) ngrams(filename bool) btreeIndex {
 	if filename {
-		return data.fileNameNgrams.Get(ng).sz
+		return data.fileNameNgrams
 	}
-	return data.ngrams.Get(ng).sz
+	return data.contentNgrams
 }
 
 type ngramIterationResults struct {
@@ -416,14 +416,15 @@ func (d *indexData) iterateNgrams(query *query.Substring) (*ngramIterationResult
 	})
 	frequencies := make([]uint32, 0, len(ngramOffs))
 	ngramLookups := 0
+	ngrams := d.ngrams(query.FileName)
 	for _, o := range ngramOffs {
 		var freq uint32
 		if query.CaseSensitive {
-			freq = d.ngramFrequency(o.ngram, query.FileName)
+			freq = ngrams.Get(o.ngram).sz
 			ngramLookups++
 		} else {
 			for _, v := range generateCaseNgrams(o.ngram) {
-				freq += d.ngramFrequency(v, query.FileName)
+				freq += ngrams.Get(v).sz
 				ngramLookups++
 			}
 		}

--- a/read.go
+++ b/read.go
@@ -288,7 +288,7 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		return nil, err
 	}
 
-	d.ngrams, err = d.newBtreeIndex(toc.ngramText, toc.postings)
+	d.contentNgrams, err = d.newBtreeIndex(toc.ngramText, toc.postings)
 	if err != nil {
 		return nil, err
 	}
@@ -656,7 +656,7 @@ func PrintNgramStats(r IndexFile) error {
 	}
 
 	var rNgram [3]rune
-	for ngram, ss := range id.ngrams.DumpMap() {
+	for ngram, ss := range id.contentNgrams.DumpMap() {
 		rNgram = ngramToRunes(ngram)
 		fmt.Printf("%d\t%q\n", ss.sz, string(rNgram[:]))
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -74,12 +74,13 @@ func TestReadWrite(t *testing.T) {
 		t.Errorf("got filename %q, want %q", got, "filename")
 	}
 
-	if len(data.ngrams.DumpMap()) != 3 {
-		t.Fatalf("got ngrams %v, want 3 ngrams", data.ngrams)
+	contentNgrams := data.contentNgrams.DumpMap()
+	if len(contentNgrams) != 3 {
+		t.Fatalf("got ngrams %v, want 3 ngrams", contentNgrams)
 	}
 
-	if sec := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
-		t.Errorf("found ngram bcq (%v) in %v", uint64(stringToNGram("bcq")), data.ngrams)
+	if sec := data.contentNgrams.Get(stringToNGram("bcq")); sec.sz > 0 {
+		t.Errorf("found ngram bcq (%v) in %v", uint64(stringToNGram("bcq")), contentNgrams)
 	}
 }
 
@@ -117,12 +118,12 @@ func TestReadWriteNames(t *testing.T) {
 		t.Errorf("got index %v, want {0,4}", data.fileNameIndex)
 	}
 
-	gotBlob, err := data.fileNameNgrams.GetBlob(stringToNGram("bCd"))
+	gotSec := data.fileNameNgrams.Get(stringToNGram("bCd"))
 	if err != nil {
 		t.Fatalf("fileNameNgrams.GetBlob: %v", err)
 	}
 
-	if !reflect.DeepEqual(gotBlob, []byte{1}) {
+	if !reflect.DeepEqual(buf.Bytes()[gotSec.off:gotSec.off+gotSec.sz], []byte{1}) {
 		t.Errorf("got trigram bcd at bits %v, want sz 2", data.fileNameNgrams)
 	}
 }
@@ -193,7 +194,7 @@ func TestGet(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.ng, func(t *testing.T) {
-			havePostingList := id.ngrams.Get(stringToNGram(tt.ng))
+			havePostingList := id.contentNgrams.Get(stringToNGram(tt.ng))
 			if !reflect.DeepEqual(tt.wantPostingList, havePostingList) {
 				t.Fatalf("\nwant:%+v\ngot: %+v", tt.wantPostingList, havePostingList)
 			}
@@ -417,12 +418,13 @@ func TestBackwardsCompat(t *testing.T) {
 					t.Errorf("got filename %q, want %q", got, "filename")
 				}
 
-				if len(data.ngrams.DumpMap()) != 3 {
-					t.Fatalf("got ngrams %v, want 3 ngrams", data.ngrams)
+				contentNgrams := data.contentNgrams.DumpMap()
+				if len(data.contentNgrams.DumpMap()) != 3 {
+					t.Fatalf("got ngrams %v, want 3 ngrams", contentNgrams)
 				}
 
-				if sec := data.ngrams.Get(stringToNGram("bcq")); sec.sz > 0 {
-					t.Errorf("found ngram bcd in %v", data.ngrams)
+				if sec := data.contentNgrams.Get(stringToNGram("bcq")); sec.sz > 0 {
+					t.Errorf("found ngram bcd in %v", contentNgrams)
 				}
 			},
 		)


### PR DESCRIPTION
The name always bothered me since we had fileNameNgrams as well. Now they are both accessed via a btreeIndex, I also took the opportunity to introduce a helper "ngrams" which returns the correct index depending on if you want filenames or contents.

Test Plan: go test