### PR TITLE
shards: always aggregate stats for tracing

### DIFF
--- a/shards/eval.go
+++ b/shards/eval.go
@@ -44,7 +44,7 @@ func (s *typeRepoSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zo
 	tr, ctx := trace.New(ctx, "typeRepoSearcher.StreamSearch", "")
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %+v", opts)
-	var stats *zoekt.Stats
+	var stats zoekt.Stats
 	defer func() {
 		tr.LazyPrintf("stats: %+v", stats)
 		if err != nil {
@@ -59,15 +59,10 @@ func (s *typeRepoSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zo
 		return err
 	}
 
-	if opts.Trace {
-		stats = &zoekt.Stats{}
-		return s.Streamer.StreamSearch(ctx, q, opts, stream.SenderFunc(func(event *zoekt.SearchResult) {
-			stats.Add(event.Stats)
-			sender.Send(event)
-		}))
-	}
-
-	return s.Streamer.StreamSearch(ctx, q, opts, sender)
+	return s.Streamer.StreamSearch(ctx, q, opts, stream.SenderFunc(func(event *zoekt.SearchResult) {
+		stats.Add(event.Stats)
+		sender.Send(event)
+	}))
 }
 
 func (s *typeRepoSearcher) List(ctx context.Context, q query.Q, opts *zoekt.ListOptions) (rl *zoekt.RepoList, err error) {


### PR DESCRIPTION
Many a time I have seen a slow search without tracing turned on. I then go to visit the net/trace page to see what happened but it is missing the stats to try work out why.

This commit will ensure we always log the aggregated statistics. This should be cheap to do given Add is relatively fast and LazyPrintf will only do the stringer operation if someone loads the debug page. It does mean a Stats object lives a bit longer in memory, but it is small.

Test Plan: go test