### PR TITLE
Diff zoekt git settings 

### DIFF
--- a/gitindex/clone.go
+++ b/gitindex/clone.go
@@ -22,30 +22,89 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 )
 
+// returns a list of all the git zoekt settings that have changed or are
+// new
+func getZoektSettingsToUpdate(repoDest string, newSettings map[string]string, newSettingsKeys []string) ([]string, error) {
+	// get the existing config for this repo - and turn it into a map. Used to check
+	// diff between old/new config
+	cmd := exec.Command("git", "-C", repoDest, "config", "--local", "--get-regexp", "zoekt")
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.Stdout = outBuf
+	cmd.Stderr = errBuf
+
+	if err := cmd.Run(); err != nil {
+		log.Printf("error getting settings\n")
+		return nil, err
+	}
+
+	// turn it into a settings map
+	oldSettings := make(map[string]string)
+	for _, cl := range bytes.Split(outBuf.Bytes(), []byte{'\n'}) {
+		if len(cl) == 0 {
+			continue
+		}
+
+		parts := bytes.SplitN(cl, []byte{' '}, 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("more parts than expected in git config key/v line")
+		}
+		oldSettings[string(parts[0])] = strings.TrimSpace(string(parts[1]))
+	}
+
+	var oldSettingsKeys []string
+	for k := range oldSettings {
+		oldSettingsKeys = append(oldSettingsKeys, k)
+	}
+	sort.Strings(oldSettingsKeys)
+
+	// get the list of settings that have changed, or are new
+	var settingsToUpdate []string
+	for _, k := range newSettingsKeys {
+		oldVal, oldHasSetting := oldSettings[k]
+		if (!oldHasSetting && newSettings[k] != "") || oldVal != newSettings[k] {
+			settingsToUpdate = append(settingsToUpdate, k)
+		}
+	}
+
+	return settingsToUpdate, nil
+}
+
 // Updates the zoekt.* git config options after a repo is cloned.
 // Once a repo is cloned, we can no longer use the --config flag to update all
 // of it's zoekt.* settings at once. `git config` is limited to one option at once.
-func updateZoektGitConfig(repoDest string, settings map[string]string) error {
+// Settings are brute updated
+func updateZoektGitConfig(repoDest string, settings map[string]string) (hasChange bool, err error) {
 	var keys []string
 	for k := range settings {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 
-	for _, k := range keys {
+	settingsToUpdate, err := getZoektSettingsToUpdate(repoDest, settings, keys)
+	if err != nil {
+		return false, err
+	}
+	// if there is nothing to update, return
+	if len(settingsToUpdate) == 0 {
+		return false, nil
+	}
+
+	for _, k := range settingsToUpdate {
 		if settings[k] != "" {
 			if err := exec.Command("git", "-C", repoDest, "config", k, settings[k]).Run(); err != nil {
-				return err
+				return true, err
 			}
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // CloneRepo clones one repository, adding the given config
@@ -61,8 +120,16 @@ func CloneRepo(destDir, name, cloneURL string, settings map[string]string) (stri
 	repoDest := filepath.Join(parent, filepath.Base(name)+".git")
 	if _, err := os.Lstat(repoDest); err == nil {
 		// Repository exists, ensure settings are in sync
-		if err := updateZoektGitConfig(repoDest, settings); err != nil {
+		hadUpdate, err := updateZoektGitConfig(repoDest, settings)
+		if err != nil {
 			return "", fmt.Errorf("failed to update repository settings: %w", err)
+		}
+		// For xvandish/zoekt only, we trigger a re-index here, since we have logic
+		// to only brute-reindex on an interval. In that case, after a zoektConfig update,
+		// if may take bruteReindexInterval hours for the repo-to be re-index and that config
+		// to actually be reflected. Unfortunately we have no easy way of knowing whether
+		if hadUpdate {
+			return repoDest, nil
 		}
 		return "", nil
 	}


### PR DESCRIPTION
This is an optimization on top of what I introduced in #600.

Rather than always updating the zoekt settings for every repo, which can be at least 10 git calls per repo (10 is the current number of zoekt settings we store), we instead get all `zoekt-*` settings with one call, and then only make calls to update the changed values. I remember testing, and the code handled new and deleted `zoekt-*` keys fine. This is just a constant speedup, but it really limits the number of git calls and IO we perform, especially with larger sets of repos.


We also make another change, in that if the zoekt-settings are updated, we return the `repoDest` which triggers a re-index right away.