### PR TITLE
fix: prune boostMatchTree if child is pruned

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -1332,6 +1332,12 @@ func pruneMatchTree(mt matchTree) (matchTree, error) {
 		mt.child, err = pruneMatchTree(mt.child)
 	case *boostMatchTree:
 		mt.child, err = pruneMatchTree(mt.child)
+		if err != nil {
+			return nil, err
+		}
+		if mt.child == nil {
+			return nil, nil
+		}
 	case *andLineMatchTree:
 		child, err := pruneMatchTree(&mt.andMatchTree)
 		if err != nil {


### PR DESCRIPTION
The old behavior led to panics in NextDoc if the child was pruned.