### PR TITLE
scoring: score methods and funcs the same

### DIFF
--- a/build/e2e_test.go
+++ b/build/e2e_test.go
@@ -1015,8 +1015,19 @@ type aStruct struct {}
 `),
 			query:        &query.Substring{Content: true, Pattern: "aStruct"},
 			wantLanguage: "Go",
-			// 7000 (full base match) + 900 (Go interface) + 500 (word) + 10 (file order)
+			// 7000 (full base match) + 900 (Go struct) + 500 (word) + 10 (file order)
 			wantScore: 8410,
+		},
+		{
+			fileName: "src/net/http/client.go",
+			content: []byte(`
+package http
+func aFunc() bool {}
+`),
+			query:        &query.Substring{Content: true, Pattern: "aFunc"},
+			wantLanguage: "Go",
+			// 7000 (full base match) + 800 (Go function) + 500 (word) + 10 (file order)
+			wantScore: 8310,
 		},
 		{
 			fileName: "src/net/http/client.go",

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -670,10 +670,8 @@ func scoreKind(language string, kind string) float64 {
 		factor = 9
 	case "interface":
 		factor = 8
-	case "function", "func":
+	case "function", "func", "method":
 		factor = 7
-	case "method":
-		factor = 6
 	case "member", "field":
 		factor = 5.5
 	case "constant", "const":
@@ -731,9 +729,7 @@ func scoreKind(language string, kind string) float64 {
 		// for each case a description of the fields in ctags in the comment
 		case "type": // interface struct talias
 			factor = 10
-		case "method": // methodSpec
-			factor = 8.5
-		case "function": // func
+		case "method", "function": // methodSpec
 			factor = 8
 		case "variable": // var member
 			factor = 7


### PR DESCRIPTION
I don't remember if there was a good reason to score methods and functions differently, but I have found examples where the difference between the two scores causes the better result to be lower ranked, although it has a higher doc-order boost.

Here is one example
```
r:golang/go bits Len
```
<img width="1195" alt="Screenshot 2023-10-19 at 17 59 20" src="https://github.com/sourcegraph/zoekt/assets/26413131/f8d44ea9-5301-4638-83ad-c8e2f6b0e422">

Note: Scip-ctags distinguishes between methods and functions, universal-ctags does not.

Test plan:
updated score tests