### PR TITLE
print raw  file

### DIFF
--- a/web/server.go
+++ b/web/server.go
@@ -613,6 +613,12 @@ func (s *Server) servePrintErr(w http.ResponseWriter, r *http.Request) error {
 
 	f := result.Files[0]
 
+	if qvals.Get("format") == "raw" {
+		w.Header().Add("Content-Type", "text/plain")
+		_, _ = w.Write(f.Content)
+		return nil
+	}
+
 	byteLines := bytes.Split(f.Content, []byte{'\n'})
 	strLines := make([]string, 0, len(byteLines))
 	for _, l := range byteLines {

--- a/web/server.go
+++ b/web/server.go
@@ -614,7 +614,8 @@ func (s *Server) servePrintErr(w http.ResponseWriter, r *http.Request) error {
 	f := result.Files[0]
 
 	if qvals.Get("format") == "raw" {
-		w.Header().Add("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		_, _ = w.Write(f.Content)
 		return nil
 	}


### PR DESCRIPTION
When adding a `format=raw` to a request `/print`, we receive the raw Content data file in response