### PR TITLE
matchtree: always use evalMatchTree

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -291,7 +291,7 @@ nextFileMatch:
 		md := d.repoMetaData[d.repos[nextDoc]]
 
 		for cost := costMin; cost <= costMax; cost++ {
-			switch mt.matches(cp, cost, known) {
+			switch evalMatchTree(cp, cost, known, mt) {
 			case matchesRequiresHigherCost:
 				if cost == costMax {
 					log.Panicf("did not decide. Repo %s, doc %d, known %v",

--- a/matchtree.go
+++ b/matchtree.go
@@ -118,8 +118,8 @@ func matchesStateForSlice[T any](v []T) matchesState {
 type matchTree interface {
 	docIterator
 
-	// matches if cost is high enough, caching known values for future
-	// evaluation at higher costs. See documentation for matchesState's values.
+	// matches if cost is high enough. See documentation for matchesState's
+	// values.
 	//
 	// Note: Do not call this directly, rather use evalMatchTree which uses
 	// known to cache responses once the state transitions away from
@@ -843,6 +843,9 @@ func breakOnNewlines(cm *candidateMatch, text []byte) []*candidateMatch {
 	return cms
 }
 
+// evalMatchTree should be called instead of directly calling
+// matchTree.matches. It cache known values for future evaluation at higher
+// costs.
 func evalMatchTree(cp *contentProvider, cost int, known map[matchTree]bool, mt matchTree) matchesState {
 	if v, ok := known[mt]; ok {
 		return matchesStatePred(v)

--- a/matchtree.go
+++ b/matchtree.go
@@ -120,6 +120,10 @@ type matchTree interface {
 
 	// matches if cost is high enough, caching known values for future
 	// evaluation at higher costs. See documentation for matchesState's values.
+	//
+	// Note: Do not call this directly, rather use evalMatchTree which uses
+	// known to cache responses once the state transitions away from
+	// matchesRequiresHigherCost.
 	matches(cp *contentProvider, cost int, known map[matchTree]bool) matchesState
 }
 
@@ -615,7 +619,7 @@ func (t *bruteForceMatchTree) matches(cp *contentProvider, cost int, known map[m
 // searches we don't want to run the regex engine if there is no line that
 // contains matches from all terms.
 func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matchTree]bool) matchesState {
-	if state := t.andMatchTree.matches(cp, cost, known); state != matchesFound {
+	if state := evalMatchTree(cp, cost, known, &t.andMatchTree); state != matchesFound {
 		return state
 	}
 


### PR DESCRIPTION
From reading the implementation recently I noticed that we should always go via evalMatchTree to ensure we correctly use the known map for caching. This updates the two call sites we didn't do this as well as documenting this requirement.

I don't think this caused any noticeable performance issues. We would do slightly more work in the case the root matchTree was an andMatchTree (or other multi children nodes), but it would have been miniscule.

Test Plan: go test