### PR TITLE
build: always add extra entry for newLinesIndices

### DIFF
--- a/build/ctags.go
+++ b/build/ctags.go
@@ -134,7 +134,7 @@ func (t *tagsToSections) Convert(content []byte, tags []*ctags.Entry) ([]zoekt.D
 		}
 		lineIdx := t.Line - 1
 		if lineIdx >= len(nls) {
-			return nil, nil, fmt.Errorf("linenum for entry out of range %v", t)
+			return nil, nil, fmt.Errorf("linenum for entry out of range %v (lineIdx=%d, lines=%d)", t, lineIdx, len(nls))
 		}
 
 		lineOff := uint32(0)
@@ -192,7 +192,6 @@ func (t *tagsToSections) newLinesIndices(in []byte) []uint32 {
 	for len(in) > 0 {
 		i := bytes.IndexByte(in, '\n')
 		if i < 0 {
-			out = append(out, finalEntry)
 			break
 		}
 
@@ -202,6 +201,8 @@ func (t *tagsToSections) newLinesIndices(in []byte) []uint32 {
 		in = in[i+1:]
 		off++
 	}
+
+	out = append(out, finalEntry)
 
 	// save buffer for reuse
 	t.nlsBuf = out[:0]


### PR DESCRIPTION
This was a regression in the recent change. If the file ended in a newline we didn't add an extra index entry, which lead to us returning the "linenum for entry out of range" error.

Test Plan: caught this on my ranking integration tests branch