### PR TITLE
Fix archive URL for ranking test

### DIFF
--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -39,7 +39,7 @@ func TestRanking(t *testing.T) {
 	requireCTags(t)
 
 	archiveURLs := []string{
-		"https://github.com/sourcegraph/sourcegraph/tree/v5.2.2",
+		"https://github.com/sourcegraph/sourcegraph-public-snapshot/tree/v5.2.2",
 		"https://github.com/golang/go/tree/go1.21.4",
 		"https://github.com/sourcegraph/cody/tree/vscode-v0.14.5",
 		// The commit before ranking e2e tests were added to avoid matching
@@ -57,10 +57,10 @@ func TestRanking(t *testing.T) {
 		q("time compare\\(", "github.com/golang/go/src/time/time.go"),
 
 		// sourcegraph/sourcegraph
-		q("graphql type User", "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/schema.graphql"),
-		q("Get database/user", "github.com/sourcegraph/sourcegraph/internal/database/users.go"),
-		q("InternalDoer", "github.com/sourcegraph/sourcegraph/internal/httpcli/client.go"),
-		q("Repository metadata Write rbac", "github.com/sourcegraph/sourcegraph/internal/rbac/constants.go"), // unsure if this is the best doc?
+		q("graphql type User", "github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/graphqlbackend/schema.graphql"),
+		q("Get database/user", "github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/users.go"),
+		q("InternalDoer", "github.com/sourcegraph/sourcegraph-public-snapshot/internal/httpcli/client.go"),
+		q("Repository metadata Write rbac", "github.com/sourcegraph/sourcegraph-public-snapshot/internal/rbac/constants.go"), // unsure if this is the best doc?
 
 		// cody
 		q("generate unit test", "github.com/sourcegraph/cody/lib/shared/src/chat/recipes/generate-test.ts"),
@@ -70,8 +70,8 @@ func TestRanking(t *testing.T) {
 		q("zoekt searcher", "github.com/sourcegraph/zoekt/api.go"),
 
 		// exact phrases
-		q("assets are not configured for this binary", "github.com/sourcegraph/sourcegraph/ui/assets/assets.go"),
-		q("sourcegraph/server docker image build", "github.com/sourcegraph/sourcegraph/dev/tools.go"),
+		q("assets are not configured for this binary", "github.com/sourcegraph/sourcegraph-public-snapshot/ui/assets/assets.go"),
+		q("sourcegraph/server docker image build", "github.com/sourcegraph/sourcegraph-public-snapshot/dev/tools.go"),
 
 		// symbols split up
 		q("bufio flush writer", "github.com/golang/go/src/net/http/transfer.go"),                        // bufioFlushWriter

--- a/internal/e2e/testdata/Get_databaseuser.txt
+++ b/internal/e2e/testdata/Get_databaseuser.txt
@@ -2,37 +2,37 @@ queryString: Get database/user
 query: (and case_substr:"Get" substr:"database/user")
 targetRank: 3
 
-github.com/sourcegraph/sourcegraph/internal/database/user_emails.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/user_emails.go
 161:func (s *userEmailsStore) Get(ctx context.Context, userID int32, email string) (emailCanonicalCase string, verified bool, err error) {
 50:	Get(ctx context.Context, userID int32, email string) (emailCanonicalCase string, verified bool, err error)
 91:func (s *userEmailsStore) GetInitialSiteAdminInfo(ctx context.Context) (email string, tosAccepted bool, err error) {
 hidden 14 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/database/user_roles.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/user_roles.go
 35:	GetUserRoleOpts    UserRoleOpts
 358:func (r *userRoleStore) GetByUserID(ctx context.Context, opts GetUserRoleOpts) ([]*types.UserRole, error) {
 365:func (r *userRoleStore) GetByRoleID(ctx context.Context, opts GetUserRoleOpts) ([]*types.UserRole, error) {
 hidden 8 more line matches
 
-**github.com/sourcegraph/sourcegraph/internal/database/users.go**
+**github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/users.go**
 940:func (u *userStore) GetByID(ctx context.Context, id int32) (*types.User, error) {
 947:func (u *userStore) GetByVerifiedEmail(ctx context.Context, email string) (*types.User, error) {
 951:func (u *userStore) GetByUsername(ctx context.Context, username string) (*types.User, error) {
 hidden 17 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/database/user_credentials.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/user_credentials.go
 248:func (s *userCredentialsStore) GetByID(ctx context.Context, id int64) (*UserCredential, error) {
 271:func (s *userCredentialsStore) GetByScope(ctx context.Context, scope UserCredentialScope) (*UserCredential, error) {
 108:	GetByID(ctx context.Context, id int64) (*UserCredential, error)
 hidden 8 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/database/user_emails_test.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/user_emails_test.go
 56:func TestUserEmails_Get(t *testing.T) {
 106:func TestUserEmails_GetPrimary(t *testing.T) {
 585:func TestUserEmails_GetLatestVerificationSentEmail(t *testing.T) {
 hidden 10 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/database/users_test.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/database/users_test.go
 628:func TestUsers_GetByVerifiedEmail(t *testing.T) {
 664:func TestUsers_GetByUsername(t *testing.T) {
 711:func TestUsers_GetByUsernames(t *testing.T) {

--- a/internal/e2e/testdata/InternalDoer.txt
+++ b/internal/e2e/testdata/InternalDoer.txt
@@ -2,25 +2,25 @@ queryString: InternalDoer
 query: case_substr:"InternalDoer"
 targetRank: 1
 
-**github.com/sourcegraph/sourcegraph/internal/httpcli/client.go**
+**github.com/sourcegraph/sourcegraph-public-snapshot/internal/httpcli/client.go**
 217:var InternalDoer, _ = InternalClientFactory.Doer()
 215:// InternalDoer is a shared client for internal communication. This is a
 
-github.com/sourcegraph/sourcegraph/internal/api/internalapi/client.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/api/internalapi/client.go
 144:	resp, err := httpcli.InternalDoer.Do(req.WithContext(ctx))
 
-github.com/sourcegraph/sourcegraph/enterprise/cmd/embeddings/qa/context_data.tsv
+github.com/sourcegraph/sourcegraph-public-snapshot/enterprise/cmd/embeddings/qa/context_data.tsv
 3:In the sourcegraph repository, what does InternalDoer do?	internal/httpcli/client.go
 4:In my codebase, what does InternalDoer do?	internal/httpcli/client.go
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/badge.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/internal/app/badge.go
 23:	totalRefs, err := backend.CountGoImporters(r.Context(), httpcli.InternalDoer, routevar.ToRepo(mux.Vars(r)))
 
-github.com/sourcegraph/sourcegraph/internal/batches/webhooks/webhooks.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/batches/webhooks/webhooks.go
 67:	Enqueue(ctx, logger, db, eventType, marshalBatchChange, id, httpcli.InternalDoer)
 74:	Enqueue(ctx, logger, db, eventType, marshalChangeset, id, httpcli.InternalDoer)
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/resolvers/app.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/internal/app/resolvers/app.go
 53:		doer:      httpcli.InternalDoer,
 354:	cli := httpcli.InternalDoer
 424:	cli := httpcli.InternalDoer

--- a/internal/e2e/testdata/Repository_metadata_Write_rbac.txt
+++ b/internal/e2e/testdata/Repository_metadata_Write_rbac.txt
@@ -2,31 +2,31 @@ queryString: Repository metadata Write rbac
 query: (and case_substr:"Repository" substr:"metadata" case_substr:"Write" substr:"rbac")
 targetRank: -1
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/repository_metadata.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/graphqlbackend/repository_metadata.go
 54:func (r *schemaResolver) AddRepoMetadata(ctx context.Context, args struct {
 95:func (r *schemaResolver) UpdateRepoMetadata(ctx context.Context, args struct {
 134:func (r *schemaResolver) DeleteRepoMetadata(ctx context.Context, args struct {
 hidden 30 more line matches
 
-github.com/sourcegraph/sourcegraph/client/web/src/repo/tree/TreePageContent.tsx
+github.com/sourcegraph/sourcegraph-public-snapshot/client/web/src/repo/tree/TreePageContent.tsx
 666:interface RepositoryContributorNodeProps extends QuerySpec {
 10:import { RepoMetadata } from '@sourcegraph/branded'
 16:import { RepositoryType, SearchPatternType, type TreeFields } from '@sourcegraph/shared/src/graphql-operations'
 hidden 46 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/repo/metadata.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/repo/metadata.md
 1:# Custom repository metadata
 18:## Adding metadata
 8:### Repository owners
 hidden 14 more line matches
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/repository_metadata_test.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/graphqlbackend/repository_metadata_test.go
 26:func TestRepositoryMetadata(t *testing.T) {
 17:	"github.com/sourcegraph/sourcegraph/internal/rbac"
 23:	rtypes "github.com/sourcegraph/sourcegraph/internal/rbac/types"
 hidden 25 more line matches
 
-github.com/sourcegraph/sourcegraph/client/web/src/repo/repoContainerRoutes.tsx
+github.com/sourcegraph/sourcegraph-public-snapshot/client/web/src/repo/repoContainerRoutes.tsx
 3:import { canWriteRepoMetadata } from '../util/rbac'
 5:import { RepositoryChangelistPage } from './commit/RepositoryCommitPage'
 9:const RepositoryCommitPage = lazyComponent(() => import('./commit/RepositoryCommitPage'), 'RepositoryCommitPage')

--- a/internal/e2e/testdata/assets_are_not_configured_for_this_binary.txt
+++ b/internal/e2e/testdata/assets_are_not_configured_for_this_binary.txt
@@ -2,37 +2,37 @@ queryString: assets are not configured for this binary
 query: (and substr:"assets" substr:"are" substr:"not" substr:"configured" substr:"for" substr:"this" substr:"binary")
 targetRank: 1
 
-**github.com/sourcegraph/sourcegraph/ui/assets/assets.go**
+**github.com/sourcegraph/sourcegraph-public-snapshot/ui/assets/assets.go**
 33:func (p FailingAssetsProvider) Assets() http.FileSystem {
 14:	Assets() http.FileSystem
 1:package assets
 hidden 12 more line matches
 
-github.com/sourcegraph/sourcegraph/schema/schema.go
+github.com/sourcegraph/sourcegraph-public-snapshot/schema/schema.go
 492:type BrandAssets struct {
 1530:type Notice struct {
 1538:type Notifications struct {
 hidden 668 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/executors/deploy_executors.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/executors/deploy_executors.md
 118:## Confirm executors are working
 194:### Configuring the auth config for use in executors
 216:### Adding certificates to a binary deployment
 hidden 47 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/getting-started/github-vs-sourcegraph.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/getting-started/github-vs-sourcegraph.md
 8:## Which is best for you?
 110:### Searching repositories, branches, and forks
 18:As your codebase grows in complexity, the value of code search quickly increases. Sourcegraph may be a good fit for your team if:
 hidden 66 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/executors/deploy_executors_terraform.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/executors/deploy_executors_terraform.md
 1:# Deploying Sourcegraph executors using Terraform on AWS or GCP
 56:## Terraform Version
 415:### **Step 1:** Update the source version of the terraform modules
 hidden 68 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/dev/background-information/sg/reference.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/dev/background-information/sg/reference.md
 496:### sg lint format
 505:### sg lint format
 1:<!-- DO NOT EDIT: generated via: go generate ./dev/sg -->

--- a/internal/e2e/testdata/generate_unit_test.txt
+++ b/internal/e2e/testdata/generate_unit_test.txt
@@ -2,7 +2,7 @@ queryString: generate unit test
 query: (and substr:"generate" substr:"unit" substr:"test")
 targetRank: 11
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/internal/insights/resolvers/insight_series_resolver.go
 300:func (j *seriesResolverGenerator) Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters, options types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error) {
 275:	Generate(ctx context.Context, series types.InsightViewSeries, baseResolver baseInsightResolver, filters types.InsightViewFilters, options types.SeriesDisplayOptions) ([]graphqlbackend.InsightSeriesResolver, error)
 286:	generateResolver resolverGenerator
@@ -14,7 +14,7 @@ github.com/golang/go/src/cmd/vendor/github.com/google/pprof/internal/report/repo
 75:	SampleUnit        string // Unit for the sample data from the profile.
 hidden 48 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/codeintel/autoindexing/internal/inference/lua/test.lua
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/codeintel/autoindexing/internal/inference/lua/test.lua
 9:  generate = function(_, paths)
 6:  patterns = { pattern.new_path_basename "sg-test" },
 8:  -- Invoked as part of unit tests for the autoindexing service

--- a/internal/e2e/testdata/graphql_type_User.txt
+++ b/internal/e2e/testdata/graphql_type_User.txt
@@ -2,37 +2,37 @@ queryString: graphql type User
 query: (and substr:"graphql" substr:"type" case_substr:"User")
 targetRank: 1
 
-**github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/schema.graphql**
+**github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/graphqlbackend/schema.graphql**
 6376:type User implements Node & SettingsSubject & Namespace {
 3862:        type: GitRefType
 5037:    type: GitRefType!
 hidden 460 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/types/types.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/types/types.go
 850:type User struct {
 1372:	Type               *SearchCountStatistics
 1766:	Type       string
 hidden 234 more line matches
 
-github.com/sourcegraph/sourcegraph/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-dashboard-owners.ts
+github.com/sourcegraph/sourcegraph-public-snapshot/client/web/src/enterprise/insights/core/backend/gql-backend/methods/get-dashboard-owners.ts
 22:                type: InsightsDashboardOwnerType.Global,
 32:                type: InsightsDashboardOwnerType.Personal,
 18:            const { currentUser, site } = data
 hidden 8 more line matches
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/apitest/types.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/graphqlbackend/apitest/types.go
 47:type User struct {
 9:	Typename    string `json:"__typename"`
 32:	Typename    string `json:"__typename"`
 hidden 11 more line matches
 
-github.com/sourcegraph/sourcegraph/cmd/frontend/internal/batches/resolvers/apitest/types.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/frontend/internal/batches/resolvers/apitest/types.go
 52:type User struct {
 364:	User  *User
 393:	Type       string
 hidden 68 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/extsvc/github/common.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/extsvc/github/common.go
 2030:type User struct {
 66:	User      *Actor `json:"User,omitempty"`
 527:	Type string

--- a/internal/e2e/testdata/sourcegraphserver_docker_image_build.txt
+++ b/internal/e2e/testdata/sourcegraphserver_docker_image_build.txt
@@ -2,37 +2,37 @@ queryString: sourcegraph/server docker image build
 query: (and substr:"sourcegraph/server" substr:"docker" substr:"image" substr:"build")
 targetRank: 14
 
-github.com/sourcegraph/sourcegraph/dev/sg/internal/images/images.go
+github.com/sourcegraph/sourcegraph-public-snapshot/dev/sg/internal/images/images.go
 458:	Build       int
 234:type ImageReference struct {
 352:type ErrNoImage struct {
 hidden 118 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/external_services/postgres.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/external_services/postgres.md
 41:### sourcegraph/server
 192:### sourcegraph/server
 53:### Docker Compose
 hidden 19 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/conf/deploy/deploytype.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/conf/deploy/deploytype.go
 66:func IsDeployTypePureDocker(deployType string) bool {
 12:	SingleDocker  = "docker-container"
 13:	DockerCompose = "docker-compose"
 hidden 19 more line matches
 
-github.com/sourcegraph/sourcegraph/schema/schema.go
+github.com/sourcegraph/sourcegraph-public-snapshot/schema/schema.go
 2621:	ExecutorsBatcheshelperImage string `json:"executors.batcheshelperImage,omitempty"`
 2627:	ExecutorsLsifGoImage string `json:"executors.lsifGoImage,omitempty"`
 2631:	ExecutorsSrcCLIImage string `json:"executors.srcCLIImage,omitempty"`
 hidden 22 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/updatecheck/handler.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/updatecheck/handler.go
 40:	latestReleaseDockerServerImageBuild = newPingResponse("5.1.8")
 45:	latestReleaseKubernetesBuild = newPingResponse("5.1.8")
 50:	latestReleaseDockerComposeOrPureDocker = newPingResponse("5.1.8")
 hidden 19 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/deploy/docker-single-container/index.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/deploy/docker-single-container/index.md
 1:# Docker Single Container Deployment
 294:### Insiders build
 238:### File system performance on Docker for Mac

--- a/internal/e2e/testdata/test_server.txt
+++ b/internal/e2e/testdata/test_server.txt
@@ -26,7 +26,7 @@ github.com/golang/go/src/net/http/server.go
 2925:type serverHandler struct {
 hidden 180 more line matches
 
-github.com/sourcegraph/sourcegraph/cmd/gitserver/server/server.go
+github.com/sourcegraph/sourcegraph-public-snapshot/cmd/gitserver/server/server.go
 132:type Server struct {
 2:package server
 741:func (s *Server) serverContext() (context.Context, context.CancelFunc) {

--- a/internal/e2e/testdata/time_compare.txt
+++ b/internal/e2e/testdata/time_compare.txt
@@ -8,12 +8,12 @@ targetRank: 1
 271:func (t Time) Compare(u Time) int {
 hidden 250 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/api/api.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/api/api.go
 127:func (r ExternalRepoSpec) Compare(s ExternalRepoSpec) int {
 7:	"time"
 170:	CreatedAt    time.Time       // the date when this settings value was created
 
-github.com/sourcegraph/sourcegraph/client/shared/src/codeintel/scip.ts
+github.com/sourcegraph/sourcegraph-public-snapshot/client/shared/src/codeintel/scip.ts
 117:    public compare(other: Range): number {
 53:        return this.compare(other) < 0
 56:        return this.compare(other) <= 0

--- a/internal/e2e/testdata/zoekt_searcher.txt
+++ b/internal/e2e/testdata/zoekt_searcher.txt
@@ -14,19 +14,19 @@ github.com/sourcegraph/zoekt/rpc/internal/srv/srv.go
 37:func (s *Searcher) Search(ctx context.Context, args *SearchArgs, reply *SearchReply) error {
 hidden 9 more line matches
 
-github.com/sourcegraph/sourcegraph/doc/admin/observability/dashboards.md
+github.com/sourcegraph/sourcegraph-public-snapshot/doc/admin/observability/dashboards.md
 16264:## Searcher
 19728:## Zoekt
 16371:### Searcher: Cache store
 hidden 713 more line matches
 
-github.com/sourcegraph/sourcegraph/monitoring/definitions/searcher.go
+github.com/sourcegraph/sourcegraph-public-snapshot/monitoring/definitions/searcher.go
 12:func Searcher() *monitoring.Dashboard {
 14:		containerName   = "searcher"
 15:		grpcServiceName = "searcher.v1.SearcherService"
 hidden 31 more line matches
 
-github.com/sourcegraph/sourcegraph/internal/search/job/job.go
+github.com/sourcegraph/sourcegraph-public-snapshot/internal/search/job/job.go
 73:	Zoekt                       zoekt.Streamer
 74:	SearcherURLs                *endpoint.Map
 75:	SearcherGRPCConnectionCache *defaults.ConnectionCache


### PR DESCRIPTION
The `sourcegraph/sourcegraph` repo is now private, so we switch to
`sourcegraph-public-snapshot` for these tests. Eventually, we'll move the
relevant tests to the sourcegraph repo itself.