### PR TITLE
BM25: Boost file name matches at root

### DIFF
--- a/build/scoring_test.go
+++ b/build/scoring_test.go
@@ -106,8 +106,8 @@ func TestBM25(t *testing.T) {
 			fileName: "a/b/c/config.go",
 			query:    &query.Substring{Pattern: "config.go"},
 			language: "Go",
-			// bm25-score: 0.60 <- sum-termFrequencyScore: 5.00, length-ratio: 0.00
-			wantScore: 0.60,
+			// bm25-score: 0.45 <- sum-termFrequencyScore: 2.00, length-ratio: 0.00
+			wantScore: 0.45,
 		},
 	}
 

--- a/eval.go
+++ b/eval.go
@@ -330,7 +330,7 @@ nextFileMatch:
 			// document frequencies. Since we don't store document frequencies in the index,
 			// we have to defer the calculation of the final BM25 score to after the whole
 			// shard has been processed.
-			tf = calculateTermFrequency(finalCands, df)
+			tf = calculateTermFrequency(&fileMatch, finalCands, df)
 		} else {
 			// Use the standard, non-experimental scoring method by default
 			d.scoreFile(&fileMatch, nextDoc, mt, known, opts)

--- a/score_test.go
+++ b/score_test.go
@@ -37,7 +37,7 @@ func TestCalculateTermFrequency(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			fm := FileMatch{}
 			df := make(termDocumentFrequency)
-			tf := calculateTermFrequency(c.cands, df)
+			tf := calculateTermFrequency(&fm, c.cands, df)
 
 			if !maps.Equal(df, c.wantDF) {
 				t.Errorf("got %v, want %v", df, c.wantDF)


### PR DESCRIPTION
With this change we prioritize file name matches at the root of the repository. This is based on the intuition that more important files tend to be closer to the root.

We also change the parameter b in the BM25 scoring function from 0.75 to 0.3 to reduce the impact of the document length on the final score. This is based on experiments that showed that our current scoring overly penalizes long but important documents.

For example, we consider documents such as a README.md or CHANGELOG at the root of the repository of high quality. However, these documents also tend to be relatively long and are thus penalized.

Note:
In previous experiments I saw that lowering b led to higher recall in our context evaluation. However I could not reproduce this. This change slightly shifts the numbers but doesn't change the overall score. 

Test plan:
- Updated unit test
