### PR TITLE
score: factors for headers in markdown

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -868,6 +868,16 @@ func scoreKind(language string, kind string) float64 {
 		case "type":
 			factor = 10
 		}
+	case "Markdown", "markdown":
+		// Headers are good signal in docs, but do not rank as highly as code.
+		switch kind {
+		case "chapter": // #
+			factor = 4
+		case "section": // ##
+			factor = 3
+		case "subsection": // ###
+			factor = 2
+		}
 	}
 
 	return factor * scoreKindMatch


### PR DESCRIPTION
When actually looking for docs this is quite useful. I did not make it high like class defs/etc in code to avoid markdown crowding out results.

Test Plan: nice results on a query like "permission lang:markdown"