### PR TITLE
all: consistently use cpu_profile as flag name

### DIFF
--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -46,7 +46,7 @@ func run() int {
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
 	languageMap := flag.String("language_map", "", "a mapping between a language and its ctags processor (a:0,b:3).")
 
-	cpuProfile := flag.String("cpuprofile", "", "write cpu profile to `file`")
+	cpuProfile := flag.String("cpu_profile", "", "write cpu profile to `file`")
 
 	flag.Parse()
 

--- a/cmd/zoekt-test/main.go
+++ b/cmd/zoekt-test/main.go
@@ -170,8 +170,8 @@ func compare(dir, patfile string, caseSensitive bool) error {
 }
 
 var (
-	memprofile = flag.String("memprofile", "", "write memory profile to `file`")
-	cpuprofile = flag.String("cpuprofile", "", "write memory profile to `file`")
+	memprofile = flag.String("mem_profile", "", "write memory profile to `file`")
+	cpuprofile = flag.String("cpu_profile", "", "write cpu profile to `file`")
 )
 
 func testLoadIndexDir(indexDir string) {


### PR DESCRIPTION
This is more a workaround since a transitive dependency has introduced a global flag "cpuprofile", leading to a panic due to registring the flag twice.

To make ourselves immune to this issue we can refactor our usages to use a FlagSet, even for "main". This is a bigger and frankly inconvenient change for a somewhat rare occurance. Instead we just rename our flag.

I feel comfortable renaming since this flag should only really be used by Zoekt developers. There will be the issue that the flag will be shown twice for commands, but I will report to the upstream repo about this problem.

Test Plan: go get -u ./... && go run ./cmd/zoekt-git-index works

Fixes https://github.com/sourcegraph/zoekt/issues/893