### PR TITLE
Add metric for indexing delay

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/backoff_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/backoff_test.go
@@ -24,7 +24,7 @@ func TestQueue_BackoffOnFail(t *testing.T) {
 
 	// item is disallowed from being pushed to heap during backoff period
 	if item, ok := queue.Pop(); ok {
-		qi := queue.items[item.RepoID]
+		qi := queue.items[item.Opts.RepoID]
 		if qi.backoff.backoffUntil.Before(bumpTime) {
 			t.Errorf("backoffDuration already passed before first attempt to push item to heap in Bump(). Increase backoffDuration for the Queue. backoffDuration: %s. maxBackoffDuration: %s.",
 				backoffDuration, maxBackoffDuration)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -461,7 +461,7 @@ func (s *Server) processQueue() {
 					sglog.Uint32("id", args.RepoID),
 					sglog.Strings("branches", branches),
 					sglog.Duration("duration", elapsed),
-					sglog.Duration("index delay", indexDelay),
+					sglog.Duration("index_delay", indexDelay),
 				)
 			case indexStateSuccessMeta:
 				log.Printf("updated meta %s in %v", args.String(), elapsed)

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -89,6 +89,30 @@ var (
 		"name",  // name of the repository that was indexed
 	})
 
+	metricIndexingDelay = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "index_indexing_delay_seconds",
+		Help: "A histogram of durations from when an index job is added to the queue, to the time it completes.",
+		Buckets: []float64{
+			60,     // 1m
+			300,    // 5m
+			1200,   // 20m
+			2400,   // 40m
+			3600,   // 1h
+			10800,  // 3h
+			18000,  // 5h
+			36000,  // 10h
+			43200,  // 12h
+			54000,  // 15h
+			72000,  // 20h
+			86400,  // 24h
+			108000, // 30h
+			126000, // 35h
+			172800, // 48h
+		}}, []string{
+		"state", // state is an indexState
+		"name",  // the name of the repository that was indexed
+	})
+
 	metricFetchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "index_fetch_seconds",
 		Help:    "A histogram of latencies for fetching a repository.",
@@ -400,12 +424,13 @@ func (s *Server) processQueue() {
 			continue
 		}
 
-		opts, ok := s.queue.Pop()
+		item, ok := s.queue.Pop()
 		if !ok {
 			time.Sleep(time.Second)
 			continue
 		}
 
+		opts := item.Opts
 		args := s.indexArgs(opts)
 
 		ran := s.muIndexDir.With(opts.Name, func() {
@@ -416,8 +441,10 @@ func (s *Server) processQueue() {
 			state, err := s.Index(args)
 
 			elapsed := time.Since(start)
-
 			metricIndexDuration.WithLabelValues(string(state), repoNameForMetric(opts.Name)).Observe(elapsed.Seconds())
+
+			indexDelay := time.Since(item.DateAddedToQueue)
+			metricIndexingDelay.WithLabelValues(string(state), repoNameForMetric(opts.Name)).Observe(indexDelay.Seconds())
 
 			if err != nil {
 				log.Printf("error indexing %s: %s", args.String(), err)
@@ -434,6 +461,7 @@ func (s *Server) processQueue() {
 					sglog.Uint32("id", args.RepoID),
 					sglog.Strings("branches", branches),
 					sglog.Duration("duration", elapsed),
+					sglog.Duration("index delay", indexDelay),
 				)
 			case indexStateSuccessMeta:
 				log.Printf("updated meta %s in %v", args.String(), elapsed)


### PR DESCRIPTION
Our dashboards currently report indexing delay using the
`index_queue_age_seconds` metric, which tracks the duration indexing jobs wait
in the queue before being "popped" for indexing. For dot com, we regularly see
the median for this metric at 2 days. However, this metric may be misleading
because it includes "noop" indexing jobs where the index is already up to date.
These jobs can stay in the queue for a long time since they are not high
priority.

This PR adds a new metric `index_indexing_delay_seconds`, which reports the
duration from when an indexing job enters the queue, to when it completes. It
uses 'state' as a label, so by setting `state='success'` we can (roughly) see
the delay from when Zoekt learns about a new version, to when that version is
available to search.