### PR TITLE
cmd/zoekt: trim '\n' from match

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -43,7 +44,8 @@ func displayMatches(files []zoekt.FileMatch, pat string, withRepo bool, list boo
 		}
 
 		for _, m := range f.LineMatches {
-			fmt.Printf("%s%s:%d:%s%s\n", r, f.FileName, m.LineNumber, m.Line, addTabIfNonEmpty(f.Debug))
+			l := bytes.TrimSuffix(m.Line, []byte{'\n'})
+			fmt.Printf("%s%s:%d:%s%s\n", r, f.FileName, m.LineNumber, l, addTabIfNonEmpty(f.Debug))
 		}
 	}
 }


### PR DESCRIPTION
Before, we'd typically have two newlines, one coming from the corpus, and one terminating the fmt.Printf call.