### PR TITLE
scoring: reduce allocations for addScore

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"regexp/syntax"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,11 +33,19 @@ import (
 
 const maxUInt16 = 0xffff
 
-func (m *FileMatch) addScore(what string, s float64, debugScore bool) {
-	if s != 0 && debugScore {
-		m.Debug += fmt.Sprintf("%s:%.2f, ", what, s)
+// addScore increments the score of the FileMatch by the computed score. If
+// debugScore is true, it also adds a debug string to the FileMatch. If raw is
+// -1, it is ignored. Otherwise, it is added to the debug string.
+func (m *FileMatch) addScore(what string, computed float64, raw float64, debugScore bool) {
+	if computed != 0 && debugScore {
+		m.Debug += fmt.Sprintf("%s:%.2f", what, computed)
+		if raw != -1 {
+			m.Debug += fmt.Sprintf("(%s), ", strconv.FormatFloat(raw, 'f', -1, 64)) // uses the smallest number of digits necessary to represent raw.
+		} else {
+			m.Debug += ", "
+		}
 	}
-	m.Score += s
+	m.Score += computed
 }
 
 func (m *FileMatch) addKeywordScore(score float64, sumTf float64, L float64, debugScore bool) {
@@ -411,7 +420,8 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	// atom-count boosts files with matches from more than 1 atom. The
 	// maximum boost is scoreFactorAtomMatch.
 	if atomMatchCount > 0 {
-		fileMatch.addScore(fmt.Sprintf("atom(%d)", atomMatchCount), (1.0-1.0/float64(atomMatchCount))*scoreFactorAtomMatch, opts.DebugScore)
+		fileMatch.addScore("atom", (1.0-1.0/float64(atomMatchCount))*scoreFactorAtomMatch, float64(atomMatchCount), opts.DebugScore)
+
 	}
 
 	maxFileScore := 0.0
@@ -436,7 +446,7 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	// Maintain ordering of input files. This
 	// strictly dominates the in-file ordering of
 	// the matches.
-	fileMatch.addScore("fragment", maxFileScore, opts.DebugScore)
+	fileMatch.addScore("fragment", maxFileScore, -1, opts.DebugScore)
 
 	if opts.UseDocumentRanks && len(d.ranks) > int(doc) {
 		weight := scoreFileRankFactor
@@ -452,13 +462,13 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 			// The file rank represents a log (base 2) count. The log ranks should be bounded at 32, but we
 			// cap it just in case to ensure it falls in the range [0, 1].
 			normalized := math.Min(1.0, ranks[0]/32.0)
-			fileMatch.addScore("file-rank", weight*normalized, opts.DebugScore)
+			fileMatch.addScore("file-rank", weight*normalized, -1, opts.DebugScore)
 		}
 	}
 
 	md := d.repoMetaData[d.repos[doc]]
-	fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(doc)/float64(len(d.boundaries))), opts.DebugScore)
-	fileMatch.addScore("repo-rank", scoreRepoRankFactor*float64(md.Rank)/maxUInt16, opts.DebugScore)
+	fileMatch.addScore("doc-order", scoreFileOrderFactor*(1.0-float64(doc)/float64(len(d.boundaries))), -1, opts.DebugScore)
+	fileMatch.addScore("repo-rank", scoreRepoRankFactor*float64(md.Rank)/maxUInt16, -1, opts.DebugScore)
 
 	if opts.DebugScore {
 		fileMatch.Debug = strings.TrimSuffix(fileMatch.Debug, ", ")


### PR DESCRIPTION
Follow-up from [this](https://sourcegraph.zoom.us/j/94120734384) comment.

We add a bit more complexity to addScore but avoid allocating a string if debugScore = false.

Test plan:
- I ran a couple of benchmarks and confirmed we don't allocate.