### PR TITLE
ranking: add test for conc vs golang

### DIFF
--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/build"
 	"github.com/sourcegraph/zoekt/internal/archive"
@@ -39,12 +40,13 @@ func TestRanking(t *testing.T) {
 	requireCTags(t)
 
 	archiveURLs := []string{
-		"https://github.com/sourcegraph/sourcegraph-public-snapshot/tree/v5.2.2",
-		"https://github.com/golang/go/tree/go1.21.4",
-		"https://github.com/sourcegraph/cody/tree/vscode-v0.14.5",
+		"https://github.com/sourcegraph/sourcegraph-public-snapshot/tree/v5.2.2", // Nov 1 2023
+		"https://github.com/golang/go/tree/go1.21.4",                             // Nov 7 2023
+		"https://github.com/sourcegraph/cody/tree/vscode-v0.14.5",                // Nov 8 2023
 		// The commit before ranking e2e tests were added to avoid matching
 		// content inside our golden files.
-		"https://github.com/sourcegraph/zoekt/commit/ef907c2371176aa3f97713d5bf182983ef090c6a",
+		"https://github.com/sourcegraph/zoekt/commit/ef907c2371176aa3f97713d5bf182983ef090c6a", // Nov 17 2023
+		"https://github.com/sourcegraph/conc/tree/5f936abd7ae87036af1f75c95fb9d0daaf00116b",    // Jan 21 2024
 	}
 	q := func(query, target string) rankingQuery {
 		return rankingQuery{Query: query, Target: target}
@@ -76,6 +78,9 @@ func TestRanking(t *testing.T) {
 		// symbols split up
 		q("bufio flush writer", "github.com/golang/go/src/net/http/transfer.go"),                        // bufioFlushWriter
 		q("coverage data writer", "github.com/golang/go/src/internal/coverage/encodecounter/encode.go"), // CoverageDataWriter
+
+		// sourcegraph/conc vs golang/go
+		q("WaitGroup", "github.com/sourcegraph/conc/waitgroup.go"),
 	}
 
 	var indexDir string

--- a/internal/e2e/testdata/WaitGroup.txt
+++ b/internal/e2e/testdata/WaitGroup.txt
@@ -1,0 +1,40 @@
+queryString: WaitGroup
+query: case_substr:"WaitGroup"
+targetRank: 2
+
+github.com/golang/go/src/sync/waitgroup.go
+23:type WaitGroup struct {
+91:func (wg *WaitGroup) Wait() {
+13:// A WaitGroup waits for a collection of goroutines to finish.
+hidden 13 more line matches
+
+**github.com/sourcegraph/conc/waitgroup.go**
+22:type WaitGroup struct {
+10:func NewWaitGroup() *WaitGroup {
+38:func (h *WaitGroup) Wait() {
+hidden 10 more line matches
+
+github.com/golang/go/test/fixedbugs/issue19467.dir/mysync.go
+9:type WaitGroup struct {
+13:func (wg *WaitGroup) Add(x int) {
+19:func (wg *WaitGroup) Done() {
+
+github.com/golang/go/test/fixedbugs/issue44370.dir/a.go
+8:type StoppableWaitGroup struct {
+16:func NewStoppableWaitGroup() *StoppableWaitGroup {
+7:// A StoppableWaitGroup waits for a collection of goroutines to finish.
+hidden 3 more line matches
+
+github.com/golang/go/src/sync/example_test.go
+20:func ExampleWaitGroup() {
+19:// using a WaitGroup to block until all the fetches are complete.
+21:	var wg sync.WaitGroup
+hidden 1 more line matches
+
+github.com/sourcegraph/conc/waitgroup_test.go
+13:func ExampleWaitGroup() {
+42:func TestWaitGroup(t *testing.T) {
+29:func ExampleWaitGroup_WaitAndRecover() {
+hidden 12 more line matches
+
+hidden 227 more file matches

--- a/internal/e2e/testdata/rank_stats.txt
+++ b/internal/e2e/testdata/rank_stats.txt
@@ -1,4 +1,4 @@
-queries: 15
-recall@1: 8 (53%)
-recall@5: 10 (67%)
-mrr: 0.607506
+queries: 16
+recall@1: 8 (50%)
+recall@5: 11 (69%)
+mrr: 0.600787


### PR DESCRIPTION
This adds a new test **and a new repo** to our e2e ranking suite. The idea is to have a query for which two repos (here golang/go and conc) of different freshness compete for the best match.

