### PR TITLE
Symbol search: improve performance for anchored queries

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -293,13 +293,14 @@ func (t *symbolSubstrMatchTree) prepare(doc uint32) {
 			continue
 		}
 
-		if end <= sections[secIdx].End {
-			t.current[0].symbol = true
-			t.current[0].symbolIdx = uint32(secIdx)
-			trimmed = append(trimmed, t.current[0])
+		if end > sections[secIdx].End {
+			t.current = t.current[1:]
+			continue
 		}
 
-		t.current = t.current[1:]
+		t.current[0].symbol = true
+		t.current[0].symbolIdx = uint32(secIdx)
+		trimmed = append(trimmed, t.current[0])
 	}
 	t.current = trimmed
 }


### PR DESCRIPTION
Search-based code intel makes heavy use of exact, anchored searches for symbol names like `^NewFoo$`. It uses regex patterns to ensure that the symbol name exactly matches the symbol being hovered over. Zoekt [does not efficiently handle anchors](https://sourcegraph.com/github.com/sourcegraph/zoekt@5c4f6a0b51d56e0357994fcee627c1481376e127/-/blob/eval.go?L756-756), falling back to a brute-force regex search that executes the regex against every symbol in the index.

This is a dirty PR that fixes the issue, but in a probably non-ideal way. I'm looking for early feedback on whether this is the correct approach. If so, I'll do some more extensive and re-request review before merge.

Explanations inline.