### PR TITLE
sourcegraph: fix wrong git config

### DIFF
--- a/api.go
+++ b/api.go
@@ -638,9 +638,9 @@ func (r *Repository) UnmarshalJSON(data []byte) error {
 	// Sourcegraph indexserver doesn't set repo.Rank, so we set it here. Setting it
 	// on read instead of during indexing allows us to avoid a complete reindex.
 	//
-	// Prefer "latest_commit_date" over "priority" for ranking. We keep priority for
+	// Prefer "latestCommitDate" over "priority" for ranking. We keep priority for
 	// backwards compatibility.
-	if _, ok := repo.RawConfig["latest_commit_date"]; ok {
+	if _, ok := repo.RawConfig["latestCommitDate"]; ok {
 		// We use the number of months since 1970 as a simple measure of repo freshness.
 		// It is monotonically increasing and stable across re-indexes and restarts.
 		r.Rank = monthsSince1970(repo.LatestCommitDate)

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -122,7 +122,7 @@ func (o *indexArgs) BuildOptions() *build.Options {
 				"fork":     marshalBool(o.Fork),
 				"archived": marshalBool(o.Archived),
 				// Calculate repo rank based on the latest commit date.
-				"latest_commit_date": "1",
+				"latestCommitDate": "1",
 			},
 		},
 		IndexDir:         o.IndexDir,

--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -254,7 +254,7 @@ func indexURL(indexDir, u string) error {
 		RepositoryDescription: zoekt.Repository{
 			// Use the latest commit date to calculate the repo rank when loading the shard.
 			// This is the same setting we use in production.
-			RawConfig: map[string]string{"latest_commit_date": "1"},
+			RawConfig: map[string]string{"latestCommitDate": "1"},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Turns out git config doesn't support "_" in the keys.

"The variable names are case-insensitive, allow only alphanumeric characters and -, and must start with an alphabetic character." [source](https://git-scm.com/docs/git-config/2.22.0#_configuration_file)

The existing tests didn't catch this because we never actually execute `git config`. Now we do.

Test plan:
New unit test