### PR TITLE
Report GCP profiles from zoekt-git-index

### DIFF
--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -109,7 +109,7 @@ func run() int {
 		opts.LanguageMap[m[0]] = ctags.StringToParser(m[1])
 	}
 
-	profiler.InitLightweight("zoekt-git-index")
+	profiler.Init("zoekt-git-index")
 	exitStatus := 0
 	for dir, name := range gitRepos {
 		opts.RepositoryDescription.Name = name

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -22,7 +22,6 @@ import (
 	"runtime/pprof"
 	"strings"
 
-	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/internal/profiler"
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -110,7 +109,7 @@ func run() int {
 		opts.LanguageMap[m[0]] = ctags.StringToParser(m[1])
 	}
 
-	profiler.InitLightweight("zoekt-git-index", zoekt.Version)
+	profiler.InitLightweight("zoekt-git-index")
 	exitStatus := 0
 	for dir, name := range gitRepos {
 		opts.RepositoryDescription.Name = name

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -22,6 +22,8 @@ import (
 	"runtime/pprof"
 	"strings"
 
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/internal/profiler"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/sourcegraph/zoekt/cmd"
@@ -70,6 +72,7 @@ func run() int {
 		}
 		*repoCacheDir = dir
 	}
+
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
 	opts.DocumentRanksPath = *offlineRanking
@@ -107,6 +110,7 @@ func run() int {
 		opts.LanguageMap[m[0]] = ctags.StringToParser(m[1])
 	}
 
+	profiler.InitLightweight("zoekt-git-index", zoekt.Version)
 	exitStatus := 0
 	for dir, name := range gitRepos {
 		opts.RepositoryDescription.Name = name

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1277,7 +1277,7 @@ func startServer(conf rootConfig) error {
 		return err
 	}
 
-	profiler.Init("zoekt-sourcegraph-indexserver", zoekt.Version, conf.blockProfileRate)
+	profiler.Init("zoekt-sourcegraph-indexserver", zoekt.Version)
 	setCompoundShardCounter(s.IndexDir)
 
 	if conf.listen != "" {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1277,7 +1277,7 @@ func startServer(conf rootConfig) error {
 		return err
 	}
 
-	profiler.Init("zoekt-sourcegraph-indexserver", zoekt.Version)
+	profiler.Init("zoekt-sourcegraph-indexserver")
 	setCompoundShardCounter(s.IndexDir)
 
 	if conf.listen != "" {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -177,7 +177,7 @@ func main() {
 	liblog := sglog.Init(resource)
 	defer liblog.Sync()
 	tracer.Init(resource)
-	profiler.Init("zoekt-webserver", zoekt.Version)
+	profiler.Init("zoekt-webserver")
 
 	if *logDir != "" {
 		if fi, err := os.Lstat(*logDir); err != nil || !fi.IsDir() {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -177,7 +177,7 @@ func main() {
 	liblog := sglog.Init(resource)
 	defer liblog.Sync()
 	tracer.Init(resource)
-	profiler.Init("zoekt-webserver", zoekt.Version, -1)
+	profiler.Init("zoekt-webserver", zoekt.Version)
 
 	if *logDir != "" {
 		if fi, err := os.Lstat(*logDir); err != nil || !fi.IsDir() {

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -5,14 +5,15 @@ import (
 	"os"
 
 	"cloud.google.com/go/profiler"
+	"github.com/sourcegraph/zoekt"
 )
 
 // Init starts the supported profilers IFF the environment variable is set.
-func Init(svcName, version string) {
+func Init(svcName string) {
 	if os.Getenv("GOOGLE_CLOUD_PROFILER_ENABLED") != "" {
 		err := profiler.Start(profiler.Config{
 			Service:        svcName,
-			ServiceVersion: version,
+			ServiceVersion: zoekt.Version,
 			MutexProfiling: true,
 			AllocForceGC:   true,
 		})
@@ -24,11 +25,11 @@ func Init(svcName, version string) {
 
 // InitLightweight starts the supported profilers IFF the environment variable is set.
 // Compared to Init, it disables mutex profiling and forced GC to reduce its overhead.
-func InitLightweight(svcName, version string) {
+func InitLightweight(svcName string) {
 	if os.Getenv("GOOGLE_CLOUD_PROFILER_ENABLED") != "" {
 		err := profiler.Start(profiler.Config{
 			Service:        svcName,
-			ServiceVersion: version,
+			ServiceVersion: zoekt.Version,
 		})
 		if err != nil {
 			log.Printf("could not initialize profiler: %s", err.Error())

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -8,13 +8,27 @@ import (
 )
 
 // Init starts the supported profilers IFF the environment variable is set.
-func Init(svcName, version string, blockProfileRate int) {
+func Init(svcName, version string) {
 	if os.Getenv("GOOGLE_CLOUD_PROFILER_ENABLED") != "" {
 		err := profiler.Start(profiler.Config{
 			Service:        svcName,
 			ServiceVersion: version,
 			MutexProfiling: true,
 			AllocForceGC:   true,
+		})
+		if err != nil {
+			log.Printf("could not initialize profiler: %s", err.Error())
+		}
+	}
+}
+
+// InitLightweight starts the supported profilers IFF the environment variable is set.
+// Compared to Init, it disables mutex profiling and forced GC to reduce its overhead.
+func InitLightweight(svcName, version string) {
+	if os.Getenv("GOOGLE_CLOUD_PROFILER_ENABLED") != "" {
+		err := profiler.Start(profiler.Config{
+			Service:        svcName,
+			ServiceVersion: version,
 		})
 		if err != nil {
 			log.Printf("could not initialize profiler: %s", err.Error())

--- a/internal/profiler/profiler.go
+++ b/internal/profiler/profiler.go
@@ -22,17 +22,3 @@ func Init(svcName string) {
 		}
 	}
 }
-
-// InitLightweight starts the supported profilers IFF the environment variable is set.
-// Compared to Init, it disables mutex profiling and forced GC to reduce its overhead.
-func InitLightweight(svcName string) {
-	if os.Getenv("GOOGLE_CLOUD_PROFILER_ENABLED") != "" {
-		err := profiler.Start(profiler.Config{
-			Service:        svcName,
-			ServiceVersion: zoekt.Version,
-		})
-		if err != nil {
-			log.Printf("could not initialize profiler: %s", err.Error())
-		}
-	}
-}


### PR DESCRIPTION
This PR initializes the GCP profiler in the `zoekt-git-index` process so we can
examine CPU and memory usage for the indexing process itself.