### PR TITLE
ctags: require scip-ctags to be present

### DIFF
--- a/build/builder.go
+++ b/build/builder.go
@@ -564,14 +564,14 @@ func NewBuilder(opts Options) (*Builder, error) {
 		finishedShards: map[string]string{},
 	}
 
-	if b.opts.CTagsPath == "" && b.opts.CTagsMustSucceed {
-		return nil, fmt.Errorf("ctags binary not found, but CTagsMustSucceed set")
-	}
-
-	parserMap, err := ctags.NewParserMap(ctags.ParserBinMap{
-		ctags.UniversalCTags: b.opts.CTagsPath,
-		ctags.ScipCTags:      b.opts.ScipCTagsPath,
-	}, b.opts.CTagsMustSucceed)
+	parserMap, err := ctags.NewParserMap(
+		ctags.ParserBinMap{
+			ctags.UniversalCTags: b.opts.CTagsPath,
+			ctags.ScipCTags:      b.opts.ScipCTagsPath,
+		},
+		opts.LanguageMap,
+		b.opts.CTagsMustSucceed,
+	)
 
 	if err != nil {
 		return nil, err

--- a/build/ctags.go
+++ b/build/ctags.go
@@ -60,13 +60,15 @@ func ctagsAddSymbolsParserMap(todo []*zoekt.Document, languageMap ctags.Language
 			continue
 		}
 
+		// If the parser kind is unknown, default to universal-ctags
+		if parserKind == ctags.UnknownCTags {
+			parserKind = ctags.UniversalCTags
+		}
+
 		parser := parserMap[parserKind]
 		if parser == nil {
-			parser = parserMap[ctags.UniversalCTags]
-			if parser == nil {
-				// this happens if CTagsMustSucceed is not true and we didn't find universal-ctags
-				continue
-			}
+			// this happens if CTagsMustSucceed is false and we didn't find the binary
+			continue
 		}
 
 		monitor.BeginParsing(doc)

--- a/ctags/parser_map.go
+++ b/ctags/parser_map.go
@@ -60,14 +60,23 @@ func StringToParser(str string) CTagsParserType {
 type ParserMap map[CTagsParserType]Parser
 type ParserBinMap map[CTagsParserType]string
 
-func NewParserMap(bins ParserBinMap, cTagsMustSucceed bool) (ParserMap, error) {
+func NewParserMap(bins ParserBinMap, languageMap LanguageMap, cTagsMustSucceed bool) (ParserMap, error) {
 	parsers := make(ParserMap)
 
-	for _, parserType := range []CTagsParserType{UniversalCTags, ScipCTags} {
-		bin := bins[parserType]
-		if bin != "" {
-			parser, err := NewParser(parserType, bin)
+	requiredTypes := []CTagsParserType{UniversalCTags}
+	for _, parserType := range languageMap {
+		if parserType == ScipCTags {
+			requiredTypes = append(requiredTypes, ScipCTags)
+			break
+		}
+	}
 
+	for _, parserType := range requiredTypes {
+		bin := bins[parserType]
+		if bin == "" && cTagsMustSucceed {
+			return nil, fmt.Errorf("ctags binary not found for %s parser type", ParserToString(parserType))
+		} else {
+			parser, err := NewParser(parserType, bin)
 			if err != nil && cTagsMustSucceed {
 				return nil, fmt.Errorf("ctags.NewParserMap: %v", err)
 			}


### PR DESCRIPTION
Previously, we didn't require that scip-ctags be available even if if you set
`require_ctags` and set `language_map` to something like `go:scip`. Instead, we
silently fell back to `universal-ctags`. This is tricky and could mask a real
issue where we expect scip-ctags to be available but it isn't.

Now, we check if SCIP is needed based on `language_map`, and if so require that
scip-ctags is available.

## Test plan

Lots of manual testing with various combinations of `language_map` and
`require_ctags`. Also hooked up this change to `sg start` and checked indexing
works well.