### PR TITLE
ctags: ignore SCIP ctags path in build test

### DIFF
--- a/build/builder_test.go
+++ b/build/builder_test.go
@@ -134,6 +134,7 @@ func TestFlags(t *testing.T) {
 	ignored := []cmp.Option{
 		// depends on $PATH setting.
 		cmpopts.IgnoreFields(Options{}, "CTagsPath"),
+		cmpopts.IgnoreFields(Options{}, "ScipCTagsPath"),
 		cmpopts.IgnoreFields(Options{}, "changedOrRemovedFiles"),
 		cmpopts.IgnoreFields(zoekt.Repository{}, "priority"),
 	}


### PR DESCRIPTION
This prevents local test failures when `SCIP_CTAGS_COMMAND` is set.