### PR TITLE
scoring: show atom count in debug score

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -411,7 +411,7 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	// atom-count boosts files with matches from more than 1 atom. The
 	// maximum boost is scoreFactorAtomMatch.
 	if atomMatchCount > 0 {
-		fileMatch.addScore("atom", (1.0-1.0/float64(atomMatchCount))*scoreFactorAtomMatch, opts.DebugScore)
+		fileMatch.addScore(fmt.Sprintf("atom(%d)", atomMatchCount), (1.0-1.0/float64(atomMatchCount))*scoreFactorAtomMatch, opts.DebugScore)
 	}
 
 	maxFileScore := 0.0


### PR DESCRIPTION
Tiny change to display the atom count in addition to the score. I caught myself several times trying to translate the score to an atom count.

Test plan:
Ran it locally
<img width="1293" alt="Screenshot 2023-10-20 at 15 36 15" src="https://github.com/sourcegraph/zoekt/assets/26413131/63f3883f-00a1-455f-8b79-244a9e8d38f4">
