### PR TITLE
feat(Search): Add support for all Apex language extensions

### DIFF
--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -16,6 +16,9 @@ import (
 )
 
 var unsupportedByLinguistAliasMap = map[string]string{
+	// Extensions that are for the Apex programming languages
+	// See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm
+	"apex": "Apex",
 	// Pkl Configuration Language (https://pkl-lang.org/)
 	// Add to linguist on 6/7/24
 	// can remove once go-enry package updates
@@ -26,6 +29,11 @@ var unsupportedByLinguistAliasMap = map[string]string{
 }
 
 var unsupportedByLinguistExtensionToNameMap = map[string]string{
+	".apex":    "Apex",
+	".apxt":    "Apex",
+	".apxc":    "Apex",
+	".cls":     "Apex",
+	".trigger": "Apex",
 	// Pkl Configuration Language (https://pkl-lang.org/)
 	".pkl": "Pkl",
 	// Magik Language

--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -16,7 +16,7 @@ import (
 )
 
 var unsupportedByLinguistAliasMap = map[string]string{
-	// Extensions for the Apex programming languages
+	// Extensions for the Apex programming language
 	// See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm
 	"apex": "Apex",
 	// Pkl Configuration Language (https://pkl-lang.org/)

--- a/internal/languages/language.go
+++ b/internal/languages/language.go
@@ -16,7 +16,7 @@ import (
 )
 
 var unsupportedByLinguistAliasMap = map[string]string{
-	// Extensions that are for the Apex programming languages
+	// Extensions for the Apex programming languages
 	// See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_dev_guide.htm
 	"apex": "Apex",
 	// Pkl Configuration Language (https://pkl-lang.org/)

--- a/internal/languages/language_test.go
+++ b/internal/languages/language_test.go
@@ -39,6 +39,12 @@ func TestGetLanguageByAlias(t *testing.T) {
 			want:   "Magik",
 			wantOk: true,
 		},
+		{
+			name:   "apex example unsupported by linguist alias",
+			alias:  "apex",
+			want:   "Apex",
+			wantOk: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -77,10 +83,16 @@ func TestGetLanguage(t *testing.T) {
 			want:     "Go",
 		},
 		{
-			name:     "unsupported by linguist extension",
+			name:     "magik: unsupported by linguist extension",
 			filename: "file.magik",
 			content:  []byte(""),
 			want:     "Magik",
+		},
+		{
+			name:     "apex: unsupported by linguist extension",
+			filename: "file.apxc",
+			content:  []byte(""),
+			want:     "Apex",
 		},
 	}
 


### PR DESCRIPTION
Part of [GRAPH-759](https://linear.app/sourcegraph/issue/GRAPH-759/issue-with-apex-extension-not-appearing-for-langapex)

Linguist only supports a subset of the file extensions often used for the Apex programming languages. This PR adds support for the main set commonly used.

**Key changes**
1. Adds all extensions for Apex
2. Updates tests

## Test plan
- [x] Update unit tests
- [x] Validate zoekt can filter by language 
- [x] validate zoekt indexes language appropriately 

 
