### PR TITLE
api: JSON omitempty on optional fields in FileMatch

### DIFF
--- a/api.go
+++ b/api.go
@@ -43,45 +43,45 @@ type FileMatch struct {
 
 	// SubRepositoryName is the globally unique name of the repo,
 	// if it came from a subrepository
-	SubRepositoryName string
+	SubRepositoryName string `json:",omitempty"`
 
 	// SubRepositoryPath holds the prefix where the subrepository
 	// was mounted.
-	SubRepositoryPath string
+	SubRepositoryPath string `json:",omitempty"`
 
 	// Commit SHA1 (hex) of the (sub)repo holding the file.
-	Version string
+	Version string `json:",omitempty"`
 
 	// Detected language of the result.
 	Language string
 
 	// For debugging. Needs DebugScore set, but public so tests in
 	// other packages can print some diagnostics.
-	Debug string
+	Debug string `json:",omitempty"`
 
-	Branches []string
+	Branches []string `json:",omitempty"`
 
 	// One of LineMatches or ChunkMatches will be returned depending on whether
 	// the SearchOptions.ChunkMatches is set.
-	LineMatches  []LineMatch
-	ChunkMatches []ChunkMatch
+	LineMatches  []LineMatch  `json:",omitempty"`
+	ChunkMatches []ChunkMatch `json:",omitempty"`
 
 	// Only set if requested
-	Content []byte
+	Content []byte `json:",omitempty"`
 
 	// Checksum of the content.
 	Checksum []byte
 
 	// Ranking; the higher, the better.
-	Score float64 // TODO - hide this field?
+	Score float64 `json:",omitempty"`
 
 	// RepositoryPriority is a Sourcegraph extension. It is used by Sourcegraph to
 	// order results from different repositories relative to each other.
-	RepositoryPriority float64
+	RepositoryPriority float64 `json:",omitempty"`
 
 	// RepositoryID is a Sourcegraph extension. This is the ID of Repository in
 	// Sourcegraph.
-	RepositoryID uint32
+	RepositoryID uint32 `json:",omitempty"`
 }
 
 func (m *FileMatch) sizeBytes() (sz uint64) {

--- a/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
@@ -4,11 +4,9 @@
   "FileMatches": [
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "ZnVuYyBtYWluKCkgew==",
@@ -30,24 +28,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "cGFja2FnZSBtYWlu",
@@ -69,24 +58,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 8010,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "CW51bSAgICAgPSA1",
@@ -113,24 +93,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 8010
       }
     ],
     [
       {
-        "Score": 6060,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "CW1lc3NhZ2UgPSAiaGVsbG8i",
@@ -157,15 +128,8 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 6060
       }
     ]
   ]

--- a/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
@@ -4,11 +4,9 @@
   "FileMatches": [
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "ZnVuYyBtYWluKCkgew==",
@@ -30,24 +28,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "cGFja2FnZSBtYWlu",
@@ -69,24 +58,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 8010,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "CW51bSAgICAgPSA1",
@@ -113,24 +93,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 8010
       }
     ],
     [
       {
-        "Score": 6060,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "go",
         "LineMatches": [
           {
             "Line": "CW1lc3NhZ2UgPSAiaGVsbG8i",
@@ -157,15 +128,8 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 6060
       }
     ]
   ]

--- a/testdata/golden/TestReadSearch/repo17_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/repo17_v17.00000.golden
@@ -4,11 +4,9 @@
   "FileMatches": [
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo17",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "ZnVuYyBtYWluKCkgew==",
@@ -30,24 +28,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo17",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "cGFja2FnZSBtYWlu",
@@ -69,15 +58,8 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     null,

--- a/testdata/golden/TestReadSearch/repo2_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo2_v16.00000.golden
@@ -4,11 +4,9 @@
   "FileMatches": [
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo2",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "ZnVuYyBtYWluKCkgew==",
@@ -30,24 +28,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "Ju1TnQKZ6mE=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo2",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "cGFja2FnZSBtYWlu",
@@ -69,15 +58,8 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "Ju1TnQKZ6mE=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     null,

--- a/testdata/golden/TestReadSearch/repo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo_v16.00000.golden
@@ -4,11 +4,9 @@
   "FileMatches": [
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "ZnVuYyBtYWluKCkgew==",
@@ -30,24 +28,15 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     [
       {
-        "Score": 510,
-        "Debug": "",
         "FileName": "main.go",
         "Repository": "repo",
-        "Branches": null,
+        "Language": "Go",
         "LineMatches": [
           {
             "Line": "cGFja2FnZSBtYWlu",
@@ -69,15 +58,8 @@
             ]
           }
         ],
-        "ChunkMatches": null,
-        "RepositoryID": 0,
-        "RepositoryPriority": 0,
-        "Content": null,
         "Checksum": "n9fUYqacPXg=",
-        "Language": "Go",
-        "SubRepositoryName": "",
-        "SubRepositoryPath": "",
-        "Version": ""
+        "Score": 510
       }
     ],
     null,


### PR DESCRIPTION
There are several fields which are optional in FileMatch. For example branch and version are only set if indexing a git repo (zoekt can index arbitrary files). We mark these fields as optional to marshal in JSON. The main benefit of this is improving the readability of some golden files.

Note: I noticed this when an unrelated commit touched these golden files.

Test Plan: go test