### PR TITLE
docker: remove scip-ctags from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,6 @@ COPY . ./
 ARG VERSION
 RUN go install -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" ./cmd/...
 
-FROM rust:alpine3.19 AS rust-builder
-
-RUN apk add --no-cache git wget musl-dev build-base
-
-RUN wget -qO- https://github.com/sourcegraph/sourcegraph/archive/0c8aa18eece45922a2b56dc0f94e21b1bb533e7d.tar.gz | tar xz && mv sourcegraph-* sourcegraph
-
-ARG TARGETARCH
-
-# Because .cargo/config.toml doesnt support triplet-specific env
-RUN cd sourcegraph/docker-images/syntax-highlighter && /sourcegraph/cmd/symbols/cargo-config.sh && cd /
-
-RUN cargo install --path sourcegraph/docker-images/syntax-highlighter --root /syntect_server --bin scip-ctags
-
 FROM alpine:3.19 AS zoekt
 
 RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget
@@ -34,6 +21,5 @@ COPY install-ctags-alpine.sh .
 RUN ./install-ctags-alpine.sh && rm install-ctags-alpine.sh
 
 COPY --from=builder /go/bin/* /usr/local/bin/
-COPY --from=rust-builder /syntect_server/bin/scip-ctags /usr/local/bin/scip-ctags
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile.indexserver
+++ b/Dockerfile.indexserver
@@ -14,7 +14,6 @@ RUN mkdir -p ${DATA_DIR}
 
 COPY --from=zoekt \
     /usr/local/bin/universal-* \
-    /usr/local/bin/scip-ctags \
     /usr/local/bin/zoekt-sourcegraph-indexserver \
     /usr/local/bin/zoekt-archive-index \
     /usr/local/bin/zoekt-git-index \


### PR DESCRIPTION
This is an optional dependency that I don't believe OSS users of docker use. We used to use these dockerfiles in Sourcegraph, but have since moved to building it in our own CI with scip-ctags.

Test Plan: built locally

``` shell
docker build -t zoekt .
docker build -t zoekt-indexserver . -f Dockerfile.indexserver
docker build -t zoekt-webserver   . -f Dockerfile.webserver
```
