### PR TITLE
cmd/zoekt: suppress logging if -v is missing

### DIFF
--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -177,6 +177,10 @@ func main() {
 	}
 	pat := flag.Arg(0)
 
+	if !*verbose {
+		log.SetOutput(io.Discard)
+	}
+
 	var searcher zoekt.Searcher
 	var err error
 	if *shard != "" {


### PR DESCRIPTION
The logging is neat for debugging, but is distracting when using cmd/zoekt as a grep replacement.