### PR TITLE
matchtree: switch to enum for matches signature

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -291,14 +291,17 @@ nextFileMatch:
 		md := d.repoMetaData[d.repos[nextDoc]]
 
 		for cost := costMin; cost <= costMax; cost++ {
-			v, ok := mt.matches(cp, cost, known)
-			if ok && !v {
+			switch mt.matches(cp, cost, known) {
+			case matchesRequiresHigherCost:
+				if cost == costMax {
+					log.Panicf("did not decide. Repo %s, doc %d, known %v",
+						md.Name, nextDoc, known)
+				}
+			case matchesFound:
+				// could short-circuit now, but we want to run higher costs to
+				// potentially find higher ranked matches.
+			case matchesNone:
 				continue nextFileMatch
-			}
-
-			if cost == costMax && !ok {
-				log.Panicf("did not decide. Repo %s, doc %d, known %v",
-					md.Name, nextDoc, known)
 			}
 		}
 

--- a/matchiter.go
+++ b/matchiter.go
@@ -92,8 +92,8 @@ func (t *noMatchTree) nextDoc() uint32 {
 
 func (t *noMatchTree) prepare(uint32) {}
 
-func (t *noMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) (bool, bool) {
-	return false, true
+func (t *noMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) matchesState {
+	return matchesNone
 }
 
 func (t *noMatchTree) updateStats(s *Stats) {


### PR DESCRIPTION
The pair of bools (matches, sure) often was quite hard to reason about. I think this came down to them often not being named at return sites, the names itself being too concise and that two booleans represents 4 possible states, but we only had two possible states.

This commit uses a more verbose enum instead of booleans. From reading the diff back I find the code easier to reason about, so I think this is a good change.

Test Plan: go test ./...
