### PR TITLE
Support BM25 scoring for chunk matches

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -33,7 +34,6 @@ const (
 	stringHeaderBytes uint64 = 16
 	pointerSize       uint64 = 8
 	interfaceBytes    uint64 = 16
-	maxUInt16                = 0xffff
 )
 
 // FileMatch contains all the matches within a file.
@@ -688,7 +688,7 @@ func (r *Repository) UnmarshalJSON(data []byte) error {
 			// Normalize the repo score within [0, maxUint16), with the midpoint at 5,000.
 			// This means popular repos (roughly ones with over 5,000 stars) see diminishing
 			// returns from more stars.
-			r.Rank = uint16(r.priority / (5000.0 + r.priority) * maxUInt16)
+			r.Rank = uint16(r.priority / (5000.0 + r.priority) * math.MaxUint16)
 		}
 	}
 
@@ -704,7 +704,7 @@ func monthsSince1970(t time.Time) uint16 {
 		return 0
 	}
 	months := int(t.Year()-1970)*12 + int(t.Month()-1)
-	return uint16(min(months, maxUInt16))
+	return uint16(min(months, math.MaxUint16))
 }
 
 // MergeMutable will merge x into r. mutated will be true if it made any

--- a/api.go
+++ b/api.go
@@ -33,6 +33,7 @@ const (
 	stringHeaderBytes uint64 = 16
 	pointerSize       uint64 = 8
 	interfaceBytes    uint64 = 16
+	maxUInt16                = 0xffff
 )
 
 // FileMatch contains all the matches within a file.
@@ -133,6 +134,22 @@ func (m *FileMatch) sizeBytes() (sz uint64) {
 	sz += sliceHeaderBytes + uint64(len(m.Checksum))
 
 	return
+}
+
+// addScore increments the score of the FileMatch by the computed score. If
+// debugScore is true, it also adds a debug string to the FileMatch. If raw is
+// -1, it is ignored. Otherwise, it is added to the debug string.
+func (m *FileMatch) addScore(what string, computed float64, raw float64, debugScore bool) {
+	if computed != 0 && debugScore {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%s", what)
+		if raw != -1 {
+			fmt.Fprintf(&b, "(%s)", strconv.FormatFloat(raw, 'f', -1, 64))
+		}
+		fmt.Fprintf(&b, ":%.2f, ", computed)
+		m.Debug += b.String()
+	}
+	m.Score += computed
 }
 
 // ChunkMatch is a set of non-overlapping matches within a contiguous range of
@@ -976,7 +993,8 @@ type SearchOptions struct {
 
 	// EXPERIMENTAL. If true, use text-search style scoring instead of the default
 	// scoring formula. The scoring algorithm treats each match in a file as a term
-	// and computes an approximation to BM25.
+	// and computes an approximation to BM25. When enabled, BM25 scoring is used for
+	// the overall FileMatch score, as well as individual LineMatch and ChunkMatch scores.
 	//
 	// The calculation of IDF assumes that Zoekt visits all documents containing any
 	// of the query terms during evaluation. This is true, for example, if all query

--- a/build/scoring_test.go
+++ b/build/scoring_test.go
@@ -94,8 +94,21 @@ func TestBM25(t *testing.T) {
 			language: "Java",
 			// bm25-score: 1.81 <- sum-termFrequencyScore: 116.00, length-ratio: 1.00
 			wantScore: 1.81,
-			// line 3: public class InnerClasses {
-			wantBestLineMatch: 3,
+			// line 54: private static <A, B> B runInnerInterface(InnerInterface<A, B> fn, A a) {
+			wantBestLineMatch: 54,
+		}, {
+			// Another content-only match
+			fileName: "example.java",
+			query: &query.And{Children: []query.Q{
+				&query.Substring{Pattern: "system"},
+				&query.Substring{Pattern: "time"},
+			}},
+			content:  exampleJava,
+			language: "Java",
+			// bm25-score: 0.96 <- sum-termFrequencies: 12, length-ratio: 1.00
+			wantScore: 0.96,
+			// line 59: if (System.nanoTime() > System.currentTimeMillis()) {
+			wantBestLineMatch: 59,
 		},
 		{
 			// Matches only on filename

--- a/eval.go
+++ b/eval.go
@@ -327,9 +327,9 @@ nextFileMatch:
 		finalCands := d.gatherMatches(nextDoc, mt, known, shouldMergeMatches)
 
 		if opts.ChunkMatches {
-			fileMatch.ChunkMatches = cp.fillChunkMatches(finalCands, opts.NumContextLines, fileMatch.Language, opts.DebugScore)
+			fileMatch.ChunkMatches = cp.fillChunkMatches(finalCands, opts.NumContextLines, fileMatch.Language, opts)
 		} else {
-			fileMatch.LineMatches = cp.fillMatches(finalCands, opts.NumContextLines, fileMatch.Language, opts.DebugScore)
+			fileMatch.LineMatches = cp.fillMatches(finalCands, opts.NumContextLines, fileMatch.Language, opts)
 		}
 
 		var tf map[string]int

--- a/read.go
+++ b/read.go
@@ -533,7 +533,14 @@ func (d *indexData) readNewlines(i uint32, buf []uint32) ([]uint32, uint32, erro
 		return nil, 0, err
 	}
 
-	return fromSizedDeltas(blob, buf), sec.sz, nil
+	nl := fromSizedDeltas(blob, buf)
+
+	// can be nil if buf is nil and there are no doc sections. However, we rely
+	// on it being non-nil to cache the read.
+	if nl == nil {
+		nl = make([]uint32, 0)
+	}
+	return nl, sec.sz, nil
 }
 
 func (d *indexData) readDocSections(i uint32, buf []DocumentSection) ([]DocumentSection, uint32, error) {

--- a/score.go
+++ b/score.go
@@ -15,31 +15,252 @@
 package zoekt
 
 import (
+	"bytes"
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
+
+	"github.com/sourcegraph/zoekt/ctags"
 )
 
 const (
-	maxUInt16   = 0xffff
 	ScoreOffset = 10_000_000
 )
 
-// addScore increments the score of the FileMatch by the computed score. If
-// debugScore is true, it also adds a debug string to the FileMatch. If raw is
-// -1, it is ignored. Otherwise, it is added to the debug string.
-func (m *FileMatch) addScore(what string, computed float64, raw float64, debugScore bool) {
-	if computed != 0 && debugScore {
-		var b strings.Builder
-		fmt.Fprintf(&b, "%s", what)
-		if raw != -1 {
-			fmt.Fprintf(&b, "(%s)", strconv.FormatFloat(raw, 'f', -1, 64))
+type chunkScore struct {
+	score      float64
+	debugScore string
+	bestLine   int
+}
+
+// scoreChunk calculates the score for each line in the chunk based on its candidate matches, and returns the score of
+// the best-scoring line, along with its line number.
+// Invariant: there should be at least one input candidate, len(ms) > 0.
+func (p *contentProvider) scoreChunk(ms []*candidateMatch, language string, opts *SearchOptions) (chunkScore, []*Symbol) {
+	nl := p.newlines()
+
+	var bestScore lineScore
+	bestLine := 0
+	var symbolInfo []*Symbol
+
+	start := 0
+	currentLine := -1
+	for i, m := range ms {
+		lineNumber := -1
+		if !m.fileName {
+			lineNumber = nl.atOffset(m.byteOffset)
 		}
-		fmt.Fprintf(&b, ":%.2f, ", computed)
-		m.Debug += b.String()
+
+		// If this match represents a new line, then score the previous line and update 'start'.
+		if i != 0 && lineNumber != currentLine {
+			score, si := p.scoreLine(ms[start:i], language, currentLine, opts)
+			symbolInfo = append(symbolInfo, si...)
+			if score.score > bestScore.score {
+				bestScore = score
+				bestLine = currentLine
+			}
+			start = i
+		}
+		currentLine = lineNumber
 	}
-	m.Score += computed
+
+	// Make sure to score the last line
+	line, si := p.scoreLine(ms[start:], language, currentLine, opts)
+	symbolInfo = append(symbolInfo, si...)
+	if line.score > bestScore.score {
+		bestScore = line
+		bestLine = currentLine
+	}
+
+	cs := chunkScore{
+		score:    bestScore.score,
+		bestLine: bestLine,
+	}
+	if opts.DebugScore {
+		cs.debugScore = fmt.Sprintf("%s, (line: %d)", bestScore.debugScore, bestLine)
+	}
+	return cs, symbolInfo
+}
+
+type lineScore struct {
+	score      float64
+	debugScore string
+}
+
+// scoreLine calculates a score for the line based on its candidate matches.
+// Invariants:
+// - All candidate matches are assumed to come from the same line in the content.
+// - If this line represents a filename, then lineNumber must be -1.
+// - There should be at least one input candidate, len(ms) > 0.
+func (p *contentProvider) scoreLine(ms []*candidateMatch, language string, lineNumber int, opts *SearchOptions) (lineScore, []*Symbol) {
+	if opts.UseBM25Scoring {
+		score, symbolInfo := p.scoreLineBM25(ms, lineNumber)
+		ls := lineScore{score: score}
+		if opts.DebugScore {
+			ls.debugScore = fmt.Sprintf("tfScore:%.2f, ", score)
+		}
+		return ls, symbolInfo
+	}
+
+	score := 0.0
+	what := ""
+	addScore := func(w string, s float64) {
+		if s != 0 && opts.DebugScore {
+			what += fmt.Sprintf("%s:%.2f, ", w, s)
+		}
+		score += s
+	}
+
+	filename := p.data(true)
+	var symbolInfo []*Symbol
+
+	var bestLine lineScore
+	for i, m := range ms {
+		data := p.data(m.fileName)
+
+		endOffset := m.byteOffset + m.byteMatchSz
+		startBoundary := m.byteOffset < uint32(len(data)) && (m.byteOffset == 0 || byteClass(data[m.byteOffset-1]) != byteClass(data[m.byteOffset]))
+		endBoundary := endOffset > 0 && (endOffset == uint32(len(data)) || byteClass(data[endOffset-1]) != byteClass(data[endOffset]))
+
+		score = 0
+		what = ""
+
+		if startBoundary && endBoundary {
+			addScore("WordMatch", scoreWordMatch)
+		} else if startBoundary || endBoundary {
+			addScore("PartialWordMatch", scorePartialWordMatch)
+		}
+
+		if m.fileName {
+			sep := bytes.LastIndexByte(data, '/')
+			startMatch := int(m.byteOffset) == sep+1
+			endMatch := endOffset == uint32(len(data))
+			if startMatch && endMatch {
+				addScore("Base", scoreBase)
+			} else if startMatch || endMatch {
+				addScore("EdgeBase", (scoreBase+scorePartialBase)/2)
+			} else if sep < int(m.byteOffset) {
+				addScore("InnerBase", scorePartialBase)
+			}
+		} else if sec, si, ok := p.findSymbol(m); ok {
+			startMatch := sec.Start == m.byteOffset
+			endMatch := sec.End == endOffset
+			if startMatch && endMatch {
+				addScore("Symbol", scoreSymbol)
+			} else if startMatch || endMatch {
+				addScore("EdgeSymbol", (scoreSymbol+scorePartialSymbol)/2)
+			} else {
+				addScore("OverlapSymbol", scorePartialSymbol)
+			}
+
+			// Score based on symbol data
+			if si != nil {
+				symbolKind := ctags.ParseSymbolKind(si.Kind)
+				sym := sectionSlice(data, sec)
+
+				addScore(fmt.Sprintf("kind:%s:%s", language, si.Kind), scoreSymbolKind(language, filename, sym, symbolKind))
+
+				// This is from a symbol tree, so we need to store the symbol
+				// information.
+				if m.symbol {
+					if symbolInfo == nil {
+						symbolInfo = make([]*Symbol, len(ms))
+					}
+					// findSymbols does not hydrate in Sym. So we need to store it.
+					si.Sym = string(sym)
+					symbolInfo[i] = si
+				}
+			}
+		}
+
+		// scoreWeight != 1 means it affects score
+		if !epsilonEqualsOne(m.scoreWeight) {
+			score = score * m.scoreWeight
+			if opts.DebugScore {
+				what += fmt.Sprintf("boost:%.2f, ", m.scoreWeight)
+			}
+		}
+
+		if score > bestLine.score {
+			bestLine.score = score
+			bestLine.debugScore = what
+		}
+	}
+
+	if opts.DebugScore {
+		bestLine.debugScore = fmt.Sprintf("score:%.2f <- %s", bestLine.score, strings.TrimSuffix(bestLine.debugScore, ", "))
+	}
+
+	return bestLine, symbolInfo
+}
+
+// scoreLineBM25 computes the score of a line according to BM25, the most common scoring algorithm for text search:
+// https://en.wikipedia.org/wiki/Okapi_BM25. Compared to the standard scoreLine algorithm, this score rewards multiple
+// term matches on a line.
+// Notes:
+// - This BM25 calculation skips inverse document frequency (idf) to keep the implementation simple.
+// - It uses the same calculateTermFrequency method as BM25 file scoring, which boosts filename and symbol matches.
+func (p *contentProvider) scoreLineBM25(ms []*candidateMatch, lineNumber int) (float64, []*Symbol) {
+	// If this is a filename, then don't compute BM25. The score would not be comparable to line scores.
+	if lineNumber < 0 {
+		return 0, nil
+	}
+
+	// Use standard parameter defaults used in Lucene (https://lucene.apache.org/core/10_1_0/core/org/apache/lucene/search/similarities/BM25Similarity.html)
+	k, b := 1.2, 0.75
+
+	// Calculate the length ratio of this line. As a heuristic, we assume an average line length of 100 characters.
+	// Usually the calculation would be based on terms, but using bytes should work fine, as we're just computing a ratio.
+	data := p.data(false)
+	nl := p.newlines()
+	lineLength := len(nl.getLines(data, lineNumber, lineNumber+1))
+	L := float64(lineLength) / 100.0
+
+	score := 0.0
+	tfs := p.calculateTermFrequency(ms, termDocumentFrequency{})
+	for _, f := range tfs {
+		score += ((k + 1.0) * float64(f)) / (k*(1.0-b+b*L) + float64(f))
+	}
+
+	// Check if any match comes from a symbol match tree, and if so hydrate in symbol information
+	var symbolInfo []*Symbol
+	for _, m := range ms {
+		if m.symbol {
+			if sec, si, ok := p.findSymbol(m); ok && si != nil {
+				// findSymbols does not hydrate in Sym. So we need to store it.
+				sym := sectionSlice(data, sec)
+				si.Sym = string(sym)
+				symbolInfo = append(symbolInfo, si)
+			}
+		}
+	}
+	return score, symbolInfo
+}
+
+// termDocumentFrequency is a map "term" -> "number of documents that contain the term"
+type termDocumentFrequency map[string]int
+
+// calculateTermFrequency computes the term frequency for the file match.
+// Notes:
+// - Filename matches count more than content matches. This mimics a common text search strategy to 'boost' matches on document titles.
+// - Symbol matches also count more than content matches, to reward matches on symbol definitions.
+func (p *contentProvider) calculateTermFrequency(cands []*candidateMatch, df termDocumentFrequency) map[string]int {
+	// Treat each candidate match as a term and compute the frequencies. For now, ignore case sensitivity and
+	// ignore whether the match is a word boundary.
+	termFreqs := map[string]int{}
+	for _, m := range cands {
+		term := string(m.substrLowered)
+		if m.fileName || p.matchesSymbol(m) {
+			termFreqs[term] += 5
+		} else {
+			termFreqs[term]++
+		}
+	}
+
+	for term := range termFreqs {
+		df[term] += 1
+	}
+	return termFreqs
 }
 
 // scoreFile computes a score for the file match using various scoring signals, like
@@ -110,30 +331,20 @@ func (d *indexData) scoreFile(fileMatch *FileMatch, doc uint32, mt matchTree, kn
 	}
 }
 
-// idf computes the inverse document frequency for a term. nq is the number of
-// documents that contain the term and documentCount is the total number of
-// documents in the corpus.
-func idf(nq, documentCount int) float64 {
-	return math.Log(1.0 + ((float64(documentCount) - float64(nq) + 0.5) / (float64(nq) + 0.5)))
-}
-
-// termDocumentFrequency is a map "term" -> "number of documents that contain the term"
-type termDocumentFrequency map[string]int
-
 // termFrequency stores the term frequencies for doc.
 type termFrequency struct {
 	doc uint32
 	tf  map[string]int
 }
 
-// scoreFilesUsingBM25 computes the score according to BM25, the most common
-// scoring algorithm for text search: https://en.wikipedia.org/wiki/Okapi_BM25.
+// scoreFilesUsingBM25 computes the score according to BM25, the most common scoring algorithm for text search:
+// https://en.wikipedia.org/wiki/Okapi_BM25.
 //
-// This scoring strategy ignores all other signals including document ranks.
-// This keeps things simple for now, since BM25 is not normalized and can be
-// tricky to combine with other scoring signals.
+// Unlike standard file scoring, this scoring strategy ignores all other signals including document ranks. This keeps
+// things simple for now, since BM25 is not normalized and can be  tricky to combine with other scoring signals. It also
+// ignores the individual LineMatch and ChunkMatch scores, instead calculating a score over all matches in the file.
 func (d *indexData) scoreFilesUsingBM25(fileMatches []FileMatch, tfs []termFrequency, df termDocumentFrequency, opts *SearchOptions) {
-	// Use standard parameter defaults (used in Lucene and academic papers)
+	// Use standard parameter defaults used in Lucene (https://lucene.apache.org/core/10_1_0/core/org/apache/lucene/search/similarities/BM25Similarity.html)
 	k, b := 1.2, 0.75
 
 	averageFileLength := float64(d.boundaries[d.numDocs()]) / float64(d.numDocs())
@@ -165,4 +376,11 @@ func (d *indexData) scoreFilesUsingBM25(fileMatches []FileMatch, tfs []termFrequ
 			fileMatches[i].Debug = fmt.Sprintf("bm25-score: %.2f <- sum-termFrequencies: %d, length-ratio: %.2f", score, sumTF, L)
 		}
 	}
+}
+
+// idf computes the inverse document frequency for a term. nq is the number of
+// documents that contain the term and documentCount is the total number of
+// documents in the corpus.
+func idf(nq, documentCount int) float64 {
+	return math.Log(1.0 + ((float64(documentCount) - float64(nq) + 0.5) / (float64(nq) + 0.5)))
 }


### PR DESCRIPTION
Currently, BM25 scoring only applies to the overall `FileMatch` score. The algorithm gathered term frequencies from all candidate matches in the file to produce a file-level score. However `LineMatch` and `ChunkMatch` scores were still calculated using the classic Zoekt scoring algorithm.

This PR implements BM25 scoring for `LineMatch` and `ChunkMatch`. It does so by calculating a BM25 per line. Compared to the classic Zoekt algorithm, this rewards multiple term matches on a line. Because our term frequency calculation also boosts symbol matches, the score smoothly balances between "many term matches" and "interesting term matches".

Now, the code is structured as follows:
* `scoreChunk`: goes through each line in the chunk, calculating its score through `scoreLine`, and returns the best-scoring line
* `scoreLine`: calculates the score for a single line

The mental model is that "the score of a chunk is always the score of its best line".

Closes SPLF-759