### PR TITLE
ranking: allow partial overlap with symbol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ name: CI
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: alpine:edge # go1.19 needs > alpine 3.15
+    # Pinned to alpine 3.19 to fix go version to 1.21. Remove this once Sourcegraph is on Go 1.22.
+    container: alpine:3.19
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/build/scoring_test.go
+++ b/build/scoring_test.go
@@ -162,6 +162,38 @@ func TestJava(t *testing.T) {
 			// 7000 (symbol) + 900 (Java enum) + 500 (word) + 300 (atom) + 10 (file order)
 			wantScore: 8710,
 		},
+		{
+			fileName: "example.java",
+			content:  exampleJava,
+			query:    &query.Substring{Content: true, Pattern: "unInnerInterface("},
+			language: "Java",
+			// 4000 (overlap Symbol) + 700 (Java method) + 50 (partial word) + 10 (file order)
+			wantScore: 4760,
+		},
+		{
+			fileName: "example.java",
+			content:  exampleJava,
+			query:    &query.Substring{Content: true, Pattern: "InnerEnum"},
+			language: "Java",
+			// 7000 (Symbol) + 900 (Java enum) + 500 (word) + 10 (file order)
+			wantScore: 8410,
+		},
+		{
+			fileName: "example.java",
+			content:  exampleJava,
+			query:    &query.Substring{Content: true, Pattern: "enum InnerEnum"},
+			language: "Java",
+			// 5500 (edge Symbol) + 900 (Java enum) + 500 (word) + 10 (file order)
+			wantScore: 6910,
+		},
+		{
+			fileName: "example.java",
+			content:  exampleJava,
+			query:    &query.Substring{Content: true, Pattern: "public enum InnerEnum {"},
+			language: "Java",
+			// 4000 (overlap Symbol) + 900 (Java enum) + 500 (word) + 10 (file order)
+			wantScore: 5410,
+		},
 	}
 
 	for _, c := range cases {

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -560,10 +560,13 @@ func findSection(secs []DocumentSection, off, sz uint32) (uint32, bool) {
 // The implementation assumes that sections do not overlap and are sorted by
 // DocumentSection.Start.
 func findMaxOverlappingSection(secs []DocumentSection, off, sz uint32) (uint32, bool) {
-	// Find the first section that might overlap
-	j := sort.Search(len(secs), func(i int) bool { return secs[i].End > off })
+	start := off
+	end := off + sz
 
-	if j == len(secs) || secs[j].Start >= off+sz {
+	// Find the first section that might overlap
+	j := sort.Search(len(secs), func(i int) bool { return secs[i].End > start })
+
+	if j == len(secs) || secs[j].Start >= end {
 		// No overlap.
 		return 0, false
 	}
@@ -574,12 +577,12 @@ func findMaxOverlappingSection(secs []DocumentSection, off, sz uint32) (uint32, 
 			return 0
 		}
 		// This cannot overflow because we make sure there is overlap before calling relOverlap
-		overlap := min(secs[j].End, off+sz) - max(secs[j].Start, off)
+		overlap := min(secs[j].End, end) - max(secs[j].Start, start)
 		return float64(overlap) / float64(secSize)
 	}
 
 	ol1 := relOverlap(j)
-	if epsilonEqualsOne(ol1) || j == len(secs)-1 || secs[j+1].Start >= off+sz {
+	if epsilonEqualsOne(ol1) || j == len(secs)-1 || secs[j+1].Start >= end {
 		return uint32(j), ol1 > 0
 	}
 

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -556,7 +556,7 @@ func findSection(secs []DocumentSection, off, sz uint32) (uint32, bool) {
 // overlaps the most with the area defined by off and sz. If no section
 // overlaps, it returns 0, false.
 //
-// The implementation assumes that secs is sorted by DocumentSection.End.
+// The implementation assumes that sections do not overlap.
 func findMaxOverlappingSection(secs []DocumentSection, off, sz uint32) (uint32, bool) {
 	// Find the first section that overlaps.
 	j := sort.Search(len(secs), func(i int) bool { return secs[i].End > off })

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -423,21 +423,29 @@ func TestFindMaxOverlappingSection(t *testing.T) {
 		name        string
 		off         uint32
 		sz          uint32
-		wantSecIx   uint32
+		wantSecIdx  uint32
 		wantOverlap bool
 	}{
-		{off: 0, sz: 1, wantSecIx: 0, wantOverlap: true},
-		{off: 0, sz: 5, wantSecIx: 0, wantOverlap: true},
-		{off: 2, sz: 5, wantSecIx: 0, wantOverlap: true},
-		{off: 2, sz: 50, wantSecIx: 1, wantOverlap: true},
-		{off: 4, sz: 10, wantSecIx: 1, wantOverlap: true},
-		{off: 5, sz: 15, wantSecIx: 1, wantOverlap: true},
-		{off: 18, sz: 10, wantSecIx: 2, wantOverlap: true},
+		{off: 0, sz: 1, wantSecIdx: 0, wantOverlap: true},
+		{off: 0, sz: 5, wantSecIdx: 0, wantOverlap: true},
+		{off: 2, sz: 5, wantSecIdx: 0, wantOverlap: true},
+		{off: 2, sz: 50, wantSecIdx: 1, wantOverlap: true},
+		{off: 4, sz: 10, wantSecIdx: 1, wantOverlap: true},
+		{off: 5, sz: 15, wantSecIdx: 1, wantOverlap: true},
+		{off: 18, sz: 10, wantSecIdx: 2, wantOverlap: true},
+
+		// Prefer full overlap, break ties by preferring the earlier section
+		{off: 10, sz: 20, wantSecIdx: 2, wantOverlap: true},
+		{off: 0, sz: 100, wantSecIdx: 0, wantOverlap: true},
+		{off: 8, sz: 100, wantSecIdx: 1, wantOverlap: true},
+		{off: 0, sz: 10, wantSecIdx: 0, wantOverlap: true},
+		{off: 16, sz: 10, wantSecIdx: 2, wantOverlap: true},
 
 		// No overlap
 		{off: 5, sz: 2, wantOverlap: false},
 		{off: 20, sz: 1, wantOverlap: false},
 		{off: 99, sz: 1, wantOverlap: false},
+		{off: 0, sz: 0, wantOverlap: false},
 	}
 
 	for _, tt := range testcases {
@@ -446,8 +454,8 @@ func TestFindMaxOverlappingSection(t *testing.T) {
 			if haveOverlap != tt.wantOverlap {
 				t.Fatalf("expected overlap %v, got %v", tt.wantOverlap, haveOverlap)
 			}
-			if got != tt.wantSecIx {
-				t.Fatalf("expected section %d, got %d", tt.wantSecIx, got)
+			if got != tt.wantSecIdx {
+				t.Fatalf("expected section %d, got %d", tt.wantSecIdx, got)
 			}
 		})
 	}

--- a/contentprovider_test.go
+++ b/contentprovider_test.go
@@ -410,14 +410,14 @@ func TestColumnHelper(t *testing.T) {
 
 func TestFindMaxOverlappingSection(t *testing.T) {
 	secs := []DocumentSection{
-		{Start: 0, End: 10},
-		{Start: 5, End: 15},
-		{Start: 17, End: 21},
+		{Start: 0, End: 5},
+		{Start: 8, End: 19},
+		{Start: 22, End: 26},
 	}
-	// 0123456789012345678901
-	// [.........[
-	//     [..........[
-	//                  [...[
+	// 012345678901234567890123456
+	// [....[
+	//         [..........[
+	//                       [...[
 
 	testcases := []struct {
 		name        string
@@ -426,16 +426,18 @@ func TestFindMaxOverlappingSection(t *testing.T) {
 		wantSecIx   uint32
 		wantOverlap bool
 	}{
-		{off: 1, sz: 5, wantSecIx: 0, wantOverlap: true},
-		{off: 0, sz: 10, wantSecIx: 0, wantOverlap: true},
-		{off: 3, sz: 10, wantSecIx: 1, wantOverlap: true},
-		{off: 8, sz: 4, wantSecIx: 1, wantOverlap: true},
-		{off: 12, sz: 15, wantSecIx: 2, wantOverlap: true},
-		{off: 16, sz: 10, wantSecIx: 2, wantOverlap: true},
+		{off: 0, sz: 1, wantSecIx: 0, wantOverlap: true},
+		{off: 0, sz: 5, wantSecIx: 0, wantOverlap: true},
+		{off: 2, sz: 5, wantSecIx: 0, wantOverlap: true},
+		{off: 2, sz: 50, wantSecIx: 1, wantOverlap: true},
+		{off: 4, sz: 10, wantSecIx: 1, wantOverlap: true},
+		{off: 5, sz: 15, wantSecIx: 1, wantOverlap: true},
+		{off: 18, sz: 10, wantSecIx: 2, wantOverlap: true},
 
 		// No overlap
-		{off: 15, sz: 2, wantOverlap: false},
-		{off: 21, sz: 1, wantOverlap: false},
+		{off: 5, sz: 2, wantOverlap: false},
+		{off: 20, sz: 1, wantOverlap: false},
+		{off: 99, sz: 1, wantOverlap: false},
 	}
 
 	for _, tt := range testcases {

--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -54,6 +54,7 @@ func TestRanking(t *testing.T) {
 		q("test server", "github.com/golang/go/src/net/http/httptest/server.go"),
 		q("bytes buffer", "github.com/golang/go/src/bytes/buffer.go"),
 		q("bufio buffer", "github.com/golang/go/src/bufio/scan.go"),
+		q("time compare\\(", "github.com/golang/go/src/time/time.go"),
 
 		// sourcegraph/sourcegraph
 		q("graphql type User", "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/schema.graphql"),

--- a/internal/e2e/testdata/bytes_buffer.txt
+++ b/internal/e2e/testdata/bytes_buffer.txt
@@ -14,11 +14,11 @@ github.com/golang/go/src/cmd/internal/edit/edit.go
 41:func NewBuffer(data []byte) *Buffer {
 hidden 13 more line matches
 
-github.com/golang/go/src/hash/crc32/crc32_ppc64le.s
-122:	SLD     $2,R8           // convert index-> bytes
-59:	MOVWZ	0(R5),R8	// 0-3 bytes of p ?Endian?
-60:	MOVWZ	4(R5),R9	// 4-7 bytes of p
-hidden 35 more line matches
+github.com/golang/go/misc/wasm/wasm_exec.js
+497:				const bytes = encoder.encode(str + "\0");
+48:			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
+192:				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+hidden 10 more line matches
 
 github.com/golang/go/src/fmt/print.go
 101:type buffer []byte

--- a/internal/e2e/testdata/bytes_buffer.txt
+++ b/internal/e2e/testdata/bytes_buffer.txt
@@ -14,11 +14,11 @@ github.com/golang/go/src/cmd/internal/edit/edit.go
 41:func NewBuffer(data []byte) *Buffer {
 hidden 13 more line matches
 
-github.com/golang/go/misc/wasm/wasm_exec.js
-497:				const bytes = encoder.encode(str + "\0");
-48:			read(fd, buffer, offset, length, position, callback) { callback(enosys()); },
-192:				return new Uint8Array(this._inst.exports.mem.buffer, array, len);
-hidden 10 more line matches
+github.com/golang/go/src/hash/crc32/crc32_ppc64le.s
+122:	SLD     $2,R8           // convert index-> bytes
+59:	MOVWZ	0(R5),R8	// 0-3 bytes of p ?Endian?
+60:	MOVWZ	4(R5),R9	// 4-7 bytes of p
+hidden 35 more line matches
 
 github.com/golang/go/src/fmt/print.go
 101:type buffer []byte

--- a/internal/e2e/testdata/coverage_data_writer.txt
+++ b/internal/e2e/testdata/coverage_data_writer.txt
@@ -5,7 +5,7 @@ targetRank: 13
 github.com/golang/go/src/internal/coverage/stringtab/stringtab.go
 19:type Writer struct {
 27:func (stw *Writer) InitWriter() {
-9:	"internal/coverage/slicereader"
+70:func (stw *Writer) Write(w io.Writer) error {
 hidden 16 more line matches
 
 github.com/golang/go/src/cmd/cover/func.go

--- a/internal/e2e/testdata/rank_stats.txt
+++ b/internal/e2e/testdata/rank_stats.txt
@@ -1,4 +1,4 @@
-queries: 14
-recall@1: 9 (64%)
-recall@5: 11 (79%)
-mrr: 0.710733
+queries: 15
+recall@1: 10 (67%)
+recall@5: 12 (80%)
+mrr: 0.730017

--- a/internal/e2e/testdata/time_compare.txt
+++ b/internal/e2e/testdata/time_compare.txt
@@ -1,0 +1,38 @@
+queryString: time compare\(
+query: (and substr:"time" substr:"compare(")
+targetRank: 1
+
+**github.com/golang/go/src/time/time.go**
+129:type Time struct {
+79:package time
+271:func (t Time) Compare(u Time) int {
+hidden 250 more line matches
+
+github.com/sourcegraph/sourcegraph/internal/api/api.go
+127:func (r ExternalRepoSpec) Compare(s ExternalRepoSpec) int {
+7:	"time"
+170:	CreatedAt    time.Time       // the date when this settings value was created
+
+github.com/sourcegraph/sourcegraph/client/shared/src/codeintel/scip.ts
+117:    public compare(other: Range): number {
+53:        return this.compare(other) < 0
+56:        return this.compare(other) <= 0
+hidden 10 more line matches
+
+github.com/golang/go/src/strings/compare.go
+13:func Compare(a, b string) int {
+14:	// NOTE(rsc): This function does NOT call the runtime cmpstring function,
+
+github.com/golang/go/src/go/constant/value.go
+1337:func Compare(x_ Value, op token.Token, y_ Value) bool {
+1102:// Division by zero leads to a run-time panic.
+1381:		re := Compare(x.re, token.EQL, y.re)
+hidden 1 more line matches
+
+github.com/golang/go/src/syscall/zsyscall_windows.go
+878:func GetSystemTimeAsFileTime(time *Filetime) {
+1088:func SetFileTime(handle Handle, ctime *Filetime, atime *Filetime, wtime *Filetime) (err error) {
+132:	procGetSystemTimeAsFileTime            = modkernel32.NewProc("GetSystemTimeAsFileTime")
+hidden 19 more line matches
+
+hidden 139 more file matches

--- a/internal/e2e/testdata/zoekt_searcher.txt
+++ b/internal/e2e/testdata/zoekt_searcher.txt
@@ -11,7 +11,7 @@ hidden 13 more line matches
 github.com/sourcegraph/zoekt/rpc/internal/srv/srv.go
 33:type Searcher struct {
 34:	Searcher zoekt.Searcher
-7:	"github.com/sourcegraph/zoekt"
+37:func (s *Searcher) Search(ctx context.Context, args *SearchArgs, reply *SearchReply) error {
 hidden 9 more line matches
 
 github.com/sourcegraph/sourcegraph/doc/admin/observability/dashboards.md
@@ -35,7 +35,7 @@ hidden 1 more line matches
 github.com/sourcegraph/zoekt/json/json.go
 26:	Searcher zoekt.Searcher
 25:type jsonSearcher struct {
-9:	"github.com/sourcegraph/zoekt"
+48:func (s *jsonSearcher) jsonSearch(w http.ResponseWriter, req *http.Request) {
 hidden 16 more line matches
 
 hidden 119 more file matches

--- a/read_test.go
+++ b/read_test.go
@@ -306,8 +306,8 @@ func TestReadSearch(t *testing.T) {
 				continue
 			}
 
-			if d := cmp.Diff(res.Files, want.FileMatches[j]); d != "" {
-				t.Errorf("matches for %s on %s\n%s", q, name, d)
+			if d := cmp.Diff(want.FileMatches[j], res.Files); d != "" {
+				t.Errorf("matches for %s on %s (-want +got)\n%s", q, name, d)
 			}
 		}
 	}

--- a/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v16.00000.golden
@@ -16,7 +16,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 6801,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -29,7 +29,7 @@
           }
         ],
         "Checksum": "n9fUYqacPXg=",
-        "Score": 510
+        "Score": 6810
       }
     ],
     [

--- a/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
+++ b/testdata/golden/TestReadSearch/ctagsrepo_v17.00000.golden
@@ -16,7 +16,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 6801,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -29,7 +29,7 @@
           }
         ],
         "Checksum": "n9fUYqacPXg=",
-        "Score": 510
+        "Score": 6810
       }
     ],
     [

--- a/testdata/golden/TestReadSearch/repo2_v16.00000.golden
+++ b/testdata/golden/TestReadSearch/repo2_v16.00000.golden
@@ -16,7 +16,7 @@
             "Before": null,
             "After": null,
             "FileName": false,
-            "Score": 501,
+            "Score": 6801,
             "DebugScore": "",
             "LineFragments": [
               {
@@ -29,7 +29,7 @@
           }
         ],
         "Checksum": "Ju1TnQKZ6mE=",
-        "Score": 510
+        "Score": 6810
       }
     ],
     [


### PR DESCRIPTION
With this update, we score matches which overlap with a symbol in any way. Before, we only added a score if the match was fully contained in a symbol. 

Test plan:
- new unit tests
- updated scoring tests 