### PR TITLE
docker: simplify apk add lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd
 
 FROM rust:alpine3.19 AS rust-builder
 
-RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git wget musl-dev>=1.1.24-r10 build-base
+RUN apk add --no-cache git wget musl-dev build-base
 
 RUN wget -qO- https://github.com/sourcegraph/sourcegraph/archive/0c8aa18eece45922a2b56dc0f94e21b1bb533e7d.tar.gz | tar xz && mv sourcegraph-* sourcegraph
 
@@ -29,8 +28,7 @@ RUN cargo install --path sourcegraph/docker-images/syntax-highlighter --root /sy
 
 FROM alpine:3.19 AS zoekt
 
-RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache git ca-certificates bind-tools tini jansson wget
+RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget
 
 COPY install-ctags-alpine.sh .
 RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -1,8 +1,7 @@
 FROM alpine:3.19
 
-RUN apk update --no-cache && apk upgrade --no-cache && \
-    apk add --no-cache ca-certificates bind-tools tini 'git>=2.38.5-r0' jansson && \
-    apk add --upgrade --no-cache 'libcrypto1.1>=1.1.1n-r0' 'libssl1.1>=1.1.1n-r0' 'pcre2>=10.40-r0' 'e2fsprogs>=1.46.6-r0'
+RUN apk add --no-cache ca-certificates bind-tools tini git jansson
+
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph
 RUN addgroup -S sourcegraph && adduser -S -G sourcegraph -h /home/sourcegraph sourcegraph && mkdir -p /data && chown -R sourcegraph:sourcegraph /data

--- a/Dockerfile.webserver
+++ b/Dockerfile.webserver
@@ -1,7 +1,6 @@
 FROM alpine:3.19
 
-RUN apk update --no-cache && apk upgrade --no-cache && \
-   apk add --no-cache ca-certificates bind-tools tini
+RUN apk add --no-cache ca-certificates bind-tools tini
 
 # Run as non-root user sourcegraph. External volumes should be mounted under /data (which will be owned by sourcegraph).
 RUN mkdir -p /home/sourcegraph


### PR DESCRIPTION
The images produced are no longer consumed directly by sourcegraph so we don't have security scanners running on them. Additionally we upgraded to the latest alpine now and some of the apk upgrade lines no longer work. Both combined means we can simplify the apk add lines.

Test Plan: built locally

```
docker build -t zoekt .
docker build -t zoekt-indexserver . -f Dockerfile.indexserver
docker build -t zoekt-webserver   . -f Dockerfile.webserver
```
