### PR TITLE
gitindex: update remote.origin.url if clone already exists

### DIFF
--- a/gitindex/clone.go
+++ b/gitindex/clone.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -60,7 +61,9 @@ func CloneRepo(destDir, name, cloneURL string, settings map[string]string) (stri
 
 	repoDest := filepath.Join(parent, filepath.Base(name)+".git")
 	if _, err := os.Lstat(repoDest); err == nil {
-		// Repository exists, ensure settings are in sync
+		// Repository exists, ensure settings are in sync including the clone URL
+		settings := maps.Clone(settings)
+		settings["remote.origin.url"] = cloneURL
 		if err := updateZoektGitConfig(repoDest, settings); err != nil {
 			return "", fmt.Errorf("failed to update repository settings: %w", err)
 		}


### PR DESCRIPTION
This is so that when authentication details change we correctly update the CloneURL for repositories managed by our mirror commands.

Alternative to https://github.com/sourcegraph/zoekt/pull/775