### PR TITLE
ctags: allow binary to be anything with validation

### DIFF
--- a/build/ctags.go
+++ b/build/ctags.go
@@ -53,6 +53,10 @@ func ctagsAddSymbolsParserMap(todo []*zoekt.Document, languageMap ctags.Language
 		parser := parserMap[parserKind]
 		if parser == nil {
 			parser = parserMap[ctags.UniversalCTags]
+			if parser == nil {
+				// this happens if CTagsMustSucceed is not true and we didn't find universal-ctags
+				continue
+			}
 		}
 
 		es, err := parser.Parse(doc.Name, doc.Content)

--- a/ctags/json_test.go
+++ b/ctags/json_test.go
@@ -27,7 +27,7 @@ func TestJSON(t *testing.T) {
 		t.Skip(err)
 	}
 
-	p, err := NewParser("universal-ctags")
+	p, err := NewParser(UniversalCTags, "universal-ctags")
 	if err != nil {
 		t.Fatal("newProcess", err)
 	}

--- a/ctags/parser_map.go
+++ b/ctags/parser_map.go
@@ -66,7 +66,7 @@ func NewParserMap(bins ParserBinMap, cTagsMustSucceed bool) (ParserMap, error) {
 	for _, parserType := range []CTagsParserType{UniversalCTags, ScipCTags} {
 		bin := bins[parserType]
 		if bin != "" {
-			parser, err := NewParser(bin)
+			parser, err := NewParser(parserType, bin)
 
 			if err != nil && cTagsMustSucceed {
 				return nil, fmt.Errorf("ctags.NewParserMap: %v", err)


### PR DESCRIPTION
Previously we enforced the binary was called universal-ctags. However, we let users override the name of the binary, so if they override it we should use it. To prevent footguns, we now validate the binary was built with the interactive feature.

In the case of scip-ctags we use the old validation of just checking the name.

Additionally we fix a bug that was introduced where if symbols are optional we continue if parsing fails.

Test Plan: indexed with and without universal-ctags. Ctags on my mbp points to something from xcode which wouldn't work

```
  $ CTAGS_COMMAND=ctags go run ./cmd/zoekt-git-index -require_ctags .
  2023/10/04 17:08:12 indexGitRepo(/Users/keegan/src/github.com/sourcegraph/zoekt, delta=false): build.NewBuilder: ctags.NewParserMap: ctags binary is not universal-ctags or is not compiled with +interactive feature: bin=ctags
  exit status 1

  $ CTAGS_COMMAND=universal-ctags go run ./cmd/zoekt-git-index -require_ctags .
  2023/10/04 17:08:29 finished github.com%2Fsourcegraph%2Fzoekt_v16.00000.zoekt: 8657338 index bytes (overhead 2.9)

  $ CTAGS_COMMAND=ctags go run ./cmd/zoekt-git-index .
  2023/10/04 17:08:40 finished github.com%2Fsourcegraph%2Fzoekt_v16.00000.zoekt: 8538246 index bytes (overhead 2.9)
```

Fixes https://github.com/sourcegraph/sourcegraph/issues/57336