### PR TITLE
go.mod: update to go 1.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
+      - name: add dependencies
+        run: apk add go
       # Pinned a commit to make go version configurable.
       # This should be safe to upgrade once this commit is in a released version:
       # https://github.com/jidicula/go-fuzz-action/commit/23cc553941669144159507e2cccdbb4afc5b3076

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     container: alpine:edge
     steps:
       - name: add dependencies
-        run: apk add go
+        run: apk add bash go
       # Pinned a commit to make go version configurable.
       # This should be safe to upgrade once this commit is in a released version:
       # https://github.com/jidicula/go-fuzz-action/commit/23cc553941669144159507e2cccdbb4afc5b3076

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   fuzz-test:
     name: fuzz test
     runs-on: ubuntu-latest
+    container: alpine:edge
     steps:
       # Pinned a commit to make go version configurable.
       # This should be safe to upgrade once this commit is in a released version:
@@ -31,7 +32,7 @@ jobs:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
           fuzz-minimize-time: 1m
-          go-version: '1.21'
+          go-version: '1.22'
 
   shellcheck:
     name: shellcheck

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.0
+golang 1.22.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.21.2
+golang 1.22.0

--- a/go.mod
+++ b/go.mod
@@ -138,4 +138,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.21
+go 1.22

--- a/matchtree.go
+++ b/matchtree.go
@@ -1115,7 +1115,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 
 		return &symbolRegexpMatchTree{
 			regexp:    regexp,
-			all:       regexp.String() == "(?i)(?-s:.)*",
+			all:       regexp.String() == "(?i)(?-s:.*)",
 			matchTree: subMT,
 		}, nil
 

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -237,9 +237,9 @@ func TestSymbolMatchTree(t *testing.T) {
 		regex    string
 		regexAll bool
 	}{
-		{query: "sym:.*", regex: "(?i)(?-s:.)*", regexAll: true},
+		{query: "sym:.*", regex: "(?i)(?-s:.*)", regexAll: true},
 		{query: "sym:(ab|cd)", regex: "(?i)ab|cd"},
-		{query: "sym:b.r", regex: "(?i)b(?-s:.)r"},
+		{query: "sym:b.r", regex: "(?i)(?-s:b.r)"},
 		{query: "sym:horse", substr: "horse"},
 		{query: `sym:\bthread\b case:yes`, regex: `\bthread\b`}, // check we disable word search opt
 		{query: `sym:\bthread\b case:no`, regex: `(?i)\bthread\b`},


### PR DESCRIPTION
Our CI pipeline uses alpine:edge which now ships with Go 1.22. I noticed, because `matchree_test.go` doesn't pass anymore on CI. There seem to have been changes in the regexp package which we catch in our tests. I couldn't find anything in the release notes, but [this](https://github.com/golang/go/commit/98c9f271d67b501ecf2ce995539abd2cdc81d505) could be related.

[Here is an example](https://go.dev/play/p/L3BJSyKB1sr). Toggle between 1.21 and 1.22 to see the difference.

test plan:
go test ./... and CI