### PR TITLE
matchtree: fix panic for missing files

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -1330,6 +1330,12 @@ func pruneMatchTree(mt matchTree) (matchTree, error) {
 		}
 	case *fileNameMatchTree:
 		mt.child, err = pruneMatchTree(mt.child)
+		if err != nil {
+			return nil, err
+		}
+		if mt.child == nil {
+			return nil, nil
+		}
 	case *boostMatchTree:
 		mt.child, err = pruneMatchTree(mt.child)
 		if err != nil {

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/rpc"
@@ -136,6 +137,9 @@ func TestBasic(t *testing.T) {
 		},
 		"/search?q=magic": {
 			`value=magic`,
+		},
+		"/search?q=foo+type:file": {
+			`value=foo`,
 		},
 		"/robots.txt": {
 			"disallow: /search",


### PR DESCRIPTION
Previously, shards crashed for queries like "foo type:file" if foo was not present.

Test plan:
updated e2e test