### PR TITLE
shards: selectRepoSet supports queries which are not wrapped in and

### DIFF
--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -288,12 +288,16 @@ func TestShardedSearcher_DocumentRanking(t *testing.T) {
 func TestFilteringShardsByRepoSetOrBranchesReposOrRepoIDs(t *testing.T) {
 	ss := newShardedSearcher(1)
 
+	// namePrefix is so we can create a repo:foo filter and match the same set
+	// of repos.
+	namePrefix := [3]string{"foo", "bar", "baz"}
+
 	repoSetNames := []string{}
 	repoIDs := []uint32{}
 	n := 10 * runtime.GOMAXPROCS(0)
 	for i := 0; i < n; i++ {
 		shardName := fmt.Sprintf("shard%d", i)
-		repoName := fmt.Sprintf("repository%.3d", i)
+		repoName := fmt.Sprintf("%s-repository%.3d", namePrefix[i%3], i)
 		repoID := hash(repoName)
 
 		if i%3 == 0 {
@@ -329,6 +333,7 @@ func TestFilteringShardsByRepoSetOrBranchesReposOrRepoIDs(t *testing.T) {
 	sub := &query.Substring{Pattern: "bla"}
 
 	repoIDsQuery := query.NewRepoIDs(repoIDs...)
+	repoQuery := &query.Repo{Regexp: regexp.MustCompile("^foo-.*")}
 
 	queries := []query.Q{
 		query.NewAnd(set, sub),
@@ -342,6 +347,19 @@ func TestFilteringShardsByRepoSetOrBranchesReposOrRepoIDs(t *testing.T) {
 		query.NewAnd(repoIDsQuery, sub),
 		// Test with the same repoIDs again
 		query.NewAnd(repoIDsQuery, sub),
+
+		query.NewAnd(repoQuery, sub),
+		query.NewAnd(repoQuery, sub),
+
+		// List has queries which are just the reposet atoms. We also test twice.
+		set,
+		set,
+		branchesRepos,
+		branchesRepos,
+		repoIDsQuery,
+		repoIDsQuery,
+		repoQuery,
+		repoQuery,
 	}
 
 	for _, q := range queries {


### PR DESCRIPTION
The previous commit which added support for selectRepoSet in List was ineffective since the queries we get for List do not look like (and ...) but instead directly specify the reposet atom.

This commit adds support for it. Additionally to help with our manual testing we add support for "repo:" query in the selectRepoSet optimization.

While pairing on this we decided to improve the debug output to tracing and rename the misnamed query.Q variable in List from r to q.

Test Plan: updated the test case to directly test the sort of queries we get in List calls. Additionally ran "zoekt-webserver -pprof" and observed in net/trace output that selectRepoSet optimization reduced the number of searched shards.