### PR TITLE
Bump the minimum compatible index version

### DIFF
--- a/read.go
+++ b/read.go
@@ -150,24 +150,6 @@ func (r *reader) readTOC(toc *indexTOC) error {
 				}
 			}
 		}
-	} else {
-		// TODO: Remove this branch when ReaderMinFeatureVersion >= 10
-
-		secs := toc.sections()
-
-		if len(secs) != int(sectionCount) {
-			secs = toc.sectionsNext()
-		}
-
-		if len(secs) != int(sectionCount) {
-			return fmt.Errorf("section count mismatch: got %d want %d", sectionCount, len(secs))
-		}
-
-		for _, s := range secs {
-			if err := s.read(r); err != nil {
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/toc.go
+++ b/toc.go
@@ -63,7 +63,7 @@ const WriteMinFeatureVersion = 10
 
 // ReadMinFeatureVersion constrains backwards compatibility by refusing to
 // load a file with a FeatureVersion below it.
-const ReadMinFeatureVersion = 8
+const ReadMinFeatureVersion = 10
 
 // 17: compound shard (multi repo)
 const NextIndexFormatVersion = 17


### PR DESCRIPTION
This bumps `ReadMinFeatureVersion` to 10 so we can simplify the `readTOC` method. This seems okay, since version 10 [was added ~3 years ago](https://github.com/sourcegraph/zoekt/commit/f7d54faa261b31f7258a2d1291531ebd89ce8ee5), meaning we can still read 3 year old index files.