### PR TITLE
zoekt-index: USAGE message if no arguments supplied

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -63,6 +63,13 @@ func main() {
 	ignoreDirs := flag.String("ignore_dirs", ".git,.hg,.svn", "comma separated list of directories to ignore.")
 	flag.Parse()
 
+	if flag.NArg() == 0 {
+		fmt.Fprintf(flag.CommandLine.Output(), "USAGE: %s [options] PATHS...\n", filepath.Base(os.Args[0]))
+		fmt.Fprintln(flag.CommandLine.Output(), "Options:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
 	// Tune GOMAXPROCS to match Linux container CPU quota.
 	_, _ = maxprocs.Set()
 


### PR DESCRIPTION
Test Plan: go run ./cmd/zoekt-index prints out useful instructions

Fixes https://github.com/sourcegraph/zoekt/issues/821