### PR TITLE
score: remove repetition-boost

### DIFF
--- a/contentprovider.go
+++ b/contentprovider.go
@@ -461,7 +461,6 @@ const (
 	scoreSymbol           = 7000.0
 	scorePartialSymbol    = 4000.0
 	scoreKindMatch        = 100.0
-	scoreRepetitionFactor = 1.0
 	scoreFactorAtomMatch  = 400.0
 
 	// File-only scoring signals. For now these are also bounded ~9000 to give them

--- a/eval.go
+++ b/eval.go
@@ -415,13 +415,9 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	}
 
 	maxFileScore := 0.0
-	repetitions := 0
 	for i := range fileMatch.LineMatches {
 		if maxFileScore < fileMatch.LineMatches[i].Score {
 			maxFileScore = fileMatch.LineMatches[i].Score
-			repetitions = 0
-		} else if maxFileScore == fileMatch.LineMatches[i].Score {
-			repetitions += 1
 		}
 
 		// Order by ordering in file.
@@ -441,9 +437,6 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	// strictly dominates the in-file ordering of
 	// the matches.
 	fileMatch.addScore("fragment", maxFileScore, opts.DebugScore)
-
-	// Prefer docs with several top-scored matches.
-	fileMatch.addScore("repetition-boost", scoreRepetitionFactor*float64(repetitions), opts.DebugScore)
 
 	if opts.UseDocumentRanks && len(d.ranks) > int(doc) {
 		weight := scoreFileRankFactor


### PR DESCRIPTION
The definition of how this is applied is very narrow and more often than not works poorly. Originally I sent out a commit to dampen this using log, but Julie suggested just removing which sounds better.

Test Plan: go test