### PR TITLE
Ranking: include filename matches in bm25

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -382,10 +382,9 @@ func addRepo(res *SearchResult, repo *Repository) {
 	res.LineFragments[repo.Name] = repo.LineFragmentTemplate
 }
 
-// Gather matches from this document. This never returns a mixture of
-// filename/content matches: if there are content matches, all
-// filename matches are trimmed from the result. The matches are
-// returned in document order and are non-overlapping.
+// Gather matches from this document. The matches are returned in document
+// order and are non-overlapping. All filename and content matches are
+// returned, with filename matches first.
 //
 // If `merge` is set, overlapping and adjacent matches will be merged
 // into a single match. Otherwise, overlapping matches will be removed,

--- a/score.go
+++ b/score.go
@@ -143,6 +143,11 @@ func (d *indexData) scoreFileUsingBM25(fileMatch *FileMatch, doc uint32, cands [
 	fileLength := float64(d.boundaries[doc+1] - d.boundaries[doc])
 	numFiles := len(d.boundaries)
 	averageFileLength := float64(d.boundaries[numFiles-1]) / float64(numFiles)
+
+	// This is very unlikely, but explicitly guard against division by zero.
+	if averageFileLength == 0 {
+		averageFileLength++
+	}
 	L := fileLength / averageFileLength
 
 	// Use standard parameter defaults (used in Lucene and academic papers)


### PR DESCRIPTION
BM25 considers a file to be a better match when there are many occurrences of
terms in the file. It's important to count all term occurrences, including
those in other fields like the filename.

For historical reasons, Zoekt trims all filename matches from a result if there
are any content matches. This meant that in BM25 scoring, we didn't account for
filename matches.

This PR refactors the match code so that we only trim filename matches when
assembling the final `FileMatch`. We retain filename matches when creating
`candidateMatch`, which lets BM25 scoring use them. Even without the better
BM25 scoring, I think this refactor makes the code easier to follow.