### PR TITLE
query: simplify empty BranchesRepos and RepoIDs

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -651,6 +651,17 @@ func evalConstants(q Q) Q {
 		if s.Pattern == "" {
 			return &Const{true}
 		}
+	case *BranchesRepos:
+		for _, br := range s.List {
+			if !br.Repos.IsEmpty() {
+				return q
+			}
+		}
+		return &Const{false}
+	case *RepoIDs:
+		if s.Repos.IsEmpty() {
+			return &Const{false}
+		}
 	case *RepoSet:
 		if len(s.Set) == 0 {
 			return &Const{false}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -76,6 +76,20 @@ func TestSimplify(t *testing.T) {
 				&Substring{Pattern: "byte"},
 				&Not{&Substring{Pattern: "byte"}}),
 		},
+		{
+			in: NewAnd(
+				NewSingleBranchesRepos("HEAD"), // Empty list matches nothing
+				&Not{&Type{Type: TypeRepo, Child: &Substring{Pattern: "hi"}}}),
+			want: &Const{false},
+		},
+		{
+			in: NewAnd(
+				NewSingleBranchesRepos("HEAD", 1),
+				&Not{&Type{Type: TypeRepo, Child: &Substring{Pattern: "hi"}}}),
+			want: NewAnd(
+				NewSingleBranchesRepos("HEAD", 1),
+				&Not{&Type{Type: TypeRepo, Child: &Substring{Pattern: "hi"}}}),
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
We recently had an incident where this was accidently unset and lead to lots of work done by zoekt which just got thrown away.

Test Plan: added unit test

Fixes https://linear.app/sourcegraph/issue/SPLF-660/include-empty-repo-query-filters-in-simplify-optimization