### PR TITLE
boost graphql types in results

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -863,6 +863,11 @@ func scoreKind(language string, kind string) float64 {
 		case "local":
 			factor = 3
 		}
+	case "GraphQL", "graphql":
+		switch kind {
+		case "type":
+			factor = 10
+		}
 	}
 
 	return factor * scoreKindMatch


### PR DESCRIPTION
Because "type" in scip-ctags matches so much we can't boost it as high as we do for classes/structs in our language specific boosting. In the case of GraphQL this is useful to boost.

Note: This work was guided by experimentation locally. Still need to set up a more robust way to track the effects of ranking changes.

Test Plan: A search like "type User" in the sourcegraph codebase now includes results from the schema.graphql files.