### PR TITLE
Improve query script output

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -56,9 +56,9 @@ func displayMatches(files []zoekt.FileMatch, withRepo bool, list bool) {
 			continue
 		}
 
-		lines, hidden := splitAtIndex(f.ChunkMatches, chunkMatchesPerFile)
+		chunks, hidden := splitAtIndex(f.ChunkMatches, chunkMatchesPerFile)
 
-		for _, m := range lines {
+		for _, m := range chunks {
 			fmt.Printf("%d:%s%s\n", m.ContentStart.LineNumber, string(m.Content), addTabIfNonEmpty(m.DebugScore))
 		}
 


### PR DESCRIPTION
Small improvements to the Zoekt query script:
* Switch to chunk matches instead of line matches to better represent
Sourcegraph search
* Make the results more readable by pulling out the filename and limiting the
number of matches