### PR TITLE
score: do scoring on candidateMatches

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -160,7 +160,7 @@ func TestSearch_ShardRepoMaxMatchCountOpt(t *testing.T) {
 
 	t.Run("stats", func(t *testing.T) {
 		got, want := sr.Stats, Stats{
-			ContentBytesLoaded: 2,
+			ContentBytesLoaded: 0,
 			FileCount:          2,
 			FilesConsidered:    2,
 			FilesSkipped:       2,

--- a/read.go
+++ b/read.go
@@ -532,7 +532,15 @@ func (d *indexData) readDocSections(i uint32, buf []DocumentSection) ([]Document
 		return nil, 0, err
 	}
 
-	return unmarshalDocSections(blob, buf), sec.sz, nil
+	ds := unmarshalDocSections(blob, buf)
+
+	// can be nil if buf is nil and there are no doc sections. However, we rely
+	// on it being non-nil to cache the read.
+	if ds == nil {
+		ds = make([]DocumentSection, 0)
+	}
+
+	return ds, sec.sz, nil
 }
 
 func (d *indexData) readRanks(toc *indexTOC) error {


### PR DESCRIPTION
This is a refactor which removes our duplicated scoring logic for ChunkMatch vs LineMatch. Instead we score slices of []*candidateMatch.

Other than being a good refactor, candidateMatch is a much more appropriate structure to stuff in extra information for scoring than our public APIs. So this enables the work we want to do around atom based scoring.

The only behaviour change in this commit are two fixes:
- DocumentSection caching would fail if empty since we relied on the empty cache to be non-nil. This lead to inflated ContentBytesLoaded.
- Empty FileMatch would still read in DocumentSection, even though it wasn't needed.

Test Plan: go test. Our coverage is decent, we have lots of ranking tests which did not change and we have hardcoded stats of work done which did not change (except for the above fixes).