### PR TITLE
Use single map for collecting files across branches

### DIFF
--- a/cmd/zoekt-repo-index/main.go
+++ b/cmd/zoekt-repo-index/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/build"
 	"github.com/sourcegraph/zoekt/gitindex"
+	"github.com/sourcegraph/zoekt/ignore"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	git "github.com/go-git/go-git/v5"
@@ -180,7 +181,7 @@ func main() {
 		}
 	}
 
-	perBranch := map[string]map[fileKey]gitindex.BlobRepo{}
+	perBranch := map[string]map[fileKey]gitindex.BlobLocation{}
 	opts.SubRepositories = map[string]*zoekt.Repository{}
 
 	// branch => repo => version
@@ -325,8 +326,8 @@ func getManifest(repo *git.Repository, branch, path string) (*manifest.Manifest,
 func iterateManifest(mf *manifest.Manifest,
 	baseURL url.URL, revPrefix string,
 	cache *gitindex.RepoCache,
-) (map[fileKey]gitindex.BlobRepo, map[string]plumbing.Hash, error) {
-	allFiles := map[fileKey]gitindex.BlobRepo{}
+) (map[fileKey]gitindex.BlobLocation, map[string]plumbing.Hash, error) {
+	allFiles := map[fileKey]gitindex.BlobLocation{}
 	allVersions := map[string]plumbing.Hash{}
 	for _, p := range mf.Project {
 		rev := mf.ProjectRevision(&p)
@@ -359,12 +360,13 @@ func iterateManifest(mf *manifest.Manifest,
 			return nil, nil, err
 		}
 
-		files, versions, err := gitindex.TreeToFiles(topRepo, tree, projURL.String(), cache)
+		rw := gitindex.NewRepoWalker(topRepo, projURL.String(), cache)
+		versions, err := rw.CollectFiles(tree, rev, &ignore.Matcher{})
 		if err != nil {
 			return nil, nil, err
 		}
 
-		for key, repo := range files {
+		for key, repo := range rw.Files {
 			allFiles[fileKey{
 				SubRepoPath: filepath.Join(p.GetPath(), key.SubRepoPath),
 				Path:        key.Path,

--- a/cmd/zoekt-repo-index/main.go
+++ b/cmd/zoekt-repo-index/main.go
@@ -361,7 +361,7 @@ func iterateManifest(mf *manifest.Manifest,
 		}
 
 		rw := gitindex.NewRepoWalker(topRepo, projURL.String(), cache)
-		versions, err := rw.CollectFiles(tree, rev, &ignore.Matcher{})
+		subVersions, err := rw.CollectFiles(tree, rev, &ignore.Matcher{})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -374,7 +374,7 @@ func iterateManifest(mf *manifest.Manifest,
 			}] = repo
 		}
 
-		for path, version := range versions {
+		for path, version := range subVersions {
 			allVersions[filepath.Join(p.GetPath(), path)] = version
 		}
 	}

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -608,13 +608,13 @@ func TestIndexDeltaBasic(t *testing.T) {
 					// setup: prepare spy versions of prepare delta / normal build so that we can observe
 					// whether they were called appropriately
 					deltaBuildCalled := false
-					prepareDeltaSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobIndexInfo, branchVersions map[string]map[string]plumbing.Hash, changedOrDeletedPaths []string, err error) {
+					prepareDeltaSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobLocation, branchVersions map[string]map[string]plumbing.Hash, changedOrDeletedPaths []string, err error) {
 						deltaBuildCalled = true
 						return prepareDeltaBuild(options, repository)
 					}
 
 					normalBuildCalled := false
-					prepareNormalSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobIndexInfo, branchVersions map[string]map[string]plumbing.Hash, err error) {
+					prepareNormalSpy := func(options Options, repository *git.Repository) (repos map[fileKey]BlobLocation, branchVersions map[string]map[string]plumbing.Hash, err error) {
 						normalBuildCalled = true
 						return prepareNormalBuild(options, repository)
 					}


### PR DESCRIPTION
When looking at large profiles for `inuse_space` on dot com, I noticed the filename maps in `prepareNormalBuild` taking a bunch of memory. This PR avoids allocating a separate map per branch, instead having `RepoWalker` collect all the entries in a single instance variable.

This is one last piece of "low hanging fruit" related to index memory. After this, we need to take a holistic look and consider a  true rewrite.

This helps allocations a bit on `sgtest/megarepo`. Note that I haven't been able to locally repro the type of profile we're seeing on dot com.

**Baseline vs. PR**
```
BenchmarkPrepareNormalBuild-10    	       1	1561963752 B/op	 4249175 allocs/op
BenchmarkPrepareNormalBuild-10    	       1	1472635928 B/op	 4238388 allocs/op
``` 

Follow up to https://github.com/sourcegraph/zoekt/pull/838.