### PR TITLE
zoekt: add debug flag to show DebugScore output

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -38,14 +38,21 @@ func displayMatches(files []zoekt.FileMatch, pat string, withRepo bool, list boo
 			r = f.Repository + "/"
 		}
 		if list {
-			fmt.Printf("%s%s\n", r, f.FileName)
+			fmt.Printf("%s%s%s\n", r, f.FileName, addTabIfNonEmpty(f.Debug))
 			continue
 		}
 
 		for _, m := range f.LineMatches {
-			fmt.Printf("%s%s:%d:%s\n", r, f.FileName, m.LineNumber, m.Line)
+			fmt.Printf("%s%s:%d:%s%s\n", r, f.FileName, m.LineNumber, m.Line, addTabIfNonEmpty(f.Debug))
 		}
 	}
+}
+
+func addTabIfNonEmpty(s string) string {
+	if s != "" {
+		return "\t" + s
+	}
+	return s
 }
 
 func loadShard(fn string, verbose bool) (zoekt.Searcher, error) {
@@ -130,6 +137,7 @@ func main() {
 	cpuProfile := flag.String("cpu_profile", "", "write cpu profile to `file`")
 	fullProfile := flag.String("full_profile", "", "write full profile to `file`")
 	profileTime := flag.Duration("profile_time", time.Second, "run this long to gather stats.")
+	debug := flag.Bool("debug", false, "show debugscore output.")
 	verbose := flag.Bool("v", false, "print some background data")
 	withRepo := flag.Bool("r", false, "print the repo before the file name")
 	list := flag.Bool("l", false, "print matching filenames only")
@@ -170,7 +178,9 @@ func main() {
 		log.Println("query:", query)
 	}
 
-	var sOpts zoekt.SearchOptions
+	sOpts := zoekt.SearchOptions{
+		DebugScore: *debug,
+	}
 	sres, err := searcher.Search(context.Background(), query, &sOpts)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Very useful for quick iteration on ranking work.

Test Plan: go run ./cmd/zoekt -debug foo