### PR TITLE
sourcegraph: Remove HTTP APIs

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -1,25 +1,21 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sourcegraph/log/logtest"
 	proto "github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver/protos/sourcegraph/zoekt/configuration/v1"
+	"github.com/sourcegraph/zoekt/ctags"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -31,630 +27,236 @@ import (
 )
 
 func TestIterateIndexOptions_Fingerprint(t *testing.T) {
-	t.Run("gRPC", func(t *testing.T) {
-		fingerprintV0 := &proto.Fingerprint{
-			Identifier:  100,
-			GeneratedAt: timestamppb.New(time.Unix(100, 0)),
-		}
+	fingerprintV0 := &proto.Fingerprint{
+		Identifier:  100,
+		GeneratedAt: timestamppb.New(time.Unix(100, 0)),
+	}
 
-		fingerprintV1 := &proto.Fingerprint{
-			Identifier:  101,
-			GeneratedAt: timestamppb.New(time.Unix(101, 0)),
-		}
+	fingerprintV1 := &proto.Fingerprint{
+		Identifier:  101,
+		GeneratedAt: timestamppb.New(time.Unix(101, 0)),
+	}
 
-		fingerprintV2 := &proto.Fingerprint{
-			Identifier:  102,
-			GeneratedAt: timestamppb.New(time.Unix(102, 0)),
-		}
+	fingerprintV2 := &proto.Fingerprint{
+		Identifier:  102,
+		GeneratedAt: timestamppb.New(time.Unix(102, 0)),
+	}
 
-		mkSearchConfigurationResponse := func(fingerprint *proto.Fingerprint, repoIDs ...int32) *proto.SearchConfigurationResponse {
-			repositories := make([]*proto.ZoektIndexOptions, 0, len(repoIDs))
-			for _, repoID := range repoIDs {
-				repositories = append(repositories, &proto.ZoektIndexOptions{
-					RepoId: repoID,
-				})
-			}
-
-			return &proto.SearchConfigurationResponse{
-				UpdatedOptions: repositories,
-				Fingerprint:    fingerprint,
-			}
-		}
-
-		grpcClient := &mockGRPCClient{
-			mockList: func(_ context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (*proto.ListResponse, error) {
-				return &proto.ListResponse{
-					RepoIds: []int32{1, 2, 3},
-				}, nil
-			},
-		}
-
-		clientOpts := []SourcegraphClientOption{
-			WithBatchSize(1),
-			WithShouldUseGRPC(true),
-			WithGRPCClient(grpcClient),
-		}
-
-		testURL := url.URL{Scheme: "http", Host: "does.not.matter", Path: "/"}
-		sg := newSourcegraphClient(&testURL, "", clientOpts...)
-
-		type step struct {
-			name string
-
-			wantFingerprint     *proto.Fingerprint
-			returnFingerprint   *proto.Fingerprint
-			returnErr           error
-			skipCheckingRepoIDs bool
-		}
-
-		for _, step := range []step{
-			{
-				name:              "first call",
-				wantFingerprint:   nil,
-				returnFingerprint: fingerprintV0,
-			},
-			{
-				name:              "second call (should provide fingerprint from last time)",
-				wantFingerprint:   fingerprintV0,
-				returnFingerprint: fingerprintV1,
-			},
-			{
-				name:              "error",
-				wantFingerprint:   fingerprintV1,
-				returnFingerprint: fingerprintV2,
-
-				returnErr:           fmt.Errorf("boom"),
-				skipCheckingRepoIDs: true, // don't bother checking repoIDs if we expect an error
-			},
-			{
-				name:              "call after error (should ignore fingerprint from last time, and provide the older one)",
-				wantFingerprint:   fingerprintV1,
-				returnFingerprint: fingerprintV2,
-			},
-		} {
-			t.Run(step.name, func(t *testing.T) {
-				called := false
-				grpcClient.mockSearchConfiguration = func(_ context.Context, in *proto.SearchConfigurationRequest, opts ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
-					called = true
-
-					diff := cmp.Diff(step.wantFingerprint, in.GetFingerprint(), protocmp.Transform())
-					if diff != "" {
-						t.Fatalf("unexpected fingerprint (-want +got):\n%s", diff)
-					}
-
-					return mkSearchConfigurationResponse(step.returnFingerprint, in.RepoIds...), step.returnErr
-				}
-
-				result, err := sg.List(context.Background(), nil)
-				if err != nil {
-					t.Fatalf("unexpected error from List: %v", err)
-				}
-
-				var iteratedIDs []uint32
-				result.IterateIndexOptions(func(options IndexOptions) {
-					iteratedIDs = append(iteratedIDs, options.RepoID)
-				})
-
-				if !called {
-					t.Fatal("expected SearchConfiguration to be called")
-				}
-
-				if step.skipCheckingRepoIDs {
-					return
-				}
-
-				sort.Slice(iteratedIDs, func(i, j int) bool {
-					return iteratedIDs[i] < iteratedIDs[j]
-				})
-
-				expectedIDs := []uint32{1, 2, 3}
-				sort.Slice(expectedIDs, func(i, j int) bool {
-					return expectedIDs[i] < expectedIDs[j]
-				})
-
-				if diff := cmp.Diff(expectedIDs, iteratedIDs); diff != "" {
-					t.Fatalf("unexpected repo ids (-want +got):\n%s", diff)
-				}
+	mkSearchConfigurationResponse := func(fingerprint *proto.Fingerprint, repoIDs ...int32) *proto.SearchConfigurationResponse {
+		repositories := make([]*proto.ZoektIndexOptions, 0, len(repoIDs))
+		for _, repoID := range repoIDs {
+			repositories = append(repositories, &proto.ZoektIndexOptions{
+				RepoId: repoID,
 			})
 		}
 
-	})
+		return &proto.SearchConfigurationResponse{
+			UpdatedOptions: repositories,
+			Fingerprint:    fingerprint,
+		}
+	}
 
-	t.Run("REST", func(t *testing.T) {
-		fingerprintV0 := "v0"
-		fingerprintV1 := "v1"
-		fingerprintV2 := "v2"
+	grpcClient := &mockGRPCClient{
+		mockList: func(_ context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (*proto.ListResponse, error) {
+			return &proto.ListResponse{
+				RepoIds: []int32{1, 2, 3},
+			}, nil
+		},
+	}
 
-		handleList := func(w http.ResponseWriter, _ *http.Request) {
-			data := struct {
-				RepoIDs []uint32
-			}{
-				RepoIDs: []uint32{1, 2, 3},
+	clientOpts := []SourcegraphClientOption{
+		WithBatchSize(1),
+	}
+
+	testURL := url.URL{Scheme: "http", Host: "does.not.matter", Path: "/"}
+	sg := newSourcegraphClient(&testURL, "", grpcClient, clientOpts...)
+
+	type step struct {
+		name string
+
+		wantFingerprint     *proto.Fingerprint
+		returnFingerprint   *proto.Fingerprint
+		returnErr           error
+		skipCheckingRepoIDs bool
+	}
+
+	for _, step := range []step{
+		{
+			name:              "first call",
+			wantFingerprint:   nil,
+			returnFingerprint: fingerprintV0,
+		},
+		{
+			name:              "second call (should provide fingerprint from last time)",
+			wantFingerprint:   fingerprintV0,
+			returnFingerprint: fingerprintV1,
+		},
+		{
+			name:              "error",
+			wantFingerprint:   fingerprintV1,
+			returnFingerprint: fingerprintV2,
+
+			returnErr:           fmt.Errorf("boom"),
+			skipCheckingRepoIDs: true, // don't bother checking repoIDs if we expect an error
+		},
+		{
+			name:              "call after error (should ignore fingerprint from last time, and provide the older one)",
+			wantFingerprint:   fingerprintV1,
+			returnFingerprint: fingerprintV2,
+		},
+	} {
+		t.Run(step.name, func(t *testing.T) {
+			called := false
+			grpcClient.mockSearchConfiguration = func(_ context.Context, in *proto.SearchConfigurationRequest, opts ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
+				called = true
+
+				diff := cmp.Diff(step.wantFingerprint, in.GetFingerprint(), protocmp.Transform())
+				if diff != "" {
+					t.Fatalf("unexpected fingerprint (-want +got):\n%s", diff)
+				}
+
+				return mkSearchConfigurationResponse(step.returnFingerprint, in.RepoIds...), step.returnErr
 			}
 
-			json.NewEncoder(w).Encode(data)
-		}
-
-		searchConfigurationHandler := func(w http.ResponseWriter, r *http.Request) {
-			http.Error(w, "this search configuration handler hasn't been overridden", http.StatusForbidden)
-		}
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/.internal/search/configuration":
-				searchConfigurationHandler(w, r)
-			case "/.internal/repos/index":
-				handleList(w, r)
-			default:
-				t.Fatalf("unexpected path: %s", r.URL.Path)
+			result, err := sg.List(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("unexpected error from List: %v", err)
 			}
-		}))
-		defer server.Close()
 
-		clientOpts := []SourcegraphClientOption{
-			WithBatchSize(1),
-			WithShouldUseGRPC(false),
-		}
-
-		testURL, err := url.Parse(server.URL)
-		if err != nil {
-			t.Fatalf("unexpected error parsing URL: %v", err)
-		}
-
-		sg := newSourcegraphClient(testURL, "", clientOpts...)
-
-		type step struct {
-			name string
-
-			wantFingerprint     string
-			returnFingerprint   string
-			returnErr           error
-			skipCheckingRepoIDs bool
-		}
-
-		for _, step := range []step{
-			{
-				name:              "first call",
-				wantFingerprint:   "",
-				returnFingerprint: fingerprintV0,
-			},
-			{
-				name:              "second call (should provide fingerprint from last time)",
-				wantFingerprint:   fingerprintV0,
-				returnFingerprint: fingerprintV1,
-			},
-			{
-				name:              "error",
-				wantFingerprint:   fingerprintV1,
-				returnFingerprint: fingerprintV2,
-
-				returnErr:           fmt.Errorf("boom"),
-				skipCheckingRepoIDs: true, // don't bother checking repoIDs if we expect an error
-			},
-			{
-				name:              "call after error (should ignore fingerprint from last time, and provide the older one)",
-				wantFingerprint:   fingerprintV1,
-				returnFingerprint: fingerprintV2,
-			},
-		} {
-			t.Run(step.name, func(t *testing.T) {
-				called := false
-
-				searchConfigurationHandler = func(w http.ResponseWriter, r *http.Request) {
-					called = true
-
-					fingerprint := r.Header.Get(fingerprintHeader)
-					if diff := cmp.Diff(step.wantFingerprint, fingerprint); diff != "" {
-						t.Fatalf("unexpected fingerprint (-want +got):\n%s", diff)
-					}
-
-					w.Header().Set(fingerprintHeader, step.returnFingerprint)
-
-					if step.returnErr != nil {
-						// The status code is a bit of a hack, but it prevents
-						// the retry logic from kicking in and stalling the test for 45 seconds.
-						http.Error(w, step.returnErr.Error(), http.StatusBadRequest)
-						return
-					}
-
-					if err := r.ParseForm(); err != nil {
-						http.Error(w, fmt.Sprintf("unexpected error parsing form for repoIDs: %v", err.Error()), http.StatusBadRequest)
-						return
-					}
-
-					repoIDs := make([]uint32, 0, len(r.Form["repoID"]))
-					for _, idStr := range r.Form["repoID"] {
-						id, err := strconv.Atoi(idStr)
-						if err != nil {
-							http.Error(w, fmt.Sprintf("invalid repo id %s: %s", idStr, err), http.StatusBadRequest)
-							return
-						}
-						repoIDs = append(repoIDs, uint32(id))
-					}
-
-					optionJSONSlice := make([][]byte, 0, len(repoIDs))
-					for _, repoID := range repoIDs {
-						option := IndexOptions{
-							RepoID: repoID,
-						}
-
-						optionJSON, err := json.Marshal(option)
-						if err != nil {
-							t.Fatalf("unexpected error marshalling JSON: %v", err)
-						}
-
-						optionJSONSlice = append(optionJSONSlice, optionJSON)
-					}
-
-					w.Write(bytes.Join(optionJSONSlice, []byte("\n")))
-				}
-
-				result, err := sg.List(context.Background(), nil)
-				if err != nil {
-					t.Fatalf("unexpected error from List: %v", err)
-				}
-
-				var iteratedIDs []uint32
-				result.IterateIndexOptions(func(options IndexOptions) {
-					iteratedIDs = append(iteratedIDs, options.RepoID)
-				})
-
-				if !called {
-					t.Fatal("expected SearchConfiguration to be called")
-				}
-
-				if step.skipCheckingRepoIDs {
-					return
-				}
-
-				sort.Slice(iteratedIDs, func(i, j int) bool {
-					return iteratedIDs[i] < iteratedIDs[j]
-				})
-
-				expectedIDs := []uint32{1, 2, 3}
-				sort.Slice(expectedIDs, func(i, j int) bool {
-					return expectedIDs[i] < expectedIDs[j]
-				})
-
-				if diff := cmp.Diff(expectedIDs, iteratedIDs); diff != "" {
-					t.Fatalf("unexpected repo ids (-want +got):\n%s", diff)
-				}
+			var iteratedIDs []uint32
+			result.IterateIndexOptions(func(options IndexOptions) {
+				iteratedIDs = append(iteratedIDs, options.RepoID)
 			})
-		}
 
-	})
+			if !called {
+				t.Fatal("expected SearchConfiguration to be called")
+			}
+
+			if step.skipCheckingRepoIDs {
+				return
+			}
+
+			sort.Slice(iteratedIDs, func(i, j int) bool {
+				return iteratedIDs[i] < iteratedIDs[j]
+			})
+
+			expectedIDs := []uint32{1, 2, 3}
+			sort.Slice(expectedIDs, func(i, j int) bool {
+				return expectedIDs[i] < expectedIDs[j]
+			})
+
+			if diff := cmp.Diff(expectedIDs, iteratedIDs); diff != "" {
+				t.Fatalf("unexpected repo ids (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestGetIndexOptions(t *testing.T) {
-	t.Run("gRPC", func(t *testing.T) {
 
-		type testCase struct {
-			name     string
-			response *proto.SearchConfigurationResponse
-			want     *IndexOptions
-			wantErr  string
-		}
+	type testCase struct {
+		name     string
+		response *proto.SearchConfigurationResponse
+		want     *IndexOptions
+		wantErr  string
+	}
 
-		for _, tc := range []testCase{
-			{
-				name: "symbols, large files",
-				response: &proto.SearchConfigurationResponse{
-					UpdatedOptions: []*proto.ZoektIndexOptions{
-						{
-							Symbols:    true,
-							LargeFiles: []string{"foo", "bar"},
-						},
+	for _, tc := range []testCase{
+		{
+			name: "symbols, large files",
+			response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols:    true,
+						LargeFiles: []string{"foo", "bar"},
 					},
 				},
-				want: &IndexOptions{
-					Symbols:    true,
-					LargeFiles: []string{"foo", "bar"},
-				},
 			},
-			{
-				name: "no symbols , large files",
-				response: &proto.SearchConfigurationResponse{
-					UpdatedOptions: []*proto.ZoektIndexOptions{
-						{
-							Symbols:    true,
-							LargeFiles: []string{"foo", "bar"},
-						},
-					},
-				},
-				want: &IndexOptions{
-					Symbols:    true,
-					LargeFiles: []string{"foo", "bar"},
-				},
-			},
-
-			{
-				name:     "empty",
-				response: nil,
-				want:     nil,
-			},
-
-			{
-				name: "symbols",
-				response: &proto.SearchConfigurationResponse{
-					UpdatedOptions: []*proto.ZoektIndexOptions{
-						{
-							Symbols: true,
-						},
-					},
-				},
-				want: &IndexOptions{
-					Symbols: true,
-				},
-			},
-			{
-				name: "repoID",
-				response: &proto.SearchConfigurationResponse{
-					UpdatedOptions: []*proto.ZoektIndexOptions{
-						{
-							RepoId: 123,
-						},
-					},
-				},
-				want: &IndexOptions{
-					RepoID: 123,
-				},
-			},
-			{
-				name: "error",
-				response: &proto.SearchConfigurationResponse{
-					UpdatedOptions: []*proto.ZoektIndexOptions{
-						{
-							Error: "boom",
-						},
-					},
-				},
-				want:    nil,
-				wantErr: "boom",
-			},
-		} {
-			called := false
-			mockClient := &mockGRPCClient{
-				mockSearchConfiguration: func(_ context.Context, _ *proto.SearchConfigurationRequest, _ ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
-					called = true
-					return tc.response, nil
-				},
-			}
-
-			testURL := &url.URL{
-				Scheme: "http",
-				Host:   "does.not.matter",
-				Path:   "/",
-			}
-
-			sg := newSourcegraphClient(
-				testURL,
-				"",
-				WithShouldUseGRPC(true),
-				WithGRPCClient(mockClient),
-			)
-
-			var got IndexOptions
-			var err error
-			sg.ForceIterateIndexOptions(func(o IndexOptions) {
-				got = o
-			}, func(_ uint32, e error) {
-				err = e
-			}, 123)
-
-			if !called {
-				t.Fatal("expected mock to be called")
-			}
-
-			if err != nil {
-				if tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr) {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			}
-
-			if tc.want == nil {
-				continue
-			}
-
-			tc.want.CloneURL = sg.getCloneURL(got.Name)
-
-			if diff := cmp.Diff(tc.want, &got, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("mismatch (-want +got):\n%s", diff)
-			}
-		}
-
-		// Mimic our fingerprint API, which doesn't return anything if the
-		// repo hasn't changed.
-		t.Run("unchanged", func(t *testing.T) {
-
-			called := false
-			mockClient := &mockGRPCClient{
-				mockSearchConfiguration: func(_ context.Context, _ *proto.SearchConfigurationRequest, _ ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
-					called = true
-					return nil, nil
-				},
-			}
-
-			testURL := &url.URL{
-				Scheme: "http",
-				Host:   "does.not.matter",
-				Path:   "/",
-			}
-
-			sg := newSourcegraphClient(
-				testURL,
-				"",
-				WithShouldUseGRPC(true),
-				WithGRPCClient(mockClient))
-
-			gotAtLeastOneOption := false
-			var err error
-			sg.ForceIterateIndexOptions(func(_ IndexOptions) {
-				gotAtLeastOneOption = true
-			}, func(_ uint32, e error) {
-				err = e
-			}, 123)
-
-			if !called {
-				t.Fatal("expected mock to be called")
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if gotAtLeastOneOption {
-				t.Fatalf("expected no options, got %v", gotAtLeastOneOption)
-			}
-		})
-
-	})
-	t.Run("REST", func(t *testing.T) {
-		var response []byte
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := r.ParseForm(); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if got, want := r.URL.String(), "/.internal/search/configuration"; got != want {
-				http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
-				return
-			}
-			if got, want := r.Form, (url.Values{"repoID": []string{"123"}}); !reflect.DeepEqual(got, want) {
-				http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
-				return
-			}
-			_, _ = w.Write(response)
-		}))
-		defer server.Close()
-
-		u, err := url.Parse(server.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		sg := newSourcegraphClient(u, "", WithBatchSize(0))
-
-		cases := map[string]*IndexOptions{
-			`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {
+			want: &IndexOptions{
 				Symbols:    true,
 				LargeFiles: []string{"foo", "bar"},
 			},
-
-			`{"Symbols": false, "LargeFiles": ["foo","bar"]}`: {
+		},
+		{
+			name: "no symbols , large files",
+			response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols:    true,
+						LargeFiles: []string{"foo", "bar"},
+					},
+				},
+			},
+			want: &IndexOptions{
+				Symbols:    true,
 				LargeFiles: []string{"foo", "bar"},
 			},
+		},
 
-			`{}`: {},
+		{
+			name:     "empty",
+			response: nil,
+			want:     nil,
+		},
 
-			`{"Symbols": true}`: {
+		{
+			name: "symbols",
+			response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols: true,
+					},
+				},
+			},
+			want: &IndexOptions{
 				Symbols: true,
 			},
-
-			`{"RepoID": 123}`: {
+		},
+		{
+			name: "repoID",
+			response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						RepoId: 123,
+					},
+				},
+			},
+			want: &IndexOptions{
 				RepoID: 123,
 			},
-
-			`{"Error": "boom"}`: nil,
-		}
-
-		for r, want := range cases {
-			response = []byte(r)
-
-			var got IndexOptions
-			var err error
-			sg.ForceIterateIndexOptions(func(o IndexOptions) {
-				got = o
-			}, func(_ uint32, e error) {
-				err = e
-			}, 123)
-
-			if err != nil && want != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if want == nil {
-				continue
-			}
-
-			want.CloneURL = sg.getCloneURL(got.Name)
-
-			if d := cmp.Diff(*want, got); d != "" {
-				t.Log("response", r)
-				t.Errorf("mismatch (-want +got):\n%s", d)
-			}
-		}
-
-		// Special case our fingerprint API which doesn't return anything if the
-		// repo hasn't changed.
-		t.Run("unchanged", func(t *testing.T) {
-			response = []byte(``)
-
-			got := false
-			var err error
-			sg.ForceIterateIndexOptions(func(_ IndexOptions) {
-				got = true
-			}, func(_ uint32, e error) {
-				err = e
-			}, 123)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got {
-				t.Fatalf("expected no options, got %v", got)
-			}
-		})
-	})
-
-	var response []byte
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if got, want := r.URL.String(), "/.internal/search/configuration"; got != want {
-			http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
-			return
-		}
-		if got, want := r.Form, (url.Values{"repoID": []string{"123"}}); !reflect.DeepEqual(got, want) {
-			http.Error(w, fmt.Sprintf("got URL %v want %v", got, want), http.StatusBadRequest)
-			return
-		}
-		_, _ = w.Write(response)
-	}))
-	defer server.Close()
-
-	u, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sg := newSourcegraphClient(u, "", WithBatchSize(0))
-
-	cases := map[string]*IndexOptions{
-		`{"Symbols": true, "LargeFiles": ["foo","bar"]}`: {
-			Symbols:    true,
-			LargeFiles: []string{"foo", "bar"},
 		},
-
-		`{"Symbols": false, "LargeFiles": ["foo","bar"]}`: {
-			LargeFiles: []string{"foo", "bar"},
+		{
+			name: "error",
+			response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Error: "boom",
+					},
+				},
+			},
+			want:    nil,
+			wantErr: "boom",
 		},
+	} {
+		called := false
+		mockClient := &mockGRPCClient{
+			mockSearchConfiguration: func(_ context.Context, _ *proto.SearchConfigurationRequest, _ ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
+				called = true
+				return tc.response, nil
+			},
+		}
 
-		`{}`: {},
+		testURL := &url.URL{
+			Scheme: "http",
+			Host:   "does.not.matter",
+			Path:   "/",
+		}
 
-		`{"Symbols": true}`: {
-			Symbols: true,
-		},
-
-		`{"RepoID": 123}`: {
-			RepoID: 123,
-		},
-
-		`{"Error": "boom"}`: nil,
-	}
-
-	for r, want := range cases {
-		response = []byte(r)
+		sg := newSourcegraphClient(
+			testURL,
+			"",
+			mockClient,
+		)
 
 		var got IndexOptions
 		var err error
@@ -664,17 +266,186 @@ func TestGetIndexOptions(t *testing.T) {
 			err = e
 		}, 123)
 
-		if err != nil && want != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if !called {
+			t.Fatal("expected mock to be called")
 		}
-		if want == nil {
+
+		if err != nil {
+			if tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+
+		if tc.want == nil {
 			continue
 		}
 
-		want.CloneURL = sg.getCloneURL(got.Name)
+		tc.want.CloneURL = sg.getCloneURL(got.Name)
 
-		if d := cmp.Diff(*want, got); d != "" {
-			t.Log("response", r)
+		if diff := cmp.Diff(tc.want, &got, cmpopts.EquateEmpty()); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	// Mimic our fingerprint API, which doesn't return anything if the
+	// repo hasn't changed.
+	t.Run("unchanged", func(t *testing.T) {
+
+		called := false
+		mockClient := &mockGRPCClient{
+			mockSearchConfiguration: func(_ context.Context, _ *proto.SearchConfigurationRequest, _ ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
+				called = true
+				return nil, nil
+			},
+		}
+
+		testURL := &url.URL{
+			Scheme: "http",
+			Host:   "does.not.matter",
+			Path:   "/",
+		}
+
+		sg := newSourcegraphClient(
+			testURL,
+			"",
+			mockClient,
+		)
+		gotAtLeastOneOption := false
+		var err error
+		sg.ForceIterateIndexOptions(func(_ IndexOptions) {
+			gotAtLeastOneOption = true
+		}, func(_ uint32, e error) {
+			err = e
+		}, 123)
+
+		if !called {
+			t.Fatal("expected mock to be called")
+		}
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if gotAtLeastOneOption {
+			t.Fatalf("expected no options, got %v", gotAtLeastOneOption)
+		}
+	})
+
+	var response *proto.SearchConfigurationResponse
+	mockClient := &mockGRPCClient{
+		mockSearchConfiguration: func(_ context.Context, req *proto.SearchConfigurationRequest, _ ...grpc.CallOption) (*proto.SearchConfigurationResponse, error) {
+			if len(req.GetRepoIds()) == 0 || req.GetRepoIds()[0] != 123 {
+				return nil, errors.New("invalid repo id")
+			}
+			return response, nil
+		},
+	}
+
+	sg := newSourcegraphClient(&url.URL{Path: "/"}, "", mockClient, WithBatchSize(0))
+
+	cases := []struct {
+		Response *proto.SearchConfigurationResponse
+		*IndexOptions
+	}{
+		{
+			Response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols:    true,
+						LargeFiles: []string{"foo", "bar"},
+					},
+				},
+			},
+			IndexOptions: &IndexOptions{
+				Symbols:     true,
+				LargeFiles:  []string{"foo", "bar"},
+				Branches:    []zoekt.RepositoryBranch{},
+				LanguageMap: map[string]ctags.CTagsParserType{},
+			},
+		},
+
+		{
+			Response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols:    false,
+						LargeFiles: []string{"foo", "bar"},
+					},
+				},
+			},
+			IndexOptions: &IndexOptions{
+				LargeFiles:  []string{"foo", "bar"},
+				Branches:    []zoekt.RepositoryBranch{},
+				LanguageMap: map[string]ctags.CTagsParserType{},
+			},
+		},
+
+		{
+			Response: &proto.SearchConfigurationResponse{},
+		},
+
+		{
+			Response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Symbols: true,
+					},
+				},
+			},
+			IndexOptions: &IndexOptions{
+				Symbols:     true,
+				Branches:    []zoekt.RepositoryBranch{},
+				LanguageMap: map[string]ctags.CTagsParserType{},
+			},
+		},
+
+		{
+			Response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						RepoId: 123,
+					},
+				},
+			},
+			IndexOptions: &IndexOptions{
+				RepoID:      123,
+				Branches:    []zoekt.RepositoryBranch{},
+				LanguageMap: map[string]ctags.CTagsParserType{},
+			},
+		},
+
+		{
+			Response: &proto.SearchConfigurationResponse{
+				UpdatedOptions: []*proto.ZoektIndexOptions{
+					{
+						Error: "boom",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		response = tc.Response
+
+		var got IndexOptions
+		var err error
+		sg.ForceIterateIndexOptions(func(o IndexOptions) {
+			got = o
+		}, func(_ uint32, e error) {
+			err = e
+		}, 123)
+
+		if err != nil && tc.IndexOptions != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tc.IndexOptions == nil {
+			continue
+		}
+
+		tc.IndexOptions.CloneURL = sg.getCloneURL(got.Name)
+
+		if d := cmp.Diff(*tc.IndexOptions, got); d != "" {
 			t.Errorf("mismatch (-want +got):\n%s", d)
 		}
 	}
@@ -682,7 +453,7 @@ func TestGetIndexOptions(t *testing.T) {
 	// Special case our fingerprint API which doesn't return anything if the
 	// repo hasn't changed.
 	t.Run("unchanged", func(t *testing.T) {
-		response = []byte(``)
+		response = &proto.SearchConfigurationResponse{}
 
 		got := false
 		var err error

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -108,11 +108,6 @@ var (
 		Help: "Number of indexed repos by code host",
 	})
 
-	metricNumAssigned = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "index_num_assigned",
-		Help: "Number of repos assigned to this indexer by code host",
-	})
-
 	metricFailingTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "index_failing_total",
 		Help: "Counts failures to index (indexing activity, should be used with rate())",
@@ -1140,19 +1135,6 @@ func getEnvWithDefaultDuration(k string, defaultVal time.Duration) time.Duration
 	return d
 }
 
-func getEnvWithDefaultBool(k string, defaultVal bool) bool {
-	v := os.Getenv(k)
-	if v == "" {
-		return defaultVal
-	}
-
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		log.Fatalf("error parsing ENV %s to bool: %s", k, err)
-	}
-	return b
-}
-
 func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
 	set := map[string]struct{}{}
 	for _, v := range strings.Split(os.Getenv(k), ",") {
@@ -1225,9 +1207,6 @@ type rootConfig struct {
 	// config values related to backoff indexing repos with one or more consecutive failures
 	backoffDuration    time.Duration
 	maxBackoffDuration time.Duration
-
-	// useGRPC is true if we should use the gRPC API to talk to Sourcegraph.
-	useGRPC bool
 }
 
 func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
@@ -1241,7 +1220,6 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.IntVar(&rc.blockProfileRate, "block_profile_rate", getEnvWithDefaultInt("BLOCK_PROFILE_RATE", -1), "Sampling rate of Go's block profiler in nanoseconds. Values <=0 disable the blocking profiler Var(default). A value of 1 includes every blocking event. See https://pkg.go.dev/runtime#SetBlockProfileRate")
 	fs.DurationVar(&rc.backoffDuration, "backoff_duration", getEnvWithDefaultDuration("BACKOFF_DURATION", 10*time.Minute), "for the given duration we backoff from enqueue operations for a repository that's failed its previous indexing attempt. Consecutive failures increase the duration of the delay linearly up to the maxBackoffDuration. A negative value disables indexing backoff.")
 	fs.DurationVar(&rc.maxBackoffDuration, "max_backoff_duration", getEnvWithDefaultDuration("MAX_BACKOFF_DURATION", 120*time.Minute), "the maximum duration to backoff from enqueueing a repo for indexing.  A negative value disables indexing backoff.")
-	fs.BoolVar(&rc.useGRPC, "use_grpc", mustGetBoolFromEnvironmentVariables([]string{"GRPC_ENABLED", "SG_FEATURE_FLAG_GRPC"}, true), "use the gRPC API to talk to Sourcegraph")
 
 	// flags related to shard merging
 	fs.DurationVar(&rc.vacuumInterval, "vacuum_interval", getEnvWithDefaultDuration("SRC_VACUUM_INTERVAL", 24*time.Hour), "run vacuum this often")
@@ -1408,13 +1386,12 @@ func newServer(conf rootConfig) (*Server, error) {
 		if v := os.Getenv("SRC_REPO_CONFIG_BATCH_SIZE"); v != "" {
 			batchSize, err = strconv.Atoi(v)
 			if err != nil {
-				return nil, fmt.Errorf("Invalid value for SRC_REPO_CONFIG_BATCH_SIZE, must be int")
+				return nil, fmt.Errorf("invalid value for SRC_REPO_CONFIG_BATCH_SIZE, must be int")
 			}
 		}
 
 		opts := []SourcegraphClientOption{
 			WithBatchSize(batchSize),
-			WithShouldUseGRPC(conf.useGRPC),
 		}
 
 		logger := sglog.Scoped("zoektConfigurationGRPCClient")
@@ -1423,8 +1400,7 @@ func newServer(conf rootConfig) (*Server, error) {
 			return nil, fmt.Errorf("initializing gRPC connection to %q: %w", rootURL.Host, err)
 		}
 
-		opts = append(opts, WithGRPCClient(client))
-		sg = newSourcegraphClient(rootURL, conf.hostname, opts...)
+		sg = newSourcegraphClient(rootURL, conf.hostname, client, opts...)
 
 	} else {
 		sg = sourcegraphFake{
@@ -1633,17 +1609,6 @@ func main() {
 	if err := rootCmd().ParseAndRun(context.Background(), os.Args[1:]); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// mustGetBoolFromEnvironmentVariables is like getBoolFromEnvironmentVariables, but it panics
-// if any of the provided environment variables fails to parse as a boolean.
-func mustGetBoolFromEnvironmentVariables(envVarNames []string, defaultBool bool) bool {
-	value, err := getBoolFromEnvironmentVariables(envVarNames, defaultBool)
-	if err != nil {
-		panic(err)
-	}
-
-	return value
 }
 
 // getBoolFromEnvironmentVariables returns the boolean defined by the first environment

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -33,7 +31,7 @@ func TestServer_defaultArgs(t *testing.T) {
 	}
 
 	s := &Server{
-		Sourcegraph:      newSourcegraphClient(root, "", WithBatchSize(0)),
+		Sourcegraph:      newSourcegraphClient(root, "", nil, WithBatchSize(0)),
 		IndexDir:         "/testdata/index",
 		CPUCount:         6,
 		IndexConcurrency: 1,
@@ -101,7 +99,7 @@ func TestServer_parallelism(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Server{
-				Sourcegraph:      newSourcegraphClient(root, "", WithBatchSize(0)),
+				Sourcegraph:      newSourcegraphClient(root, "", nil, WithBatchSize(0)),
 				IndexDir:         "/testdata/index",
 				CPUCount:         tt.cpuCount,
 				IndexConcurrency: tt.indexConcurrency,
@@ -117,7 +115,7 @@ func TestServer_parallelism(t *testing.T) {
 
 	t.Run("index option is limited by available CPU", func(t *testing.T) {
 		s := &Server{
-			Sourcegraph:      newSourcegraphClient(root, "", WithBatchSize(0)),
+			Sourcegraph:      newSourcegraphClient(root, "", nil, WithBatchSize(0)),
 			IndexDir:         "/testdata/index",
 			IndexConcurrency: 1,
 		}
@@ -133,138 +131,64 @@ func TestServer_parallelism(t *testing.T) {
 }
 
 func TestListRepoIDs(t *testing.T) {
-	t.Run("gRPC", func(t *testing.T) {
+	grpcClient := &mockGRPCClient{}
 
-		grpcClient := &mockGRPCClient{}
+	clientOptions := []SourcegraphClientOption{
+		WithBatchSize(0),
+	}
 
-		clientOptions := []SourcegraphClientOption{
-			WithShouldUseGRPC(true),
-			WithGRPCClient(grpcClient),
-			WithBatchSize(0),
-		}
+	testURL := url.URL{Scheme: "http", Host: "does.not.matter"}
+	testHostname := "test-hostname"
+	s := newSourcegraphClient(&testURL, testHostname, grpcClient, clientOptions...)
 
-		testURL := url.URL{Scheme: "http", Host: "does.not.matter"}
-		testHostname := "test-hostname"
-		s := newSourcegraphClient(&testURL, testHostname, clientOptions...)
+	listCalled := false
+	grpcClient.mockList = func(ctx context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (*proto.ListResponse, error) {
+		listCalled = true
 
-		listCalled := false
-		grpcClient.mockList = func(ctx context.Context, in *proto.ListRequest, opts ...grpc.CallOption) (*proto.ListResponse, error) {
-			listCalled = true
-
-			gotRepoIDs := in.GetIndexedIds()
-			sort.Slice(gotRepoIDs, func(i, j int) bool {
-				return gotRepoIDs[i] < gotRepoIDs[j]
-			})
-
-			wantRepoIDs := []int32{1, 3}
-			sort.Slice(wantRepoIDs, func(i, j int) bool {
-				return wantRepoIDs[i] < wantRepoIDs[j]
-			})
-
-			if diff := cmp.Diff(wantRepoIDs, gotRepoIDs); diff != "" {
-				t.Errorf("indexed repoIDs mismatch (-want +got):\n%s", diff)
-			}
-
-			hostname := in.GetHostname()
-			if diff := cmp.Diff(testHostname, hostname); diff != "" {
-				t.Errorf("hostname mismatch (-want +got):\n%s", diff)
-			}
-
-			return &proto.ListResponse{RepoIds: []int32{1, 2, 3}}, nil
-		}
-
-		ctx := context.Background()
-		got, err := s.List(ctx, []uint32{1, 3})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if !listCalled {
-			t.Fatalf("List was not called")
-		}
-
-		receivedRepoIDs := got.IDs
-		sort.Slice(receivedRepoIDs, func(i, j int) bool {
-			return receivedRepoIDs[i] < receivedRepoIDs[j]
+		gotRepoIDs := in.GetIndexedIds()
+		sort.Slice(gotRepoIDs, func(i, j int) bool {
+			return gotRepoIDs[i] < gotRepoIDs[j]
 		})
 
-		expectedRepoIDs := []uint32{1, 2, 3}
-		sort.Slice(expectedRepoIDs, func(i, j int) bool {
-			return expectedRepoIDs[i] < expectedRepoIDs[j]
+		wantRepoIDs := []int32{1, 3}
+		sort.Slice(wantRepoIDs, func(i, j int) bool {
+			return wantRepoIDs[i] < wantRepoIDs[j]
 		})
 
-		if diff := cmp.Diff(expectedRepoIDs, receivedRepoIDs); diff != "" {
-			t.Errorf("mismatch in list of all repoIDs (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("REST", func(t *testing.T) {
-		var gotBody string
-		var gotURL *url.URL
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			gotURL = r.URL
-
-			b, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			gotBody = string(b)
-
-			_, err = w.Write([]byte(`{"RepoIDs": [1, 2, 3]}`))
-			if err != nil {
-				t.Fatal(err)
-			}
-		}))
-		defer ts.Close()
-
-		u, err := url.Parse(ts.URL)
-		if err != nil {
-			t.Fatal(err)
+		if diff := cmp.Diff(wantRepoIDs, gotRepoIDs); diff != "" {
+			t.Errorf("indexed repoIDs mismatch (-want +got):\n%s", diff)
 		}
 
-		s := newSourcegraphClient(u, "test-indexed-search-1", WithBatchSize(0))
-
-		gotRepos, err := s.List(context.Background(), []uint32{1, 3})
-		if err != nil {
-			t.Fatal(err)
+		hostname := in.GetHostname()
+		if diff := cmp.Diff(testHostname, hostname); diff != "" {
+			t.Errorf("hostname mismatch (-want +got):\n%s", diff)
 		}
 
-		if want := []uint32{1, 2, 3}; !cmp.Equal(gotRepos.IDs, want) {
-			t.Errorf("repos mismatch (-want +got):\n%s", cmp.Diff(want, gotRepos.IDs))
-		}
-		if want := `{"Hostname":"test-indexed-search-1","IndexedIDs":[1,3]}`; gotBody != want {
-			t.Errorf("body mismatch (-want +got):\n%s", cmp.Diff(want, gotBody))
-		}
-		if want := "/.internal/repos/index"; gotURL.Path != want {
-			t.Errorf("request path mismatch (-want +got):\n%s", cmp.Diff(want, gotURL.Path))
-		}
-	})
-}
+		return &proto.ListResponse{RepoIds: []int32{1, 2, 3}}, nil
+	}
 
-func TestListRepoIDs_Error_REST(t *testing.T) {
-	// Note: There is no gRPC equivalent to this test because gRPC errors are
-	// always returned as an error to the caller.
-
-	msg := "deadbeaf deadbeaf"
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		// This is how Sourcegraph returns error messages to the caller.
-		http.Error(w, msg, http.StatusInternalServerError)
-	}))
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
+	ctx := context.Background()
+	got, err := s.List(ctx, []uint32{1, 3})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	s := newSourcegraphClient(u, "test-indexed-search-1", WithBatchSize(0))
-	s.restClient.RetryMax = 0
+	if !listCalled {
+		t.Fatalf("List was not called")
+	}
 
-	_, err = s.List(context.Background(), []uint32{1, 3})
+	receivedRepoIDs := got.IDs
+	sort.Slice(receivedRepoIDs, func(i, j int) bool {
+		return receivedRepoIDs[i] < receivedRepoIDs[j]
+	})
 
-	if !strings.Contains(err.Error(), msg) {
-		t.Fatalf("%s does not contain %s", err.Error(), msg)
+	expectedRepoIDs := []uint32{1, 2, 3}
+	sort.Slice(expectedRepoIDs, func(i, j int) bool {
+		return expectedRepoIDs[i] < expectedRepoIDs[j]
+	})
+
+	if diff := cmp.Diff(expectedRepoIDs, receivedRepoIDs); diff != "" {
+		t.Errorf("mismatch in list of all repoIDs (-want +got):\n%s", diff)
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -16,8 +16,6 @@ import (
 	"github.com/sourcegraph/zoekt"
 )
 
-var reCompound = regexp.MustCompile(`compound-.*\.zoekt`)
-
 var metricShardMergingRunning = promauto.NewGauge(prometheus.GaugeOpts{
 	Name: "index_shard_merging_running",
 	Help: "Set to 1 if indexserver's merge job is running.",

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.0-rc.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0
-	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/keegancsmith/rpc v1.3.0
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 	github.com/opentracing/opentracing-go v1.2.0
@@ -97,6 +96,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.16.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect


### PR DESCRIPTION
We no longer serve these old HTTP APIs starting with Sourcegraph 5.3, so this code is no longer required.

I hope this makes your lives a little easier by not having to maintain two code paths.

If this change is annoying (because you cannot backport fixes to older versions as easily), feel free to either keep it on hold or close it.

## Test plan

CI still passes, anything else I should be trying?