### PR TITLE
tenant: don't log missing tenant for watchdog

### DIFF
--- a/internal/tenant/context.go
+++ b/internal/tenant/context.go
@@ -29,6 +29,9 @@ const (
 	skipLogging contextKey = iota
 )
 
+// WithSkipMissingLogging skips logging when the tenant ID is missing. We use
+// this, for example in the health check handler, when we know that the tenant
+// ID is not needed.
 func WithSkipMissingLogging(ctx context.Context) context.Context {
 	return context.WithValue(ctx, skipLogging, skipLogging)
 }

--- a/internal/tenant/context_test.go
+++ b/internal/tenant/context_test.go
@@ -1,0 +1,45 @@
+package tenant
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/zoekt/internal/tenant/tenanttest"
+	"github.com/sourcegraph/zoekt/trace"
+)
+
+func TestLog(t *testing.T) {
+	tenanttest.MockEnforce(t)
+
+	cases := []struct {
+		name          string
+		ctx           context.Context
+		expectedCount int64
+	}{
+		{
+			name:          "With Tenant",
+			ctx:           tenanttest.NewTestContext(),
+			expectedCount: 0,
+		},
+		{
+			name:          "Skip Logging",
+			ctx:           WithSkipMissingLogging(context.Background()),
+			expectedCount: 0,
+		},
+		{
+			name:          "Missing Tenant",
+			ctx:           context.Background(),
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, ctx := trace.New(tc.ctx, "test", "test")
+			Log(ctx, tr)
+			require.Equal(t, tc.expectedCount, pprofUniqID.Load())
+		})
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -32,7 +32,9 @@ import (
 	"time"
 
 	"github.com/grafana/regexp"
+
 	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/internal/tenant"
 	zjson "github.com/sourcegraph/zoekt/json"
 	"github.com/sourcegraph/zoekt/query"
 )
@@ -206,7 +208,7 @@ func (s *Server) serveHealthz(w http.ResponseWriter, r *http.Request) {
 	q := &query.Const{Value: true}
 	opts := &zoekt.SearchOptions{ShardMaxMatchCount: 1, TotalMaxMatchCount: 1, MaxDocDisplayCount: 1}
 
-	result, err := s.Searcher.Search(r.Context(), q, opts)
+	result, err := s.Searcher.Search(tenant.WithSkipMissingLogging(r.Context()), q, opts)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("not ready: %v", err), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
I suspect that most if not all of the "missing_tenant" profiles we see come from watchdog.
Here we add the same `skipLogging` marker we use in Sourcegraph.