### PR TITLE
go.mod: update to go 1.22.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.1
+golang 1.22.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.19 AS builder
+FROM golang:1.22.7-alpine3.19 AS builder
 
 RUN apk add --no-cache ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 
 go 1.22.0
 
-toolchain go1.22.1
+toolchain go1.22.7


### PR DESCRIPTION
Among other fixes, Go 1.22.6 fixes a code signing issue on macOS and XCode 16 that prevents Zoetk from running:
https://github.com/golang/go/issues/68088