### PR TITLE
score: always upscore symbol matches

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -680,6 +680,10 @@ func scoreKind(language string, kind string) float64 {
 		factor = 5
 	case "var", "variable":
 		factor = 4
+
+	default:
+		// No idea what it is, but its something regarded as a symbol
+		factor = 1
 	}
 
 	// Refer to universal-ctags --list-kinds-full=<language> to learn about which


### PR DESCRIPTION
Right now if you don't match any of our kinds, we do not boost your result at all. However, there is likely a long tail of stuff that our symbol code detects which is more useful than just random bits of code.

I noticed then when exploring things like markdown output from ctags.

Test Plan: a few tests that top results were still stable