### PR TITLE
tenant: introduce systemtenant

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -231,7 +231,7 @@ nextFileMatch:
 
 			// 🚨 SECURITY: Skip documents that don't belong to the tenant. This check is
 			// necessary to prevent leaking data across tenants.
-			if !tenant.EqualsID(ctx, repoMetadata.TenantID) {
+			if !tenant.HasAccess(ctx, repoMetadata.TenantID) {
 				continue
 			}
 
@@ -624,7 +624,7 @@ func (d *indexData) List(ctx context.Context, q query.Q, opts *ListOptions) (rl 
 		}
 		// 🚨 SECURITY: Skip documents that don't belong to the tenant. This check is
 		// necessary to prevent leaking data across tenants.
-		if !tenant.EqualsID(ctx, d.repoMetaData[i].TenantID) {
+		if !tenant.HasAccess(ctx, d.repoMetaData[i].TenantID) {
 			continue
 		}
 		rle := &d.repoListEntry[i]

--- a/internal/tenant/query.go
+++ b/internal/tenant/query.go
@@ -2,12 +2,17 @@ package tenant
 
 import (
 	"context"
+
+	"github.com/sourcegraph/zoekt/internal/tenant/systemtenant"
 )
 
 // EqualsID returns true if the tenant ID in the context matches the
 // given ID. If tenant enforcement is disabled, it always returns true.
 func EqualsID(ctx context.Context, id int) bool {
 	if !EnforceTenant() {
+		return true
+	}
+	if systemtenant.Is(ctx) {
 		return true
 	}
 	t, err := FromContext(ctx)

--- a/internal/tenant/query.go
+++ b/internal/tenant/query.go
@@ -6,9 +6,9 @@ import (
 	"github.com/sourcegraph/zoekt/internal/tenant/systemtenant"
 )
 
-// EqualsID returns true if the tenant ID in the context matches the
+// HasAccess returns true if the tenant ID in the context matches the
 // given ID. If tenant enforcement is disabled, it always returns true.
-func EqualsID(ctx context.Context, id int) bool {
+func HasAccess(ctx context.Context, id int) bool {
 	if !EnforceTenant() {
 		return true
 	}

--- a/internal/tenant/systemtenant/systemtenant.go
+++ b/internal/tenant/systemtenant/systemtenant.go
@@ -1,6 +1,5 @@
-// Package systemtenant contains function to mark a context as allowed to
-// access shards across all tenants. This must only be used for tasks that are
-// not request specific.
+// Package systemtenant exports UnsafeCtx which allows to access shards across
+// all tenants. This must only be used for tasks that are not request specific.
 package systemtenant
 
 import (
@@ -11,9 +10,9 @@ type contextKey int
 
 const systemTenantKey contextKey = iota
 
-// Ctx is a context that allows queries across all tenants. This must only be
-// used for tasks that are not user request specific.
-var Ctx = context.WithValue(context.Background(), systemTenantKey, systemTenantKey)
+// UnsafeCtx is a context that allows queries across all tenants. Don't use this
+// for user requests.
+var UnsafeCtx = context.WithValue(context.Background(), systemTenantKey, systemTenantKey)
 
 // Is returns true if the context has been marked to allow queries across all
 // tenants.

--- a/internal/tenant/systemtenant/systemtenant.go
+++ b/internal/tenant/systemtenant/systemtenant.go
@@ -1,0 +1,33 @@
+// Package systemtenant contains function to mark a context as allowed to
+// access shards across all tenants. This must only be used for tasks that are
+// not request specific.
+package systemtenant
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sourcegraph/zoekt/internal/tenant/internal/tenanttype"
+)
+
+type contextKey int
+
+const systemTenantKey contextKey = iota
+
+// With marks a ctx to be allowed to access shards across all tenants. This MUST
+// NOT BE USED on the user request path.
+func With(ctx context.Context) (context.Context, error) {
+	// We don't want to allow setting the system tenant on a context that already
+	// has a user tenant set.
+	if _, ok := tenanttype.GetTenant(ctx); ok {
+		return nil, fmt.Errorf("tenant context already set")
+	}
+	return context.WithValue(ctx, systemTenantKey, systemTenantKey), nil
+}
+
+// Is returns true if the context has been marked to allow queries across all
+// tenants.
+func Is(ctx context.Context) bool {
+	_, ok := ctx.Value(systemTenantKey).(contextKey)
+	return ok
+}

--- a/internal/tenant/systemtenant/systemtenant.go
+++ b/internal/tenant/systemtenant/systemtenant.go
@@ -5,25 +5,15 @@ package systemtenant
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/sourcegraph/zoekt/internal/tenant/internal/tenanttype"
 )
 
 type contextKey int
 
 const systemTenantKey contextKey = iota
 
-// With marks a ctx to be allowed to access shards across all tenants. This MUST
-// NOT BE USED on the user request path.
-func With(ctx context.Context) (context.Context, error) {
-	// We don't want to allow setting the system tenant on a context that already
-	// has a user tenant set.
-	if _, ok := tenanttype.GetTenant(ctx); ok {
-		return nil, fmt.Errorf("tenant context already set")
-	}
-	return context.WithValue(ctx, systemTenantKey, systemTenantKey), nil
-}
+// Ctx is a context that allows queries across all tenants. This must only be
+// used for tasks that are not user request specific.
+var Ctx = context.WithValue(context.Background(), systemTenantKey, systemTenantKey)
 
 // Is returns true if the context has been marked to allow queries across all
 // tenants.

--- a/internal/tenant/systemtenant/systemtenant_test.go
+++ b/internal/tenant/systemtenant/systemtenant_test.go
@@ -11,5 +11,5 @@ func TestSystemtenantRoundtrip(t *testing.T) {
 	if Is(context.Background()) {
 		t.Fatal()
 	}
-	require.True(t, Is(Ctx))
+	require.True(t, Is(UnsafeCtx))
 }

--- a/internal/tenant/systemtenant/systemtenant_test.go
+++ b/internal/tenant/systemtenant/systemtenant_test.go
@@ -11,7 +11,5 @@ func TestSystemtenantRoundtrip(t *testing.T) {
 	if Is(context.Background()) {
 		t.Fatal()
 	}
-	ctx, err := With(context.Background())
-	require.NoError(t, err)
-	require.True(t, Is(ctx))
+	require.True(t, Is(Ctx))
 }

--- a/internal/tenant/systemtenant/systemtenant_test.go
+++ b/internal/tenant/systemtenant/systemtenant_test.go
@@ -1,0 +1,17 @@
+package systemtenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemtenantRoundtrip(t *testing.T) {
+	if Is(context.Background()) {
+		t.Fatal()
+	}
+	ctx, err := With(context.Background())
+	require.NoError(t, err)
+	require.True(t, Is(ctx))
+}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/internal/tenant/systemtenant"
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/trace"
 )
@@ -1064,7 +1065,11 @@ func (s *shardedSearcher) getLoaded() loaded {
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {
 	q := query.Const{Value: true}
-	result, err := s.List(context.Background(), &q, nil)
+	ctx, err := systemtenant.With(context.Background())
+	if err != nil {
+		return &rankedShard{Searcher: s}
+	}
+	result, err := s.List(ctx, &q, nil)
 	if err != nil {
 		return &rankedShard{Searcher: s}
 	}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -1065,7 +1065,7 @@ func (s *shardedSearcher) getLoaded() loaded {
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {
 	q := query.Const{Value: true}
-	result, err := s.List(systemtenant.Ctx, &q, nil)
+	result, err := s.List(systemtenant.UnsafeCtx, &q, nil)
 	if err != nil {
 		return &rankedShard{Searcher: s}
 	}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -1065,6 +1065,9 @@ func (s *shardedSearcher) getLoaded() loaded {
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {
 	q := query.Const{Value: true}
+	// We need to use UnsafeCtx here, otherwise we cannot return a proper
+	// rankedShard. On the user request path we use selectRepoSet which relies on
+	// rankedShard.repos being set.
 	result, err := s.List(systemtenant.UnsafeCtx, &q, nil)
 	if err != nil {
 		return &rankedShard{Searcher: s}

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -1065,11 +1065,7 @@ func (s *shardedSearcher) getLoaded() loaded {
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {
 	q := query.Const{Value: true}
-	ctx, err := systemtenant.With(context.Background())
-	if err != nil {
-		return &rankedShard{Searcher: s}
-	}
-	result, err := s.List(ctx, &q, nil)
+	result, err := s.List(systemtenant.Ctx, &q, nil)
 	if err != nil {
 		return &rankedShard{Searcher: s}
 	}


### PR DESCRIPTION
Some tasks, such as loading shards, require priviledged access on startup. Here I introduce `systemtenant` which we can use for these kinds of things.

This is motivated by a bug where the symbol sidebar in multi-tenant node wouldn't work because ranked shards were not loaded correctly which in turn caused `SelectRepoSet` to return 0 shards always.

Test plan:
- added unit test
- manual testing: symbol sidebar works now
