### PR TITLE
zoekt-mirror-gerrit: fix fetch for meta/config

### DIFF
--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -285,7 +285,7 @@ func addMetaConfigFetch(repoDir string) error {
 
 	rm := cfg.Remotes["origin"]
 	if rm != nil {
-		configRefSpec := config.RefSpec("+refs/meta/config:refs/heads/meta/config")
+		configRefSpec := config.RefSpec("+refs/meta/config:refs/heads/meta-config")
 		if !slices.Contains(rm.Fetch, configRefSpec) {
 			rm.Fetch = append(rm.Fetch, configRefSpec)
 		}


### PR DESCRIPTION
The current configuration creates a conflict with default fetch config `+refs/heads/*:refs/heads/*`.

The first fetch is ok but once a local "refs/heads/meta/config" exists fetch fails because 2 fetch rules match for local "refs/heads/meta/config" : "refs/meta/config" and "refs/heads/meta/config"

Changing local ref name fixes the problem