### PR TITLE
Remove index queue age metric

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -90,25 +90,10 @@ var (
 	})
 
 	metricIndexingDelay = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "index_indexing_delay_seconds",
-		Help: "A histogram of durations from when an index job is added to the queue, to the time it completes.",
-		Buckets: []float64{
-			60,     // 1m
-			300,    // 5m
-			1200,   // 20m
-			2400,   // 40m
-			3600,   // 1h
-			10800,  // 3h
-			18000,  // 5h
-			36000,  // 10h
-			43200,  // 12h
-			54000,  // 15h
-			72000,  // 20h
-			86400,  // 24h
-			108000, // 30h
-			126000, // 35h
-			172800, // 48h
-		}}, []string{
+		Name:    "index_indexing_delay_seconds",
+		Help:    "A histogram of durations from when an index job is added to the queue, to the time it completes.",
+		Buckets: prometheus.ExponentialBuckets(60, 2, 12), // 1m -> ~3 days
+	}, []string{
 		"state", // state is an indexState
 		"name",  // the name of the repository that was indexed
 	})

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -107,10 +107,6 @@ func (q *Queue) Pop() (result QueueItem, ok bool) {
 
 	q.mu.Unlock()
 
-	name := repoNameForMetric(item.opts.Name)
-	age := time.Since(dateAdded)
-	metricQueueAge.WithLabelValues(name).Observe(age.Seconds())
-
 	return QueueItem{item.opts, dateAdded}, true
 }
 
@@ -449,25 +445,4 @@ var (
 		Name: "index_queue_cap",
 		Help: "The number of repositories tracked by the index queue, including popped items. Should be the same as index_num_assigned.",
 	})
-	metricQueueAge = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "index_queue_age_seconds",
-		Help: "A histogram of the amount of time a popped repository spent sitting in the queue beforehand.",
-		Buckets: []float64{
-			60,     // 1m
-			300,    // 5m
-			1200,   // 20m
-			2400,   // 40m
-			3600,   // 1h
-			10800,  // 3h
-			18000,  // 5h
-			36000,  // 10h
-			43200,  // 12h
-			54000,  // 15h
-			72000,  // 20h
-			86400,  // 24h
-			108000, // 30h
-			126000, // 35h
-			172800, // 48h
-		},
-	}, []string{"name"}) // name=name of the repository that was just popped from the queue
 )


### PR DESCRIPTION
The new metric `index_indexing_delay_seconds` is looking good on dot com and
producing more interpretable results. This PR removes the old metric
`index_queue_age_seconds`. And it increases the bucket range for the new
metric, since we sometimes exceed the current 2 day limit.