### PR TITLE
add last_activity_after flag (zoekt-mirror-gitlab)

### DIFF
--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sourcegraph/zoekt/gitindex"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -48,6 +49,7 @@ func main() {
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the given regexp.")
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
+	lastActivityAfter := flag.String("last_activity_after", "", "only mirror repos that have been active since this date (format: 2006-01-02).")
 	flag.Parse()
 
 	if *dest == "" {
@@ -87,6 +89,14 @@ func main() {
 	}
 	if *isPublic {
 		opt.Visibility = gitlab.Visibility(gitlab.PublicVisibility)
+	}
+
+	if *lastActivityAfter != "" {
+		targetDate, err := time.Parse("2006-01-02", *lastActivityAfter)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opt.LastActivityAfter = gitlab.Time(targetDate)
 	}
 
 	var gitlabProjects []*gitlab.Project


### PR DESCRIPTION
This PR adds a flag to zoekt-git-mirror to filter repositories by update date.

When mirroring to update the index, it is inefficient to mirror all repositories, so we want to add this flag because we only want to get repositories that were active at the time of the last mirror.

```bash
$ zoekt-mirror-gitlab --dest=. --last_activity_after=2024-10-16
```

Please let us know what do you think. Thank you!