### PR TITLE
remove deprecated ShardMaxImportantMatch TotalMaxImportantMatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ name: CI
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: alpine:edge # go1.19 needs > alpine 3.15
+    # Pinned to alpine 3.19 to fix go version to 1.21. Remove this once Sourcegraph is on Go 1.22.
+    container: alpine:3.19
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/api.go
+++ b/api.go
@@ -892,12 +892,6 @@ type SearchOptions struct {
 	// be set to 1 to find all repositories containing a result.
 	ShardRepoMaxMatchCount int
 
-	// Deprecated: this field is not read anymore.
-	ShardMaxImportantMatch int
-
-	// Deprecated: this field is not read anymore.
-	TotalMaxImportantMatch int
-
 	// Abort the search after this much time has passed.
 	MaxWallTime time.Duration
 
@@ -986,8 +980,6 @@ func (s *SearchOptions) String() string {
 	addInt("ShardMaxMatchCount", s.ShardMaxMatchCount)
 	addInt("TotalMaxMatchCount", s.TotalMaxMatchCount)
 	addInt("ShardRepoMaxMatchCount", s.ShardRepoMaxMatchCount)
-	addInt("ShardMaxImportantMatch", s.ShardMaxImportantMatch)
-	addInt("TotalMaxImportantMatch", s.TotalMaxImportantMatch)
 	addInt("MaxDocDisplayCount", s.MaxDocDisplayCount)
 	addInt("MaxMatchDisplayCount", s.MaxMatchDisplayCount)
 	addInt("NumContextLines", s.NumContextLines)

--- a/api_proto_test.go
+++ b/api_proto_test.go
@@ -335,9 +335,6 @@ func TestProtoRoundtrip(t *testing.T) {
 	t.Run("SearchOptions", func(t *testing.T) {
 		f := func(f1 *SearchOptions) bool {
 			if f1 != nil {
-				// Ignore deprecated and unimplemented fields
-				f1.ShardMaxImportantMatch = 0
-				f1.TotalMaxImportantMatch = 0
 				f1.SpanContext = nil
 			}
 			p1 := f1.ToProto()


### PR DESCRIPTION
Both of these fields have been unread and mark deprecated for a while.

Test Plan: go test