### PR TITLE
ChunkMatches: drop trailing newline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: fuzz test
     runs-on: ubuntu-latest
     steps:
-      - uses: jidicula/go-fuzz-action@4f24eed45b25214f31a9fe035ca68ea2c88c6a13 # v1.2.0
+      - uses: jidicula/go-fuzz-action@0206b61afc603b665297621fa5e691b1447a5e57 # to make go version configurable
         with:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
           fuzz-minimize-time: 1m
+          go-version: '1.21'
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
     name: fuzz test
     runs-on: ubuntu-latest
     steps:
-      - uses: jidicula/go-fuzz-action@0206b61afc603b665297621fa5e691b1447a5e57 # to make go version configurable
+      # Pinned a commit to make go version configurable.
+      # This should be safe to upgrade once this commit is in a released version:
+      # https://github.com/jidicula/go-fuzz-action/commit/23cc553941669144159507e2cccdbb4afc5b3076
+      - uses: jidicula/go-fuzz-action@0206b61afc603b665297621fa5e691b1447a5e57
         with:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -454,6 +454,12 @@ func (nls newlines) getLines(data []byte, low, high int) []byte {
 	lowStart, _ := nls.lineBounds(low)
 	_, highEnd := nls.lineBounds(high - 1)
 
+	// Drop any trailing newline
+	if highEnd == uint32(len(data)) && len(data) > 0 && data[len(data)-1] == '\n' {
+		highEnd = highEnd - 1
+		lowStart = min(lowStart, highEnd)
+	}
+
 	return data[lowStart:highEnd]
 }
 
@@ -680,7 +686,6 @@ func sectionSlice(data []byte, sec DocumentSection) []byte {
 	}
 	return data[sec.Start:sec.End]
 }
-
 
 // scoreSymbolKind boosts a match based on the combination of language, symbol
 // and kind. The language string comes from go-enry, the symbol and kind from

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -454,7 +454,13 @@ func (nls newlines) getLines(data []byte, low, high int) []byte {
 	lowStart, _ := nls.lineBounds(low)
 	_, highEnd := nls.lineBounds(high - 1)
 
-	// Drop any trailing newline
+	// Drop any trailing newline. Editors do not treat a trailing newline as
+	// the start of a new line, so we should not either. lineBounds clamps to
+	// len(data) when an out-of-bounds line is requested.
+	//
+	// As an example, if we request lines 1-5 from a file with contents
+	// `one\ntwo\nthree\n`, we should return `one\ntwo\nthree` because those are
+	// the three "lines" in the file, separated by newlines.
 	if highEnd == uint32(len(data)) && len(data) > 0 && data[len(data)-1] == '\n' {
 		highEnd = highEnd - 1
 		lowStart = min(lowStart, highEnd)

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -461,7 +461,7 @@ func (nls newlines) getLines(data []byte, low, high int) []byte {
 	// As an example, if we request lines 1-5 from a file with contents
 	// `one\ntwo\nthree\n`, we should return `one\ntwo\nthree` because those are
 	// the three "lines" in the file, separated by newlines.
-	if highEnd == uint32(len(data)) && len(data) > 0 && data[len(data)-1] == '\n' {
+	if highEnd == uint32(len(data)) && bytes.HasSuffix(data, []byte{'\n'}) {
 		highEnd = highEnd - 1
 		lowStart = min(lowStart, highEnd)
 	}

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -32,7 +32,8 @@ func TestGetLines(t *testing.T) {
 	for _, content := range contents {
 		t.Run("", func(t *testing.T) {
 			newLines := getNewlines(content)
-			lines := bytes.Split(content, []byte{'\n'}) // TODO does split group consecutive sep?
+			// Trim the last newline before splitting because a trailing newline does not constitute a new line
+			lines := bytes.Split(bytes.TrimSuffix(content, []byte{'\n'}), []byte{'\n'})
 			wantGetLines := func(low, high int) []byte {
 				low--
 				high--

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -560,7 +560,10 @@ func TestContextLines(t *testing.T) {
 						// Returns 3 instead of 4 new line characters since we swallow
 						// the last new line in Before, Fragments and After.
 						Before: "\n\n\n",
-						After:  "\n\n\n",
+						// Returns 2 instead of 3 new line characters since a
+						// trailing newline at the end of the file does not
+						// constitue a new line.
+						After: "\n\n",
 					},
 				},
 			},


### PR DESCRIPTION
I'd like to start taking advantage of the `NumContextLines` option, but have been running into an issue where, if context lines were to extend past the end of the file, we get the trailing newline at the end of the file. 

This is not desirable because the empty slice after a trailing newline is not treated as a "line" by any editor, so when we split on newlines, an empty line is shown to the user. By the time we're splitting on newlines, we do not know whether or not we're at the end of the file, so we cannot know whether we can trim that trailing newline, or whether it is, correctly, an empty line that should be rendered. 

This is really annoying stuff that bites us elsewhere as well (searcher, syntax highlighter). It might be nice to unify the definitions of "what is a line" in some library, but for now, I'll be happy with "don't return an extra line."