### PR TITLE
Tackle the issue of XML files filtered as binaries in search results

### DIFF
--- a/index/builder.go
+++ b/index/builder.go
@@ -609,7 +609,6 @@ func (b *Builder) Add(doc Document) error {
 		doc.SkipReason = fmt.Sprintf("document size %d larger than limit %d", len(doc.Content), b.opts.SizeMax)
 	} else if err := b.docChecker.Check(doc.Content, b.opts.TrigramMax, allowLargeFile); err != nil {
 		doc.SkipReason = err.Error()
-		doc.Language = "binary"
 	}
 
 	b.todo = append(b.todo, &doc)

--- a/index/shard_builder.go
+++ b/index/shard_builder.go
@@ -412,11 +412,8 @@ func (b *ShardBuilder) Add(doc Document) error {
 
 	if len(doc.Content) > MaxFileSize {
 		doc.SkipReason = fmt.Sprintf("file size %d exceeds maximum size %d", len(doc.Content), MaxFileSize)
-	}
-
-	if idx := bytes.IndexByte(doc.Content, 0); idx >= 0 {
+	} else if idx := bytes.IndexByte(doc.Content, 0); idx >= 0 {
 		doc.SkipReason = fmt.Sprintf("binary content at byte offset %d", idx)
-		doc.Language = "binary"
 	}
 
 	if doc.SkipReason != "" {

--- a/index/shard_builder.go
+++ b/index/shard_builder.go
@@ -412,8 +412,11 @@ func (b *ShardBuilder) Add(doc Document) error {
 
 	if len(doc.Content) > MaxFileSize {
 		doc.SkipReason = fmt.Sprintf("file size %d exceeds maximum size %d", len(doc.Content), MaxFileSize)
-	} else if idx := bytes.IndexByte(doc.Content, 0); idx >= 0 {
+	}
+
+	if idx := bytes.IndexByte(doc.Content, 0); idx >= 0 {
 		doc.SkipReason = fmt.Sprintf("binary content at byte offset %d", idx)
+		doc.Language = "binary"
 	}
 
 	if doc.SkipReason != "" {

--- a/index/shard_builder_test.go
+++ b/index/shard_builder_test.go
@@ -47,3 +47,49 @@ func TestShardName(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineLanguageIfUnknown(t *testing.T) {
+	tests := []struct {
+		name        string
+		doc         Document
+		wantLang    string
+		skipContent bool
+	}{
+		{
+			name: "already has language",
+			doc: Document{
+				Name:     "test.java",
+				Language: "Go",
+				Content:  []byte("package main"),
+			},
+			wantLang: "Go",
+		},
+		{
+			name: "skipped file",
+			doc: Document{
+				Name:       "large.js",
+				SkipReason: "too large",
+				Content:    []byte(notIndexedMarker + "too large"),
+			},
+			wantLang: "JavaScript",
+		},
+		{
+			name: "skipped file with unknown extension",
+			doc: Document{
+				Name:       "deadb33f",
+				SkipReason: "binary",
+				Content:    []byte(notIndexedMarker + "binary"),
+			},
+			wantLang: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			DetermineLanguageIfUnknown(&tt.doc)
+			if tt.doc.Language != tt.wantLang {
+				t.Errorf("DetermineLanguageIfUnknown() got language = %v, want %v", tt.doc.Language, tt.wantLang)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When skipping a doc, we currently report the detected language as "binary" (if it looks like binary) or "skipped" (if it's skipped for any other reason). Skipped docs are still added to the index and can still be returned as search results, for example if you only match on filename. So sometimes file matches are returned with "skipped" as their language, even though the file path is clearly some other language like XML.

This PR updates the indexing logic to still detect the language even if the document is skipped. However, we avoid passing the contents to the language detection library to avoid running detection on huge files.

Closes https://linear.app/sourcegraph/issue/SPLF-826/xml-files-filtered-as-binaries-in-search-results

[Test example](https://sourcegraph.test:3443/search?q=context:global+r:%5Egithub%5C.com/rust-lang/stdarch%24+file:%5Ecrates/stdarch-verify/x86-intel%5C.xml&patternType=keyword&sm=0)
[Test example 2](https://sourcegraph.test:3443/search?q=context:global+repo:%5Egithub%5C.com/rust-lang/stdarch%24+file:%5Ecrates/std_detect/src/detect/test_data/linux-artificial-aarch64%5C.auxv%24+&patternType=keyword&sm=0)