### PR TITLE
Avoid reopening packfile on every object access

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -408,11 +408,23 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 
 	opts.BuildOptions.RepositoryDescription.Source = opts.RepoDir
 
-	repo, repoCloser, err := openRepo(opts.RepoDir)
-	if err != nil {
-		return false, fmt.Errorf("openRepo: %w", err)
+	var repo *git.Repository
+
+	// TODO: remove this feature flag once we test this on a large-scale instance.
+	optimizeRepoOpen := os.Getenv("ZOEKT_ENABLE_GOGIT_OPTIMIZATION")
+	if b, err := strconv.ParseBool(optimizeRepoOpen); b && err == nil {
+		var repoCloser io.Closer
+		repo, repoCloser, err = openRepo(opts.RepoDir)
+		if err != nil {
+			return false, fmt.Errorf("openRepo: %w", err)
+		}
+		defer repoCloser.Close()
+	} else {
+		repo, err = git.PlainOpen(opts.RepoDir)
+		if err != nil {
+			return false, fmt.Errorf("git.PlainOpen: %w", err)
+		}
 	}
-	defer repoCloser.Close()
 
 	if err := setTemplatesFromConfig(&opts.BuildOptions.RepositoryDescription, opts.RepoDir); err != nil {
 		log.Printf("setTemplatesFromConfig(%s): %s", opts.RepoDir, err)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -605,7 +605,7 @@ func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 	}
 
 	// If there's a .git directory, use that as the new root.
-	if _, err := fs.Stat(git.GitDirName); err == nil {
+	if fi, err := fs.Stat(git.GitDirName); err == nil && fi.IsDir() {
 		if fs, err = fs.Chroot(git.GitDirName); err != nil {
 			return nil, nil, fmt.Errorf("fs.Chroot: %w", err)
 		}

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -90,14 +90,14 @@ func TestIndexTinyRepo(t *testing.T) {
 	// Create a repo with one file in it.
 	dir := t.TempDir()
 	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
-	executeCommand(t, dir, exec.Command("git", "config", "--global", "user.name", "Thomas"))
-	executeCommand(t, dir, exec.Command("git", "config", "--global", "user.email", "thomas@google.com"))
-
-	if err := os.WriteFile(filepath.Join(dir, "repo", "file1.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
 
 	repoDir := filepath.Join(dir, "repo")
+	executeCommand(t, repoDir, exec.Command("git", "config", "user.name", "Thomas"))
+	executeCommand(t, repoDir, exec.Command("git", "config", "user.email", "thomas@google.com"))
+
+	if err := os.WriteFile(filepath.Join(repoDir, "file1.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 	executeCommand(t, repoDir, exec.Command("git", "add", "."))
 	executeCommand(t, repoDir, exec.Command("git", "commit", "-m", "initial commit"))
 


### PR DESCRIPTION
By default, the `go-git` library will open the packfile on every call to `Repository.BlobObject`, then close it. During indexing, we collect the list of files to index, then iterate through each one calling `Repository.BlobObject`. So on every object access the packfile reopened, and `go-git` reallocates some in-memory buffers.

This PR bypasses `git.PlainOpen` to allow us to enable the `KeepDescriptors` option. This option keeps packfile files open, and caches wrappers for them. The files then need to be explicitly closed when done with the repo.

Benefits:
* Avoid reallocating the memory buffers on every object access (see benchmark results below)
* (Highly speculative) I suspect this could improve OS decisions around when to cache portions of the packfile.

Relates to SPLF-636
