### PR TITLE
score: clean up debug output

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -501,7 +501,7 @@ func (p *contentProvider) chunkMatchScore(secs []DocumentSection, m *ChunkMatch,
 	maxScore := &debugScore{}
 
 	addScore := func(what string, s float64) {
-		if debug {
+		if s != 0 && debug {
 			score.what += fmt.Sprintf("%s:%.2f, ", what, s)
 		}
 		score.score += s
@@ -568,7 +568,7 @@ func (p *contentProvider) chunkMatchScore(secs []DocumentSection, m *ChunkMatch,
 	}
 
 	if debug {
-		maxScore.what = fmt.Sprintf("score:%f <- %s", maxScore.score, strings.TrimRight(maxScore.what, ", "))
+		maxScore.what = fmt.Sprintf("score:%.2f <- %s", maxScore.score, strings.TrimSuffix(maxScore.what, ", "))
 	}
 
 	return maxScore.score, maxScore.what
@@ -584,7 +584,7 @@ func (p *contentProvider) matchScore(secs []DocumentSection, m *LineMatch, langu
 	maxScore := &debugScore{}
 
 	addScore := func(what string, s float64) {
-		if debug {
+		if s != 0 && debug {
 			score.what += fmt.Sprintf("%s:%.2f, ", what, s)
 		}
 		score.score += s

--- a/eval.go
+++ b/eval.go
@@ -33,7 +33,7 @@ import (
 const maxUInt16 = 0xffff
 
 func (m *FileMatch) addScore(what string, s float64, debugScore bool) {
-	if debugScore {
+	if s != 0 && debugScore {
 		m.Debug += fmt.Sprintf("%s:%.2f, ", what, s)
 	}
 	m.Score += s
@@ -466,6 +466,10 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	md := d.repoMetaData[d.repos[doc]]
 	fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(doc)/float64(len(d.boundaries))), opts.DebugScore)
 	fileMatch.addScore("repo-rank", scoreRepoRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
+
+	if opts.DebugScore {
+		fileMatch.Debug = strings.TrimSuffix(fileMatch.Debug, ", ")
+	}
 }
 
 // scoreFileUsingBM25 computes a score for the file match using an approximation to BM25, the most common scoring


### PR DESCRIPTION
This commit does the following to the debug output:
- consistent fmt string for chunk and line matches
- do not include in debug if 0 score
- trim ", " suffix on final score string

Test Plan: debug output is more succinct :)