### PR TITLE
Debug: write memory profile if heap exceeds threshold

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -562,7 +562,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 	names = uniq(names)
 
 	log.Printf("attempting to index %d total files", totalFiles)
-	for _, name := range names {
+	for idx, name := range names {
 		keys := fileKeys[name]
 
 		for _, key := range keys {
@@ -574,9 +574,12 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 			if err := builder.Add(doc); err != nil {
 				return false, fmt.Errorf("error adding document with name %s: %w", key.FullPath(), err)
 			}
+
+			if idx%10_000 == 0 {
+				builder.CheckMemoryUsage()
+			}
 		}
 	}
-
 	return true, builder.Finish()
 }
 

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -514,6 +514,9 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 		return false, fmt.Errorf("build.NewBuilder: %w", err)
 	}
 
+	// Preparing the build can consume substantial memory, so check usage before starting to index.
+	builder.CheckMemoryUsage()
+
 	var ranks repoPathRanks
 	var meanRank float64
 	if opts.BuildOptions.DocumentRanksPath != "" {


### PR DESCRIPTION
This PR adds adds a debugging flag to periodically check memory usage against a threshold. If it exceeds the threshold, then a memory profile like `indexmemory.prof.1` is written to disk. No more than 10 profiles will be written.

I've already found this more useful than the existing `-memprofile` flag, so I removed that. It's hard to get insights using that flag, since it only takes a single profile per shard, forces GC, and forces parallelism to 1.