### PR TITLE
Fix outdated log line

### DIFF
--- a/read.go
+++ b/read.go
@@ -128,13 +128,13 @@ func (r *reader) readTOCSections(toc *indexTOC, tags []string) error {
 				// If we don't recognize the section, we may be reading a newer index than the current version. Use
 				// a "dummy section" struct to skip over it.
 				skipSection = true
-				log.Printf("encountered malformed index section (%s), skipping over it", tag)
+				log.Printf("encountered unrecognized index section (%s), skipping over it", tag)
 
 				switch sectionKind(kind) {
 				case sectionKindSimple:
 					sec = &simpleSection{}
 				case sectionKindCompound:
-					sec = &lazyCompoundSection{}
+					sec = &compoundSection{}
 				case sectionKindCompoundLazy:
 					sec = &lazyCompoundSection{}
 				default:


### PR DESCRIPTION
Tiny follow up to https://github.com/sourcegraph/zoekt/pull/826. I resolved a conflict incorrectly and reverted a log line improvement.