### PR TITLE
Simplify error handling in readTOC

### DIFF
--- a/read.go
+++ b/read.go
@@ -126,9 +126,9 @@ func (r *reader) readTOC(toc *indexTOC) error {
 			}
 			sec := secs[tag]
 			if sec == nil || sec.kind() != sectionKind(kind) {
-				return fmt.Errorf("encountered malformed undex section. tag: %s, kind: %d", tag, sectionKind(kind))
+				return fmt.Errorf("encountered malformed index section. tag: %s, kind: %d", tag, sectionKind(kind))
 			}
-			
+
 			if err := sec.read(r); err != nil {
 				return err
 			}

--- a/read.go
+++ b/read.go
@@ -130,12 +130,12 @@ func (r *reader) readTOC(toc *indexTOC) error {
 			if sec == nil || sec.kind() != sectionKind(kind) {
 				// If we don't recognize the section, we may be reading a newer index than the current version. Use
 				// a "dummy section" struct to skip over it.
-				log.Printf("encountered malformed index section (%s), skipping over it", tag)
+				log.Printf("encountered unrecognized index section (%s), skipping over it", tag)
 				switch sectionKind(kind) {
 				case sectionKindSimple:
 					sec = &simpleSection{}
 				case sectionKindCompound:
-					sec = &compoundSection{}
+					sec = &lazyCompoundSection{}
 				case sectionKindCompoundLazy:
 					sec = &lazyCompoundSection{}
 				default:


### PR DESCRIPTION
Small improvement to how we handle unknown or malformed sections when reading the TOC.

Note: this PR originally removed some of the "skip section" handling. That has been restored, since it is important for downgrades.