### PR TITLE
Indexing: improve doc content checks

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -248,9 +248,9 @@ type Builder struct {
 	todo         []*zoekt.Document
 	size         int
 
-	parserMap ctags.ParserMap
-
-	building sync.WaitGroup
+	parserMap  ctags.ParserMap
+	docChecker zoekt.DocChecker
+	building   sync.WaitGroup
 
 	errMu      sync.Mutex
 	buildError error
@@ -623,7 +623,7 @@ func (b *Builder) Add(doc zoekt.Document) error {
 		// files, the corresponding shard would be mostly empty, so
 		// insert a reason here too.
 		doc.SkipReason = fmt.Sprintf("document size %d larger than limit %d", len(doc.Content), b.opts.SizeMax)
-	} else if err := zoekt.CheckText(doc.Content, b.opts.TrigramMax, allowLargeFile); err != nil {
+	} else if err := b.docChecker.Check(doc.Content, b.opts.TrigramMax, allowLargeFile); err != nil {
 		doc.SkipReason = err.Error()
 		doc.Language = "binary"
 	}

--- a/build/builder.go
+++ b/build/builder.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net/url"
 	"os"
 	"os/exec"
@@ -618,20 +617,13 @@ func (b *Builder) Add(doc zoekt.Document) error {
 	}
 
 	allowLargeFile := b.opts.IgnoreSizeMax(doc.Name)
-
-	// Adjust trigramMax for allowed large files so we don't exclude them.
-	trigramMax := b.opts.TrigramMax
-	if allowLargeFile {
-		trigramMax = math.MaxInt64
-	}
-
 	if len(doc.Content) > b.opts.SizeMax && !allowLargeFile {
 		// We could pass the document on to the shardbuilder, but if
 		// we pass through a part of the source tree with binary/large
 		// files, the corresponding shard would be mostly empty, so
 		// insert a reason here too.
 		doc.SkipReason = fmt.Sprintf("document size %d larger than limit %d", len(doc.Content), b.opts.SizeMax)
-	} else if err := zoekt.CheckText(doc.Content, trigramMax); err != nil {
+	} else if err := zoekt.CheckText(doc.Content, b.opts.TrigramMax, allowLargeFile); err != nil {
 		doc.SkipReason = err.Error()
 		doc.Language = "binary"
 	}

--- a/build/builder.go
+++ b/build/builder.go
@@ -246,11 +246,11 @@ type Builder struct {
 
 	nextShardNum int
 	todo         []*zoekt.Document
+	docChecker   zoekt.DocChecker
 	size         int
 
-	parserMap  ctags.ParserMap
-	docChecker zoekt.DocChecker
-	building   sync.WaitGroup
+	parserMap ctags.ParserMap
+	building  sync.WaitGroup
 
 	errMu      sync.Mutex
 	buildError error

--- a/index_test.go
+++ b/index_test.go
@@ -3204,28 +3204,30 @@ func TestSkipInvalidContent(t *testing.T) {
 	}
 }
 
-func TestCheckText(t *testing.T) {
+func TestDocChecker(t *testing.T) {
+	docChecker := DocChecker{}
+
 	// Test valid and invalid text
 	for _, text := range []string{"", "simple ascii", "símplé unicödé", "\uFEFFwith utf8 'bom'", "with \uFFFD unicode replacement char"} {
-		if err := CheckText([]byte(text), 20000, false); err != nil {
-			t.Errorf("CheckText(%q): %v", text, err)
+		if err := docChecker.Check([]byte(text), 20000, false); err != nil {
+			t.Errorf("Check(%q): %v", text, err)
 		}
 	}
 	for _, text := range []string{"zero\x00byte", "xx", "0123456789abcdefghi"} {
-		if err := CheckText([]byte(text), 15, false); err == nil {
-			t.Errorf("CheckText(%q) succeeded", text)
+		if err := docChecker.Check([]byte(text), 15, false); err == nil {
+			t.Errorf("Check(%q) succeeded", text)
 		}
 	}
 
 	// Test valid and invalid text with an allowed large file
 	for _, text := range []string{"0123456789abcdefghi", "qwertyuiopasdfghjklzxcvbnm"} {
-		if err := CheckText([]byte(text), 15, true); err != nil {
-			t.Errorf("CheckText(%q): %v", text, err)
+		if err := docChecker.Check([]byte(text), 15, true); err != nil {
+			t.Errorf("Check(%q): %v", text, err)
 		}
 	}
 	for _, text := range []string{"zero\x00byte", "xx"} {
-		if err := CheckText([]byte(text), 15, true); err == nil {
-			t.Errorf("CheckText(%q) succeeded", text)
+		if err := docChecker.Check([]byte(text), 15, true); err == nil {
+			t.Errorf("Check(%q) succeeded", text)
 		}
 	}
 }

--- a/index_test.go
+++ b/index_test.go
@@ -3205,13 +3205,26 @@ func TestSkipInvalidContent(t *testing.T) {
 }
 
 func TestCheckText(t *testing.T) {
+	// Test valid and invalid text
 	for _, text := range []string{"", "simple ascii", "símplé unicödé", "\uFEFFwith utf8 'bom'", "with \uFFFD unicode replacement char"} {
-		if err := CheckText([]byte(text), 20000); err != nil {
+		if err := CheckText([]byte(text), 20000, false); err != nil {
 			t.Errorf("CheckText(%q): %v", text, err)
 		}
 	}
 	for _, text := range []string{"zero\x00byte", "xx", "0123456789abcdefghi"} {
-		if err := CheckText([]byte(text), 15); err == nil {
+		if err := CheckText([]byte(text), 15, false); err == nil {
+			t.Errorf("CheckText(%q) succeeded", text)
+		}
+	}
+
+	// Test valid and invalid text with an allowed large file
+	for _, text := range []string{"0123456789abcdefghi", "qwertyuiopasdfghjklzxcvbnm"} {
+		if err := CheckText([]byte(text), 15, true); err != nil {
+			t.Errorf("CheckText(%q): %v", text, err)
+		}
+	}
+	for _, text := range []string{"zero\x00byte", "xx"} {
+		if err := CheckText([]byte(text), 15, true); err == nil {
 			t.Errorf("CheckText(%q) succeeded", text)
 		}
 	}


### PR DESCRIPTION
This change makes a couple improvements to the doc content checks during indexing. When a large file is explicitly marked as "allowed", we don't enforce the max trigram count. However, we still iterated through all its trigrams and collected them in a map. Now we short-circuit the check to avoid counting all the trigrams.

We now also reuse the trigram map across documents. This makes sense, as it's always presized with the same capacity hint. This doesn't have a significant effect on indexing speed, but significantly reduces allocations. Here's a memprofile diff for `alloc_space` from indexing `sgtest/megarepo` before and after the change:

```
Showing nodes accounting for -9872.87MB, 15.77% of 62604.52MB total
Dropped 304 nodes (cum <= 313.02MB)
Showing top 10 nodes out of 17
      flat  flat%   sum%        cum   cum%
-9741.64MB 15.56% 15.56% -9741.64MB 15.56%  github.com/sourcegraph/zoekt.CheckText
 -135.66MB  0.22% 15.78%  -135.66MB  0.22%  bytes.growSlice
    2.50MB 0.004% 15.77%    74.90MB  0.12%  github.com/go-git/go-git/v5/plumbing/format/packfile.(*Packfile).getNextObject
    2.38MB 0.0038% 15.77% -9950.84MB 15.89%  github.com/sourcegraph/zoekt/gitindex.indexGitRepo
   -0.45MB 0.00072% 15.77% -9856.94MB 15.74%  github.com/sourcegraph/zoekt/build.(*Builder).Add
         0     0% 15.77%  -101.01MB  0.16%  bytes.(*Buffer).Grow (inline)
         0     0% 15.77%  -135.66MB  0.22%  bytes.(*Buffer).grow
```