### PR TITLE
nix: use go 1.21 and universal-ctags 6.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682879489,
-        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
+        "lastModified": 1697456312,
+        "narHash": "sha256-roiSnrqb5r+ehnKCauPLugoU8S36KgmWraHgRqVYndo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
+        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,20 @@
       in { default = import ./shell.nix { inherit pkgs; }; });
     # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
     overlays.ctags = self: super: rec {
-      universal-ctags = super.universal-ctags.overrideAttrs (old: {
-        version = "5.9.20220403.0";
+      my-universal-ctags = super.universal-ctags.overrideAttrs (old: {
+        version = "6.0.0";
         src = super.fetchFromGitHub {
           owner = "universal-ctags";
           repo = "ctags";
-          rev = "f95bb3497f53748c2b6afc7f298cff218103ab90";
-          sha256 = "sha256-pd89KERQj6K11Nue3YFNO+NLOJGqcMnHkeqtWvMFk38=";
+          rev = "3af413544a0ed0a4c52200894cfd6391f06d2e94";
+          sha256 = "sha256-XlqBndo8g011SDGp3zM7S+AQ0aCp6rpQlqJF6e5Dd6w=";
         };
         # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
         doCheck = false;
         checkFlags = [ ];
       });
+      # The ctags in the registry currently is 6.0.0 so we can skip building in that case
+      universal-ctags = if super.universal-ctags.version == my-universal-ctags.version then super.universal-ctags else my-universal-ctags;
     };
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -11,7 +11,7 @@ pkgs.mkShell {
   name = "zoekt";
 
   nativeBuildInputs = [
-    pkgs.go_1_20
+    pkgs.go_1_21
 
     # zoekt-git-index
     pkgs.git


### PR DESCRIPTION
I have been experimenting with newer universal-ctags to see the improved support in non-scip-ctags languages. This is the first step to supporting it, but will also require ensuring we update in Sourcegraph.

Test Plan: nix develop and go test