### PR TITLE
fix: don't modify candidates

### DIFF
--- a/build/scoring_test.go
+++ b/build/scoring_test.go
@@ -77,8 +77,8 @@ func TestBM25(t *testing.T) {
 			query:    &query.Substring{Pattern: "example"},
 			content:  exampleJava,
 			language: "Java",
-			// keyword-score:1.63 (sum-tf: 6.00, length-ratio: 2.00)
-			wantScore: 1.63,
+			// keyword-score:1.69 (sum-tf: 7.00, length-ratio: 2.00)
+			wantScore: 1.69,
 		}, {
 			// Matches only on content
 			fileName: "example.java",

--- a/contentprovider.go
+++ b/contentprovider.go
@@ -147,7 +147,7 @@ func (p *contentProvider) findOffset(filename bool, r uint32) uint32 {
 // returned by the API it needs to be copied.
 func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int, language string, debug bool) []LineMatch {
 	var filenameMatches []*candidateMatch
-	contentMatches := ms[:0]
+	contentMatches := make([]*candidateMatch, 0, len(ms))
 
 	for _, m := range ms {
 		if m.fileName {
@@ -194,7 +194,7 @@ func (p *contentProvider) fillMatches(ms []*candidateMatch, numContextLines int,
 // returned by the API it needs to be copied.
 func (p *contentProvider) fillChunkMatches(ms []*candidateMatch, numContextLines int, language string, debug bool) []ChunkMatch {
 	var filenameMatches []*candidateMatch
-	contentMatches := ms[:0]
+	contentMatches := make([]*candidateMatch, 0, len(ms))
 
 	for _, m := range ms {
 		if m.fileName {


### PR DESCRIPTION
While working on ranking, I noticed that sum-tf is wrong if we have filename and content matches.

<img width="1169" alt="image" src="https://github.com/sourcegraph/zoekt/assets/26413131/bb85aaa3-b0fd-437d-b57d-b47f5d1fa3ae">


We use `finalCands` in our BM25 scoring, however, `finalCands` is modified in `fillChunkMatches` and `fillMatches` which can lead to surprising scores.

Test plan:
updated unit test