### PR TITLE
ci: use correct version of ctags

### DIFF
--- a/install-ctags-alpine.sh
+++ b/install-ctags-alpine.sh
@@ -3,5 +3,5 @@ set -eux
 # shellcheck disable=SC3040
 set -o pipefail || true
 # Commit from 2023-10-24. Please always pick a commit from the main branch.
-export SOURCEGRAPH_COMMIT=4dd4ce3d91da5cac2ac6169d3005714247178f57
+export SOURCEGRAPH_COMMIT=45a6748bb491513b9e1162d888711ca9b3bb4303
 wget -O - https://raw.githubusercontent.com/sourcegraph/sourcegraph/$SOURCEGRAPH_COMMIT/cmd/symbols/ctags-install-alpine.sh | sh


### PR DESCRIPTION
It seems only the comment was updated, the commit it pointed to was incorrect. This should hopefully resolve an error in CI due to different version of ctags between CI and local dev.

Test Plan: CI