### PR TITLE
Enabling numContextLines in non-json format

### DIFF
--- a/web/api.go
+++ b/web/api.go
@@ -28,6 +28,7 @@ type ApiSearchResult struct {
 type LastInput struct {
 	Query string
 	Num   int
+	Ctx   int
 
 	// If set, focus on the search box.
 	AutoFocus bool

--- a/web/server.go
+++ b/web/server.go
@@ -280,12 +280,10 @@ func (s *Server) serveSearchErr(r *http.Request) (*ApiSearchResult, error) {
 	}
 
 	numCtxLines := 0
-	if qvals.Get("format") == "json" {
-		if ctxLinesStr := qvals.Get("ctx"); ctxLinesStr != "" {
-			numCtxLines, err = strconv.Atoi(ctxLinesStr)
-			if err != nil || numCtxLines < 0 || numCtxLines > 10 {
-				return nil, fmt.Errorf("Number of context lines must be between 0 and 10")
-			}
+	if ctxLinesStr := qvals.Get("ctx"); ctxLinesStr != "" {
+		numCtxLines, err = strconv.Atoi(ctxLinesStr)
+		if err != nil || numCtxLines < 0 || numCtxLines > 10 {
+			return nil, fmt.Errorf("Number of context lines must be between 0 and 10")
 		}
 	}
 	sOpts.NumContextLines = numCtxLines

--- a/web/server.go
+++ b/web/server.go
@@ -311,6 +311,7 @@ func (s *Server) serveSearchErr(r *http.Request) (*ApiSearchResult, error) {
 		Last: LastInput{
 			Query:     queryStr,
 			Num:       num,
+			Ctx:       numCtxLines,
 			AutoFocus: true,
 		},
 		Stats:       result.Stats,


### PR DESCRIPTION
This PR makes NumContextLines available in formats other than json.

## Why
Currently, I want to run my own search UI template on zoekt-webserver. However, since NumContextLines is only available in json format, I cannot use that information in my own template.

Please let us know what do you think. Thank you!
