### PR TITLE
feat: GitLab: exclude user repos

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -51,7 +51,8 @@ type ConfigEntry struct {
 	Active                 bool
 	NoArchived             bool
 	GerritFetchMetaConfig  bool
-  GerritRepoNameFormat   string
+	GerritRepoNameFormat   string
+	ExcludeUserRepos       bool
 }
 
 func randomize(entries []ConfigEntry) []ConfigEntry {
@@ -243,6 +244,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			if c.OnlyPublic {
 				cmd.Args = append(cmd.Args, "-public")
 			}
+			if c.ExcludeUserRepos {
+				cmd.Args = append(cmd.Args, "-exclude_user")
+			}
 			if c.CredentialPath != "" {
 				cmd.Args = append(cmd.Args, "-token", c.CredentialPath)
 			}
@@ -261,9 +265,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			if c.Active {
 				cmd.Args = append(cmd.Args, "-active")
 			}
-      if c.GerritFetchMetaConfig {
+			if c.GerritFetchMetaConfig {
 				cmd.Args = append(cmd.Args, "-fetch-meta-config")
-      }
+			}
 			if c.GerritRepoNameFormat != "" {
 				cmd.Args = append(cmd.Args, "-repo-name-format", c.GerritRepoNameFormat)
 			}

--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -46,7 +46,7 @@ func main() {
 	isMember := flag.Bool("membership", false, "only mirror repos this user is a member of ")
 	isPublic := flag.Bool("public", false, "only mirror public repos")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
-	excludeUserRepos := flag.Bool("exclude-user", false, "exclude user repos")
+	excludeUserRepos := flag.Bool("exclude_user", false, "exclude user repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
 	flag.Parse()

--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -46,6 +46,7 @@ func main() {
 	isMember := flag.Bool("membership", false, "only mirror repos this user is a member of ")
 	isPublic := flag.Bool("public", false, "only mirror public repos")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
+	excludeUserRepos := flag.Bool("exclude-user", false, "exclude user repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
 	flag.Parse()
@@ -103,6 +104,9 @@ func main() {
 			if project.DefaultBranch == "" {
 				continue
 			}
+			if *excludeUserRepos && project.Namespace.Kind == "user" {
+				continue
+			}
 
 			gitlabProjects = append(gitlabProjects, project)
 		}
@@ -128,7 +132,6 @@ func main() {
 		}
 		gitlabProjects = trimmed
 	}
-
 	fetchProjects(destDir, apiToken, gitlabProjects)
 
 	if *deleteRepos {


### PR DESCRIPTION
When running searches against GitLab repos, I would like to filter out repositories that live in user namespaces, as these generally are forks or personal projects that are less relevant and clutter up search results.