### PR TITLE
Increase trace limit for indexing

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -526,6 +526,7 @@ func jitterTicker(d time.Duration, sig ...os.Signal) <-chan struct{} {
 // Index starts an index job for repo name at commit.
 func (s *Server) Index(args *indexArgs) (state indexState, err error) {
 	tr := trace.New("index", args.Name)
+	tr.SetMaxEvents(30) // Ensure we capture all indexing events
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
Indexing traces are always cut off, so this PR increases the limit so we can double-check what takes the most time during indexing. This feels safe since indexing traces are relatively rare.