### PR TITLE
Indexing: limit shard parallelism when index concurrency is set

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -641,12 +641,12 @@ func sglogBranches(key string, branches []zoekt.RepositoryBranch) sglog.Field {
 }
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
-	parallelism := s.CPUCount / s.IndexConcurrency
+	parallelism := math.Ceil(float64(s.CPUCount) / float64(s.IndexConcurrency))
 	return &indexArgs{
 		IndexOptions: opts,
 
 		IndexDir:    s.IndexDir,
-		Parallelism: parallelism,
+		Parallelism: int(parallelism),
 
 		Incremental: true,
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -641,11 +641,12 @@ func sglogBranches(key string, branches []zoekt.RepositoryBranch) sglog.Field {
 }
 
 func (s *Server) indexArgs(opts IndexOptions) *indexArgs {
+	parallelism := s.CPUCount / s.IndexConcurrency
 	return &indexArgs{
 		IndexOptions: opts,
 
 		IndexDir:    s.IndexDir,
-		Parallelism: s.CPUCount,
+		Parallelism: parallelism,
 
 		Incremental: true,
 
@@ -1409,13 +1410,15 @@ func newServer(conf rootConfig) (*Server, error) {
 		}
 	}
 
-	if conf.indexConcurrency < 1 {
-		conf.indexConcurrency = 1
-	}
-
 	cpuCount := int(math.Round(float64(runtime.GOMAXPROCS(0)) * (conf.cpuFraction)))
 	if cpuCount < 1 {
 		cpuCount = 1
+	}
+
+	if conf.indexConcurrency < 1 {
+		conf.indexConcurrency = 1
+	} else if conf.indexConcurrency > int64(cpuCount) {
+		conf.indexConcurrency = int64(cpuCount)
 	}
 
 	q := NewQueue(conf.backoffDuration, conf.maxBackoffDuration, logger)

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -33,9 +33,10 @@ func TestServer_defaultArgs(t *testing.T) {
 	}
 
 	s := &Server{
-		Sourcegraph: newSourcegraphClient(root, "", WithBatchSize(0)),
-		IndexDir:    "/testdata/index",
-		CPUCount:    6,
+		Sourcegraph:      newSourcegraphClient(root, "", WithBatchSize(0)),
+		IndexDir:         "/testdata/index",
+		CPUCount:         6,
+		IndexConcurrency: 1,
 	}
 	want := &indexArgs{
 		IndexOptions: IndexOptions{
@@ -49,6 +50,55 @@ func TestServer_defaultArgs(t *testing.T) {
 	got := s.indexArgs(IndexOptions{Name: "testName"})
 	if !cmp.Equal(got, want) {
 		t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(want, got))
+	}
+}
+
+func TestServer_parallelism(t *testing.T) {
+	root, err := url.Parse("http://api.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name             string
+		cpuCount         int
+		indexConcurrency int
+		wantParallelism  int
+	}{
+		{
+			name:             "CPU count divides evenly",
+			cpuCount:         16,
+			indexConcurrency: 2,
+			wantParallelism:  8,
+		},
+		{
+			name:             "round parallelism down",
+			cpuCount:         4,
+			indexConcurrency: 3,
+			wantParallelism:  1,
+		},
+		{
+			name:             "no shard level parallelism",
+			cpuCount:         4,
+			indexConcurrency: 4,
+			wantParallelism:  1,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name,  func(t *testing.T) {
+			s := &Server{
+				Sourcegraph:      newSourcegraphClient(root, "", WithBatchSize(0)),
+				IndexDir:         "/testdata/index",
+				CPUCount:         tt.cpuCount,
+				IndexConcurrency: tt.indexConcurrency,
+			}
+
+			got := s.indexArgs(IndexOptions{Name: "testName"})
+			if !cmp.Equal(got.Parallelism, tt.wantParallelism) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.wantParallelism, got))
+			}
+		})
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -72,10 +72,10 @@ func TestServer_parallelism(t *testing.T) {
 			wantParallelism:  8,
 		},
 		{
-			name:             "round parallelism down",
+			name:             "round parallelism up",
 			cpuCount:         4,
 			indexConcurrency: 3,
-			wantParallelism:  1,
+			wantParallelism:  2,
 		},
 		{
 			name:             "no shard level parallelism",
@@ -96,7 +96,7 @@ func TestServer_parallelism(t *testing.T) {
 
 			got := s.indexArgs(IndexOptions{Name: "testName"})
 			if !cmp.Equal(got.Parallelism, tt.wantParallelism) {
-				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.wantParallelism, got))
+				t.Errorf("mismatch, want: %d, got: %d", tt.wantParallelism, got.Parallelism)
 			}
 		})
 	}


### PR DESCRIPTION
By default, `zoekt-sourcegraph-indexserver` builds one repo at a time. For each
repo, shards are built in parallel using a number of threads equal to available
CPUs. There are two ways to adjust the indexing concurrency:
1. Passing `cpu_fraction`, which limits the available CPUs for parallel shard
building
2. Passing `index_concurrency` (or setting the `SRC_INDEX_CONCURRENCY`
environment variable), to index more than one repo at once

If you set `index_concurrency` to some number greater than 1, then indexing
will use more threads than available CPUs. This seems undesirable, especially
if you set `cpu_fraction`, since you'd expect that to put an upper bound on CPU
usage.

This changes the shard-level parallelism to `available CPUs / index_concurrency`
(rounded down), to bound the CPU usage as expected.