### PR TITLE
contentprovider: cache last newlines lookup

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -642,6 +642,8 @@ func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matc
 		}
 	}
 
+	newlines := cp.newlines()
+
 	type lineRange struct {
 		start int
 		end   int
@@ -649,7 +651,7 @@ func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matc
 	lines := make([]lineRange, 0, len(t.children[fewestChildren].(*substrMatchTree).current))
 	prev := -1
 	for _, candidate := range t.children[fewestChildren].(*substrMatchTree).current {
-		line, byteStart, byteEnd := cp.newlines().atOffset(candidate.byteOffset)
+		line, byteStart, byteEnd := newlines.atOffset(candidate.byteOffset)
 		if line == prev {
 			continue
 		}


### PR DESCRIPTION
I wanted to introduce another call to newlines.atOffset for the purpose of scoring. I was worried about doubling the calls to this so introduced a tiny (but hopefully effective) performance optimization.

Essentially we often look up multiple times on the same line, but then the return of atOffset shouldn't change. So we introduce a tiny cache for this.

We could do even more and if we are not on the same line, use the last computed index to restrict which side of the nls.locs we look at. However, there are no direct benchmarks for this and I haven't seen it in profiles before. So just doing this minor optimization for fun.

Test Plan: go test