### PR TITLE
all: remove detailed debug file logging

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -13,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/atomic"
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/sourcegraph/zoekt"
 )
@@ -71,12 +69,6 @@ func (s *Server) merge(mergeCmd func(args ...string) *exec.Cmd) {
 	metricShardMergingRunning.Set(1)
 	defer metricShardMergingRunning.Set(0)
 
-	wc := &lumberjack.Logger{
-		Filename:   filepath.Join(s.IndexDir, "zoekt-merge-log.tsv"),
-		MaxSize:    100, // Megabyte
-		MaxBackups: 5,
-	}
-
 	// We keep creating compound shards until we run out of shards to merge or until
 	// we encounter an error during merging.
 	next := true
@@ -105,12 +97,6 @@ func (s *Server) merge(mergeCmd func(args ...string) *exec.Cmd) {
 			if err != nil {
 				log.Printf("mergeCmd: out=%s, err=%s", out, err)
 				return
-			}
-
-			newCompoundName := reCompound.Find(out)
-			now := time.Now()
-			for _, s := range c.shards {
-				_, _ = fmt.Fprintf(wc, "%s\t%s\t%s\t%s\n", now.UTC().Format(time.RFC3339), "merge", filepath.Base(s.path), string(newCompoundName))
 			}
 
 			next = true

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,6 @@ require (
 	golang.org/x/sys v0.11.0
 	google.golang.org/grpc v1.56.1
 	google.golang.org/protobuf v1.31.0
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
We have noticed profiles where lumberjack is responsible for 1GB of memory. This is surprising and we haven't used the log output in a long time. Rather than debugging, we are going to remove it for now and when we need detailed logs again we can add something back.

Test Plan: go test