### PR TITLE
Indexing: properly block on shard building

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -854,8 +854,8 @@ func (b *Builder) flush() error {
 
 	if b.opts.Parallelism > 1 && b.opts.MemProfile == "" {
 		b.building.Add(1)
+		b.throttle <- 1
 		go func() {
-			b.throttle <- 1
 			done, err := b.buildShard(todo, shard)
 			<-b.throttle
 


### PR DESCRIPTION
When indexing, we build shards in parallel based on the `parallelism` flag.
Each shard handles ~100MB of document contents, which should limit the memory
usage to roughly `100MB * parallelism`.

Looking at the size of the buffered document contents in memory profiles, we
see much higher usage than this. The issue seems to be that we continue to
buffer up documents even if all threads are busy building shards. This can be a
real problem if shards take a super long time to build (say because ctags is
slow) -- we could end up buffering a ton of content into memory at once.

This change fixes the throttling logic so we block indexing when all threads
are busy building shards.