### PR TITLE
merging: In compound shards, sort repos by id

### DIFF
--- a/indexdata.go
+++ b/indexdata.go
@@ -76,7 +76,12 @@ type indexData struct {
 	// name => mask (power of 2)
 	branchIDs []map[string]uint
 
-	metaData     IndexMetadata
+	metaData IndexMetadata
+
+	// Repository metadata for all repositories contained in this shard.
+	//
+	// Invariant: Repositories in repoMetaData are sorted by ID in increasing order,
+	// see zoekt.merge.
 	repoMetaData []Repository
 
 	subRepos     []uint32


### PR DESCRIPTION
We sort shards in compound shards by repository ID so that we can use binary search instead of looping through the entire list of repos when when calling `build.findShard`.

We have seen that for very large compound shards (5k+ repos) it can take a long time to find a specific repo which can slow down initial indexing even for no-op indexes after a restart of indexserver.

The sort order will impact ranking of non-bm25 search, because doc-order acts as a tie-breaker. However, the actual impact is very small, because "LastCommitDate" is a stronger signal.

Note:
We moved from `priority` to `LatestCommitDate` as tie breaker in #832. Hence, sorting repos in compound shards by priority doesn't make much sense anymore.

Test plan:
New unit test