### PR TITLE
eval: simplify query.RawConfig

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -75,6 +75,8 @@ func (d *indexData) simplify(in query.Q) query.Q {
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Set[repo.Name]
 			})
+		case query.RawConfig:
+			return d.simplifyMultiRepo(q, func(repo *Repository) bool { return uint8(r)&encodeRawConfig(repo.RawConfig) == uint8(r) })
 		case *query.RepoIDs:
 			return d.simplifyMultiRepo(q, func(repo *Repository) bool {
 				return r.Repos.Contains(repo.ID)

--- a/eval_test.go
+++ b/eval_test.go
@@ -329,6 +329,22 @@ func TestSimplifyRepoRegexp(t *testing.T) {
 	}
 }
 
+func TestSimplifyRcRawConfig(t *testing.T) {
+	d := compoundReposShard(t, "foo", "bar")
+	var all = query.RcOnlyPrivate | query.RcNoForks | query.RcNoArchived
+
+	got := d.simplify(all)
+	if d := cmp.Diff(&query.Const{Value: true}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+
+	var none = query.RcOnlyPublic | query.RcNoForks | query.RcNoArchived
+	got = d.simplify(none)
+	if d := cmp.Diff(&query.Const{Value: false}, got); d != "" {
+		t.Fatalf("-want, +got:\n%s", d)
+	}
+}
+
 func TestSimplifyBranchesRepos(t *testing.T) {
 	d := compoundReposShard(t, "foo", "bar")
 


### PR DESCRIPTION
While working on scoring I noticed that public repos always have an advantage compared to private repos. The reason is that we have `doc(rawConfig:RcOnlyPublic|...)` as part of the match tree, which contributes +1 to the atom count.

For compound shards this won't help because we will likely have a mix of public and private repos, but this is still a good optimization to have in general.

Test plan:
New unit test