### PR TITLE
scoring: handle scip-ctags kinds

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -660,6 +660,8 @@ func scoreKind(language string, kind string) float64 {
 
 	// Generic ranking which will be overriden by language specific ranking
 	switch kind {
+	case "type": // scip-ctags regression workaround https://github.com/sourcegraph/sourcegraph/issues/57659
+		factor = 8
 	case "class":
 		factor = 10
 	case "struct":
@@ -721,6 +723,19 @@ func scoreKind(language string, kind string) float64 {
 		}
 	case "Go", "go":
 		switch kind {
+		// scip-ctags regression workaround https://github.com/sourcegraph/sourcegraph/issues/57659
+		// for each case a description of the fields in ctags in the comment
+		case "type": // interface struct talias
+			factor = 10
+		case "method": // methodSpec
+			factor = 8.5
+		case "function": // func
+			factor = 8
+		case "variable": // var member
+			factor = 7
+		case "constant": // const
+			factor = 6
+
 		case "interface": // interfaces
 			factor = 10
 		case "struct": // structs


### PR DESCRIPTION
There are likely more that we are missing. We only briefly looked at golang, likely other languages are also affected. The regression is scip-ctags returning different values for kind.

Will follow-up with a more comprehensive workaround until scip-ctags issues are resolved.

Test Plan: manually tested queries like "test server" against the golang repo until the test server struct was the top result.

Co-authored-by: @stefanhengl 

See https://github.com/sourcegraph/sourcegraph/issues/57659
