### PR TITLE
Expand upper range on indexing delay metric

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -92,7 +92,7 @@ var (
 	metricIndexingDelay = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "index_indexing_delay_seconds",
 		Help:    "A histogram of durations from when an index job is added to the queue, to the time it completes.",
-		Buckets: prometheus.ExponentialBuckets(60, 2, 12), // 1m -> ~3 days
+		Buckets: prometheus.ExponentialBuckets(60, 2, 14), // 1 minute -> 5.5 days
 	}, []string{
 		"state", // state is an indexState
 		"name",  // the name of the repository that was indexed


### PR DESCRIPTION
When adding this metric, I got the calculation wrong. So the maximum bucket was capped at ~1.3 days, which we easily saturate at the 90% percentile.

This PR updates it to ~ 5.5 days to be safe:
```
>>> math.pow(2, 14 - 1) / 60 / 24
5.688888888888889
```

Note the `- 1`, which is the key piece I missed before.