### PR TITLE
matchtree: do not depend on String for symbol all optimization

### DIFF
--- a/matchtree.go
+++ b/matchtree.go
@@ -1391,16 +1391,20 @@ func isRegexpAll(r *syntax.Regexp) bool {
 	// Note: we don't care about any flags since we are looking for .* and we
 	// don't mind if . matches all or everything but newline.
 
-	// Our main target: .*
-	if r.Op == syntax.OpStar && len(r.Sub) == 1 { // *
-		// (?s:.) or (?-s:.)
-		return r.Sub[0].Op == syntax.OpAnyChar || r.Sub[0].Op == syntax.OpAnyCharNotNL
-	}
+	// for loop is for visiting children of OpCapture/OpConcat until we hit .*
+	for {
+		// Our main target: .*
+		if r.Op == syntax.OpStar && len(r.Sub) == 1 { // *
+			// (?s:.) or (?-s:.)
+			return r.Sub[0].Op == syntax.OpAnyChar || r.Sub[0].Op == syntax.OpAnyCharNotNL
+		}
 
-	// Strip away expressions being wrapped in paranthesis
-	if (r.Op == syntax.OpCapture || r.Op == syntax.OpConcat) && len(r.Sub) == 1 {
-		return isRegexpAll(r.Sub[0])
-	}
+		// Strip away expressions being wrapped in paranthesis
+		if (r.Op == syntax.OpCapture || r.Op == syntax.OpConcat) && len(r.Sub) == 1 {
+			r = r.Sub[0]
+			continue
+		}
 
-	return false
+		return false
+	}
 }

--- a/matchtree_test.go
+++ b/matchtree_test.go
@@ -16,6 +16,7 @@ package zoekt
 
 import (
 	"reflect"
+	"regexp/syntax"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring"
@@ -383,5 +384,40 @@ func TestRepoIDs(t *testing.T) {
 	}
 	if mt.nextDoc() != maxUInt32 {
 		t.Fatalf("expected %d document, but got at least 1 more", len(want))
+	}
+}
+
+func TestIsRegexpAll(t *testing.T) {
+	valid := []string{
+		".*",
+		"(.*)",
+		"(?-s:.*)",
+		"(?s:.*)",
+		"(?i)(?-s:.*)",
+	}
+	invalid := []string{
+		".",
+		"foo",
+		"(foo.*)",
+	}
+
+	for _, s := range valid {
+		r, err := syntax.Parse(s, syntax.Perl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !isRegexpAll(r) {
+			t.Errorf("expected %q to match all", s)
+		}
+	}
+
+	for _, s := range invalid {
+		r, err := syntax.Parse(s, syntax.Perl)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if isRegexpAll(r) {
+			t.Errorf("expected %q to not match all", s)
+		}
 	}
 }


### PR DESCRIPTION
In go 1.22 the way go converts a query like .* into a String changed. This meant that when we compiled zoekt in the sourcegraph codebase our "regex matches all" optimization stopped working.

This commit moves us to a simple inspection of the syntax tree which will be stable across versions and to be honest just feels better.

To do this we introduce a field "origRegexp" to the regexpMatchTree so we can avoid needing to recompile the syntax tree. Note: Regexp does not offer a way to get at its internal syntax.Regexp which would be nice.

This PR has a refactor commit first so its clearer that we correctly set origRegexp everywhere.

Test Plan: go test and added a unit test

Fixes https://github.com/sourcegraph/sourcegraph/issues/61017
