### PR TITLE
web: escape + as %2B in file path templates

### DIFF
--- a/web/snippets.go
+++ b/web/snippets.go
@@ -16,11 +16,11 @@ package web
 
 import (
 	"bytes"
-	"html/template"
 	"log"
 	"net/url"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/sourcegraph/zoekt"
 )
@@ -33,12 +33,12 @@ func (s *Server) formatResults(result *zoekt.SearchResult, query string, localPr
 	if !localPrint {
 		for repo, str := range result.RepoURLs {
 			if str != "" {
-				templateMap[repo] = s.getTemplate(str)
+				templateMap[repo] = s.getTextTemplate(str)
 			}
 		}
 		for repo, str := range result.LineFragments {
 			if str != "" {
-				fragmentMap[repo] = s.getTemplate(str)
+				fragmentMap[repo] = s.getTextTemplate(str)
 			}
 		}
 	}


### PR DESCRIPTION
When constructing a shard we specify templates for constructing a URL. Finally those URLs end up going via html/template which has pretty strict escaping rules. This commit makes two changes:

URL construction via text/template. We still get the safety benefits later on when finally rendering the output, but given we are constructing URLs it makes more sense to use text/template.

Special escaping of + in URLs. I couldn't convince html/template to not break URls containing + in it. So instead we use + escaped to %2B. I tested gerrit, github and sourcegraph with %2B in filenames and they all worked.

To do the above I introduced a template function called URLJoinPath which is a wrapper around url.JoinPath with the additional behaviour around + escaping.

Test Plan: Did lots of updates in tests. See diff.

Fixes #807 