### PR TITLE
gitindex: include environ for git tests

### DIFF
--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -753,6 +753,8 @@ func TestRepoPathRanks(t *testing.T) {
 }
 
 func runScript(t *testing.T, cwd string, script string) {
+	t.Helper()
+
 	err := os.MkdirAll(cwd, 0o755)
 	if err != nil {
 		t.Fatalf("ensuring path %q exists: %s", cwd, err)
@@ -760,6 +762,7 @@ func runScript(t *testing.T, cwd string, script string) {
 
 	cmd := exec.Command("sh", "-euxc", script)
 	cmd.Dir = cwd
+	cmd.Env = append([]string{"GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM="}, os.Environ()...)
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("execution error: %v, output %s", err, out)

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -526,16 +526,13 @@ func TestIndexDeltaBasic(t *testing.T) {
 			repositoryDir := t.TempDir()
 
 			// setup: initialize the repository and all of its branches
-			runGitScript := func(t *testing.T, dir, script string) {
-				runScript(t, dir, script, "GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM=")
-			}
-			runGitScript(t, repositoryDir, "git init -b master")
-			runGitScript(t, repositoryDir, fmt.Sprintf("git config user.email %q", "you@example.com"))
-			runGitScript(t, repositoryDir, fmt.Sprintf("git config user.name %q", "Your Name"))
+			runScript(t, repositoryDir, "git init -b master")
+			runScript(t, repositoryDir, fmt.Sprintf("git config user.email %q", "you@example.com"))
+			runScript(t, repositoryDir, fmt.Sprintf("git config user.name %q", "Your Name"))
 
 			for _, b := range test.branches {
-				runGitScript(t, repositoryDir, fmt.Sprintf("git checkout -b %q", b))
-				runGitScript(t, repositoryDir, fmt.Sprintf("git commit --allow-empty -m %q", "empty commit"))
+				runScript(t, repositoryDir, fmt.Sprintf("git checkout -b %q", b))
+				runScript(t, repositoryDir, fmt.Sprintf("git commit --allow-empty -m %q", "empty commit"))
 			}
 
 			for _, step := range test.steps {
@@ -545,7 +542,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 
 						hadChange := false
 
-						runGitScript(t, repositoryDir, fmt.Sprintf("git checkout %q", b))
+						runScript(t, repositoryDir, fmt.Sprintf("git checkout %q", b))
 
 						for _, d := range step.deletedDocuments[b] {
 							hadChange = true
@@ -557,7 +554,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 								t.Fatalf("deleting file %q: %s", d.Name, err)
 							}
 
-							runGitScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
+							runScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
 						}
 
 						for _, d := range step.addedDocuments[b] {
@@ -575,14 +572,14 @@ func TestIndexDeltaBasic(t *testing.T) {
 								t.Fatalf("writing file %q: %s", d.Name, err)
 							}
 
-							runGitScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
+							runScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
 						}
 
 						if !hadChange {
 							continue
 						}
 
-						runGitScript(t, repositoryDir, fmt.Sprintf("git commit -m %q", step.name))
+						runScript(t, repositoryDir, fmt.Sprintf("git commit -m %q", step.name))
 					}
 
 					// setup: prepare indexOptions with given overrides
@@ -755,7 +752,7 @@ func TestRepoPathRanks(t *testing.T) {
 	}
 }
 
-func runScript(t *testing.T, cwd string, script string, env ...string) {
+func runScript(t *testing.T, cwd string, script string) {
 	err := os.MkdirAll(cwd, 0o755)
 	if err != nil {
 		t.Fatalf("ensuring path %q exists: %s", cwd, err)
@@ -763,7 +760,6 @@ func runScript(t *testing.T, cwd string, script string, env ...string) {
 
 	cmd := exec.Command("sh", "-euxc", script)
 	cmd.Dir = cwd
-	cmd.Env = env
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("execution error: %v, output %s", err, out)


### PR DESCRIPTION
A recent change introduced GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM, but ran into the footgun of unsetting the rest of the environ when cmd.Env is non-empty. This for example broke tests for me since we didn't have my custom $PATH set.

Instead we revert the change and make a much smaller change to just always set the relevant environment variables.

Test Plan: go test
