### PR TITLE
trace: add service.instance.id

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -970,17 +970,6 @@ func listIndexed(indexDir string) []uint32 {
 	return repoIDs
 }
 
-func hostnameBestEffort() string {
-	if h := os.Getenv("NODE_NAME"); h != "" {
-		return h
-	}
-	if h := os.Getenv("HOSTNAME"); h != "" {
-		return h
-	}
-	hostname, _ := os.Hostname()
-	return hostname
-}
-
 // setupTmpDir sets up a temporary directory on the same volume as the
 // indexes.
 //
@@ -1207,7 +1196,7 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.Int64Var(&rc.indexConcurrency, "index_concurrency", getEnvWithDefaultInt64("SRC_INDEX_CONCURRENCY", 1), "the number of concurrent index jobs to run.")
 	fs.StringVar(&rc.index, "index", getEnvWithDefaultString("DATA_DIR", build.DefaultDir), "set index directory to use")
 	fs.StringVar(&rc.listen, "listen", ":6072", "listen on this address.")
-	fs.StringVar(&rc.hostname, "hostname", hostnameBestEffort(), "the name we advertise to Sourcegraph when asking for the list of repositories to index. Can also be set via the NODE_NAME environment variable.")
+	fs.StringVar(&rc.hostname, "hostname", zoekt.HostnameBestEffort(), "the name we advertise to Sourcegraph when asking for the list of repositories to index. Can also be set via the NODE_NAME environment variable.")
 	fs.Float64Var(&rc.cpuFraction, "cpu_fraction", 1.0, "use this fraction of the cores for indexing.")
 	fs.IntVar(&rc.blockProfileRate, "block_profile_rate", getEnvWithDefaultInt("BLOCK_PROFILE_RATE", -1), "Sampling rate of Go's block profiler in nanoseconds. Values <=0 disable the blocking profiler Var(default). A value of 1 includes every blocking event. See https://pkg.go.dev/runtime#SetBlockProfileRate")
 	fs.DurationVar(&rc.backoffDuration, "backoff_duration", getEnvWithDefaultDuration("BACKOFF_DURATION", 10*time.Minute), "for the given duration we backoff from enqueue operations for a repository that's failed its previous indexing attempt. Consecutive failures increase the duration of the delay linearly up to the maxBackoffDuration. A negative value disables indexing backoff.")
@@ -1521,7 +1510,7 @@ func main() {
 	liblog := sglog.Init(sglog.Resource{
 		Name:       "zoekt-indexserver",
 		Version:    zoekt.Version,
-		InstanceID: hostnameBestEffort(),
+		InstanceID: zoekt.HostnameBestEffort(),
 	})
 	defer liblog.Sync()
 

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -164,13 +164,15 @@ func main() {
 		os.Exit(0)
 	}
 
-	liblog := sglog.Init(sglog.Resource{
+	resource := sglog.Resource{
 		Name:       "zoekt-webserver",
 		Version:    zoekt.Version,
 		InstanceID: zoekt.HostnameBestEffort(),
-	})
+	}
+
+	liblog := sglog.Init(resource)
 	defer liblog.Sync()
-	tracer.Init("zoekt-webserver", zoekt.Version, zoekt.HostnameBestEffort())
+	tracer.Init(resource)
 	profiler.Init("zoekt-webserver", zoekt.Version, -1)
 
 	if *logDir != "" {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -167,10 +167,10 @@ func main() {
 	liblog := sglog.Init(sglog.Resource{
 		Name:       "zoekt-webserver",
 		Version:    zoekt.Version,
-		InstanceID: os.Getenv("HOSTNAME"),
+		InstanceID: zoekt.HostnameBestEffort(),
 	})
 	defer liblog.Sync()
-	tracer.Init("zoekt-webserver", zoekt.Version)
+	tracer.Init("zoekt-webserver", zoekt.Version, zoekt.HostnameBestEffort())
 	profiler.Init("zoekt-webserver", zoekt.Version, -1)
 
 	if *logDir != "" {

--- a/indexbuilder.go
+++ b/indexbuilder.go
@@ -21,6 +21,7 @@ import (
 	"hash/crc64"
 	"html/template"
 	"log"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -39,6 +40,17 @@ type searchableString struct {
 
 // Filled by the linker
 var Version string
+
+func HostnameBestEffort() string {
+	if h := os.Getenv("NODE_NAME"); h != "" {
+		return h
+	}
+	if h := os.Getenv("HOSTNAME"); h != "" {
+		return h
+	}
+	hostname, _ := os.Hostname()
+	return hostname
+}
 
 // Store character (unicode codepoint) offset (in bytes) this often.
 const runeOffsetFrequency = 100

--- a/internal/tracer/jaeger.go
+++ b/internal/tracer/jaeger.go
@@ -5,21 +5,22 @@ import (
 	"reflect"
 
 	"github.com/opentracing/opentracing-go"
+	sglog "github.com/sourcegraph/log"
 	"github.com/uber/jaeger-client-go"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
 )
 
-func configureJaeger(svcName string, version string, instanceID string) (opentracing.Tracer, error) {
+func configureJaeger(resource sglog.Resource) (opentracing.Tracer, error) {
 	cfg, err := jaegercfg.FromEnv()
-	cfg.ServiceName = svcName
+	cfg.ServiceName = resource.Name
 	if err != nil {
 		return nil, err
 	}
 	cfg.Tags = append(
 		cfg.Tags,
-		opentracing.Tag{Key: "service.version", Value: version},
-		opentracing.Tag{Key: "service.instance.id", Value: instanceID},
+		opentracing.Tag{Key: "service.version", Value: resource.Version},
+		opentracing.Tag{Key: "service.instance.id", Value: resource.InstanceID},
 	)
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via

--- a/internal/tracer/jaeger.go
+++ b/internal/tracer/jaeger.go
@@ -10,13 +10,17 @@ import (
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
 )
 
-func configureJaeger(svcName string, version string) (opentracing.Tracer, error) {
+func configureJaeger(svcName string, version string, instanceID string) (opentracing.Tracer, error) {
 	cfg, err := jaegercfg.FromEnv()
 	cfg.ServiceName = svcName
 	if err != nil {
 		return nil, err
 	}
-	cfg.Tags = append(cfg.Tags, opentracing.Tag{Key: "service.version", Value: version})
+	cfg.Tags = append(
+		cfg.Tags,
+		opentracing.Tag{Key: "service.version", Value: version},
+		opentracing.Tag{Key: "service.instance.id", Value: instanceID},
+	)
 	if reflect.DeepEqual(cfg.Sampler, &jaegercfg.SamplerConfig{}) {
 		// Default sampler configuration for when it is not specified via
 		// JAEGER_SAMPLER_* env vars. In most cases, this is sufficient

--- a/internal/tracer/opentelemetry.go
+++ b/internal/tracer/opentelemetry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
+	sglog "github.com/sourcegraph/log"
 	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	otpropagator "go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel"
@@ -16,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	w3cpropagator "go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
+	otelresource "go.opentelemetry.io/otel/sdk/resource"
 	oteltracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 
@@ -33,7 +34,7 @@ import (
 //
 // This setup is based on the one done in sourcegraph/sourcegraph - when making changes,
 // be wary of divergences from the source: https://github.com/sourcegraph/sourcegraph/blob/main/internal/tracer/otel.go
-func configureOpenTelemetry(svcName string, version string, instanceID string) (opentracing.Tracer, error) {
+func configureOpenTelemetry(resource sglog.Resource) (opentracing.Tracer, error) {
 	// Ensure propagation between services continues to work. This is also done by another
 	// project that uses the OpenTracing bridge:
 	// https://sourcegraph.com/github.com/thanos-io/thanos/-/blob/pkg/tracing/migration/bridge.go?L62
@@ -51,11 +52,11 @@ func configureOpenTelemetry(svcName string, version string, instanceID string) (
 		return nil, fmt.Errorf("new exporter: %w", err)
 	}
 	provider := oteltracesdk.NewTracerProvider(
-		oteltracesdk.WithResource(resource.NewWithAttributes(
+		oteltracesdk.WithResource(otelresource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(svcName),
-			semconv.ServiceInstanceIDKey.String(instanceID),
-			semconv.ServiceVersionKey.String(version))),
+			semconv.ServiceNameKey.String(resource.Name),
+			semconv.ServiceInstanceIDKey.String(resource.InstanceID),
+			semconv.ServiceVersionKey.String(resource.Version))),
 		oteltracesdk.WithSampler(oteltracesdk.AlwaysSample()),
 		oteltracesdk.WithSpanProcessor(processor),
 	)

--- a/internal/tracer/opentelemetry.go
+++ b/internal/tracer/opentelemetry.go
@@ -33,7 +33,7 @@ import (
 //
 // This setup is based on the one done in sourcegraph/sourcegraph - when making changes,
 // be wary of divergences from the source: https://github.com/sourcegraph/sourcegraph/blob/main/internal/tracer/otel.go
-func configureOpenTelemetry(svcName string, version string) (opentracing.Tracer, error) {
+func configureOpenTelemetry(svcName string, version string, instanceID string) (opentracing.Tracer, error) {
 	// Ensure propagation between services continues to work. This is also done by another
 	// project that uses the OpenTracing bridge:
 	// https://sourcegraph.com/github.com/thanos-io/thanos/-/blob/pkg/tracing/migration/bridge.go?L62
@@ -54,6 +54,7 @@ func configureOpenTelemetry(svcName string, version string) (opentracing.Tracer,
 		oteltracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(svcName),
+			semconv.ServiceInstanceIDKey.String(instanceID),
 			semconv.ServiceVersionKey.String(version))),
 		oteltracesdk.WithSampler(oteltracesdk.AlwaysSample()),
 		oteltracesdk.WithSpanProcessor(processor),

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/opentracing/opentracing-go"
+	sglog "github.com/sourcegraph/log"
 )
 
 type tracerType string
@@ -35,7 +36,7 @@ func inferTracerType() tracerType {
 // Init should only be called from main and only once
 // It will initialize the configured tracer, and register it as the global tracer
 // This MUST be the same tracer as the one used by Sourcegraph
-func Init(svcName, version, instanceID string) {
+func Init(resource sglog.Resource) {
 	var (
 		tt     = inferTracerType()
 		tracer opentracing.Tracer
@@ -43,7 +44,7 @@ func Init(svcName, version, instanceID string) {
 	)
 	switch tt {
 	case tracerTypeJaeger:
-		tracer, err = configureJaeger(svcName, version, instanceID)
+		tracer, err = configureJaeger(resource)
 		if err != nil {
 			log.Printf("failed to configure Jaeger tracer: %v", err)
 			return
@@ -51,7 +52,7 @@ func Init(svcName, version, instanceID string) {
 		log.Printf("INFO: using Jaeger tracer")
 
 	case tracerTypeOpenTelemetry:
-		tracer, err = configureOpenTelemetry(svcName, version, instanceID)
+		tracer, err = configureOpenTelemetry(resource)
 		if err != nil {
 			log.Printf("failed to configure OpenTelemetry tracer: %v", err)
 			return

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -35,7 +35,7 @@ func inferTracerType() tracerType {
 // Init should only be called from main and only once
 // It will initialize the configured tracer, and register it as the global tracer
 // This MUST be the same tracer as the one used by Sourcegraph
-func Init(svcName, version string) {
+func Init(svcName, version, instanceID string) {
 	var (
 		tt     = inferTracerType()
 		tracer opentracing.Tracer
@@ -43,7 +43,7 @@ func Init(svcName, version string) {
 	)
 	switch tt {
 	case tracerTypeJaeger:
-		tracer, err = configureJaeger(svcName, version)
+		tracer, err = configureJaeger(svcName, version, instanceID)
 		if err != nil {
 			log.Printf("failed to configure Jaeger tracer: %v", err)
 			return
@@ -51,7 +51,7 @@ func Init(svcName, version string) {
 		log.Printf("INFO: using Jaeger tracer")
 
 	case tracerTypeOpenTelemetry:
-		tracer, err = configureOpenTelemetry(svcName, version)
+		tracer, err = configureOpenTelemetry(svcName, version, instanceID)
 		if err != nil {
 			log.Printf("failed to configure OpenTelemetry tracer: %v", err)
 			return


### PR DESCRIPTION
This adds `service.instance.id=<bestEffortHostname>` to Zoekt traces. 

<img width="2124" alt="image" src="https://github.com/sourcegraph/zoekt/assets/26413131/1aa4cc95-b897-4735-bb90-5eb092a3d186">
