### PR TITLE
Fix GitHub/GitLab brand capitalization

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -84,7 +84,7 @@ supported by all projects.
 
 ## What about the search on `github.com`?
 
-Github's search has great coverage, but unfortunately, its search
+GitHub's search has great coverage, but unfortunately, its search
 functionality doesn't support arbitrary substrings. For example, a
 query [for part of my
 surname](https://github.com/search?utf8=%E2%9C%93&q=nienhuy&type=Code)


### PR DESCRIPTION
This change ensures consistent capitalization of the GitHub and GitLab brand names in Markdown documentation.

[_Created by Sourcegraph batch change `sqs/capitalize-brands-correctly`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/capitalize-brands-correctly)