### PR TITLE
all: set severity hint in most log output

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/debug.go
+++ b/cmd/zoekt-sourcegraph-indexserver/debug.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -35,7 +34,7 @@ func debugIndex() *ffcli.Command {
 				return err
 			}
 			msg, err := s.forceIndex(uint32(id))
-			log.Println(msg)
+			infoLog.Println(msg)
 			if err != nil {
 				return err
 			}

--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
@@ -321,7 +320,7 @@ func fetchRepo(ctx context.Context, gitDir string, o *indexArgs, c gitIndexConfi
 			name := o.BuildOptions().RepositoryDescription.Name
 			id := o.BuildOptions().RepositoryDescription.ID
 
-			log.Printf("delta build: failed to prepare delta build for %q (ID %d): failed to fetch both latest and prior commits: %s", name, id, err)
+			errorLog.Printf("delta build: failed to prepare delta build for %q (ID %d): failed to fetch both latest and prior commits: %s", name, id, err)
 			err = fetchOnlyLatestCommits()
 			if err != nil {
 				return err

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -205,6 +205,9 @@ func TestMain(m *testing.M) {
 	level := sglog.LevelInfo
 	if !testing.Verbose() {
 		log.SetOutput(io.Discard)
+		debugLog.SetOutput(io.Discard)
+		infoLog.SetOutput(io.Discard)
+		errorLog.SetOutput(io.Discard)
 		level = sglog.LevelNone
 	}
 

--- a/cmd/zoekt-sourcegraph-indexserver/owner.go
+++ b/cmd/zoekt-sourcegraph-indexserver/owner.go
@@ -53,7 +53,7 @@ func (o *ownerChecker) Init() error {
 	if err := o.Check(); errors.Is(err, fs.ErrNotExist) {
 		// do nothing, first run so we just write out the file
 	} else if errors.As(err, &ownerErr) {
-		debug.Printf("WARN: detected a change in ownership at startup. You can ignore this if you only have one zoekt replica: %s", err)
+		debugLog.Printf("WARN: detected a change in ownership at startup. You can ignore this if you only have one zoekt replica: %s", err)
 	} else if err != nil {
 		return err
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/queue.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue.go
@@ -316,7 +316,7 @@ func (q *Queue) MaybeRemoveMissing(ids []uint32) []uint32 {
 
 	// heuristically skip expensive work
 	if sameSize {
-		debug.Printf("skipping MaybeRemoveMissing due to same size: %d", len(ids))
+		debugLog.Printf("skipping MaybeRemoveMissing due to same size: %d", len(ids))
 		return nil
 	}
 

--- a/shards/shards.go
+++ b/shards/shards.go
@@ -303,13 +303,13 @@ func (tl *loader) load(keys ...string) {
 		tl.ss.replace(chunk)
 	}
 
-	log.Printf("loading %d shard(s): %s", len(keys), humanTruncateList(keys, 5))
+	log.Printf("[INFO] loading %d shard(s): %s", len(keys), humanTruncateList(keys, 5))
 
 	lastProgress := time.Now()
 	for i, key := range keys {
 		// If taking a while to start-up occasionally give a progress message
 		if time.Since(lastProgress) > 5*time.Second {
-			log.Printf("still need to load %d shards...", len(keys)-i)
+			log.Printf("[INFO] still need to load %d shards...", len(keys)-i)
 			lastProgress = time.Now()
 
 			publishLoaded()
@@ -325,7 +325,7 @@ func (tl *loader) load(keys ...string) {
 			shard, err := loadShard(key)
 			if err != nil {
 				metricShardsLoadFailedTotal.Inc()
-				log.Printf("reloading: %s, err %v ", key, err)
+				log.Printf("[ERROR] reloading: %s, err %v ", key, err)
 				return
 			}
 			metricShardsLoadedTotal.Inc()
@@ -896,7 +896,7 @@ func searchOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoek
 	defer func() {
 		metricSearchShardRunning.Dec()
 		if e := recover(); e != nil {
-			log.Printf("crashed shard: %s: %#v, %s", s, e, debug.Stack())
+			log.Printf("[ERROR] crashed shard: %s: %#v, %s", s, e, debug.Stack())
 
 			if sr == nil {
 				sr = &zoekt.SearchResult{}
@@ -918,7 +918,7 @@ func listOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoekt.
 	defer func() {
 		metricListShardRunning.Dec()
 		if r := recover(); r != nil {
-			log.Printf("crashed shard: %s: %s, %s", s.String(), r, debug.Stack())
+			log.Printf("[ERROR] crashed shard: %s: %s, %s", s.String(), r, debug.Stack())
 			sink <- shardListResult{
 				&zoekt.RepoList{Crashes: 1}, nil,
 			}
@@ -1088,7 +1088,7 @@ func mkRankedShard(s zoekt.Searcher) *rankedShard {
 	// rankedShard.repos being set.
 	result, err := s.List(systemtenant.UnsafeCtx, &q, nil)
 	if err != nil {
-		log.Printf("mkRankedShard(%s): failed to cache repository list: %v", s, err)
+		log.Printf("[ERROR] mkRankedShard(%s): failed to cache repository list: %v", s, err)
 		return &rankedShard{Searcher: s}
 	}
 

--- a/shards/shards_test.go
+++ b/shards/shards_test.go
@@ -17,8 +17,10 @@ package shards
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -38,6 +40,14 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/query"
 )
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	os.Exit(m.Run())
+}
 
 type crashSearcher struct{}
 
@@ -59,8 +69,10 @@ func (s *crashSearcher) String() string { return "crashSearcher" }
 
 func TestCrashResilience(t *testing.T) {
 	out := &bytes.Buffer{}
+	oldOut := log.Writer()
 	log.SetOutput(out)
-	defer log.SetOutput(os.Stderr)
+	defer log.SetOutput(oldOut)
+
 	ss := newShardedSearcher(2)
 	ss.ranked.Store([]*rankedShard{{Searcher: &crashSearcher{}}})
 

--- a/shards/watcher.go
+++ b/shards/watcher.go
@@ -179,7 +179,7 @@ func (s *DirectoryWatcher) scan() error {
 	}
 
 	if len(toDrop) > 0 {
-		log.Printf("unloading %d shard(s): %s", len(toDrop), humanTruncateList(toDrop, 5))
+		log.Printf("[INFO] unloading %d shard(s): %s", len(toDrop), humanTruncateList(toDrop, 5))
 	}
 
 	s.loader.drop(toDrop...)
@@ -244,7 +244,7 @@ func (s *DirectoryWatcher) watch() error {
 				// Ignore ErrEventOverflow since we rely on the presence of events so
 				// safe to ignore.
 				if err != nil && err != fsnotify.ErrEventOverflow {
-					log.Println("watcher error:", err)
+					log.Println("[ERROR] watcher error:", err)
 				}
 
 			case <-s.quit:
@@ -260,7 +260,7 @@ func (s *DirectoryWatcher) watch() error {
 		defer close(s.stopped)
 		for range signal {
 			if err := s.scan(); err != nil {
-				log.Println("watcher error:", err)
+				log.Println("[ERROR] watcher error:", err)
 			}
 		}
 	}()


### PR DESCRIPTION
I was inspecting logs in GKE and it incorrectly categorized the severity of nearly all logs from zoekt-webserver and zoekt-indexserver. This is a hack to make it work better without putting in the bigger work of migrating us to structured logging.

Test Plan: go test