### PR TITLE
index: enable shard merging by default

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -98,6 +98,9 @@ type indexArgs struct {
 	// DeltaShardNumberFallbackThreshold is an upper limit on the number of preexisting shards that can exist
 	// before attempting a delta build.
 	DeltaShardNumberFallbackThreshold uint64
+
+	// ShardMerging is true if we want zoekt-git-index to respect compound shards.
+	ShardMerging bool
 }
 
 // BuildOptions returns a build.Options represented by indexArgs. Note: it
@@ -131,6 +134,8 @@ func (o *indexArgs) BuildOptions() *build.Options {
 		DocumentRanksVersion: o.DocumentRanksVersion,
 
 		LanguageMap: o.LanguageMap,
+
+		ShardMerging: o.ShardMerging,
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1216,7 +1216,6 @@ type rootConfig struct {
 	targetSize          int64
 	minSize             int64
 	minAgeDays          int
-	maxPriority         float64
 
 	// config values related to backoff indexing repos with one or more consecutive failures
 	backoffDuration    time.Duration
@@ -1242,7 +1241,6 @@ func (rc *rootConfig) registerRootFlags(fs *flag.FlagSet) {
 	fs.Int64Var(&rc.targetSize, "merge_target_size", getEnvWithDefaultInt64("SRC_MERGE_TARGET_SIZE", 2000), "the target size of compound shards in MiB")
 	fs.Int64Var(&rc.minSize, "merge_min_size", getEnvWithDefaultInt64("SRC_MERGE_MIN_SIZE", 1800), "the minimum size of a compound shard in MiB")
 	fs.IntVar(&rc.minAgeDays, "merge_min_age", getEnvWithDefaultInt("SRC_MERGE_MIN_AGE", 7), "the time since the last commit in days. Shards with newer commits are excluded from merging.")
-	fs.Float64Var(&rc.maxPriority, "merge_max_priority", getEnvWithDefaultFloat64("SRC_MERGE_MAX_PRIORITY", math.MaxFloat64), "the maximum priority a shard can have to be considered for merging.")
 }
 
 func startServer(conf rootConfig) error {
@@ -1455,7 +1453,6 @@ func newServer(conf rootConfig) (*Server, error) {
 			targetSizeBytes: conf.targetSize * 1024 * 1024,
 			minSizeBytes:    conf.minSize * 1024 * 1024,
 			minAgeDays:      conf.minAgeDays,
-			maxPriority:     conf.maxPriority,
 		},
 		timeout: indexingTimeout,
 	}, err

--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -180,9 +180,6 @@ type mergeOpts struct {
 	// merging. For example, a value of 7 means that only repos that have been
 	// inactive for 7 days will be considered for merging.
 	minAgeDays int
-
-	// the MAX priority a shard can have to be considered for merging.
-	maxPriority float64
 }
 
 // isExcluded returns true if a shard should not be merged, false otherwise.
@@ -210,10 +207,6 @@ func isExcluded(path string, fi os.FileInfo, opts mergeOpts) bool {
 	}
 
 	if repos[0].LatestCommitDate.After(time.Now().AddDate(0, 0, -opts.minAgeDays)) {
-		return true
-	}
-
-	if priority, err := strconv.ParseFloat(repos[0].RawConfig["priority"], 64); err == nil && priority > opts.maxPriority {
 		return true
 	}
 

--- a/tombstones.go
+++ b/tombstones.go
@@ -5,15 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 )
-
-// ShardMergingEnabled returns true if SRC_ENABLE_SHARD_MERGING is set to true.
-func ShardMergingEnabled() bool {
-	t := os.Getenv("SRC_ENABLE_SHARD_MERGING")
-	enabled, _ := strconv.ParseBool(t)
-	return enabled
-}
 
 var mockRepos []*Repository
 


### PR DESCRIPTION
Relates to SPLF-175

This enables shard merging by default for zoekt-sourcegraph-indexserver.

Sourcegraph has been using shard merging in production for several years. We have recently confirmed significant performance improvements for queries which are bound by `matchTree` construction. 

I also remove `-merge_max_priority` because we have stopped using it.

Use `SRC_DISABLE_SHARD_MERGING` to disable shard merging. 

Test plan:
mostly CI, I did some manual testing to confirm that shard merging is enabled by default for zoekt-sourcegraph-indexserver.