### PR TITLE
scoring: remove IDF from BM25 scoring

### DIFF
--- a/internal/e2e/scoring_test.go
+++ b/internal/e2e/scoring_test.go
@@ -79,8 +79,8 @@ func TestBM25(t *testing.T) {
 			query:    &query.Substring{Pattern: "example"},
 			content:  exampleJava,
 			language: "Java",
-			// bm25-score: 0.58 <- sum-termFrequencyScore: 14.00, length-ratio: 1.00
-			wantScore: 0.58,
+			// sum-termFrequencyScore: 14.00, length-ratio: 1.00
+			wantScore: 2.02,
 			// line 5:    private final int exampleField;
 			wantBestLineMatch: 5,
 		}, {
@@ -93,8 +93,8 @@ func TestBM25(t *testing.T) {
 			}},
 			content:  exampleJava,
 			language: "Java",
-			// bm25-score: 1.81 <- sum-termFrequencyScore: 116.00, length-ratio: 1.00
-			wantScore: 1.81,
+			// sum-termFrequencyScore: 116.00, length-ratio: 1.00
+			wantScore: 6.30,
 			// line 54: private static <A, B> B runInnerInterface(InnerInterface<A, B> fn, A a) {
 			wantBestLineMatch: 54,
 		}, {
@@ -106,8 +106,8 @@ func TestBM25(t *testing.T) {
 			}},
 			content:  exampleJava,
 			language: "Java",
-			// bm25-score: 0.96 <- sum-termFrequencies: 12, length-ratio: 1.00
-			wantScore: 0.96,
+			// sum-termFrequencies: 12, length-ratio: 1.00
+			wantScore: 3.33,
 			// line 59: if (System.nanoTime() > System.currentTimeMillis()) {
 			wantBestLineMatch: 59,
 		},
@@ -117,16 +117,16 @@ func TestBM25(t *testing.T) {
 			query:    &query.Substring{Pattern: "java"},
 			content:  exampleJava,
 			language: "Java",
-			// bm25-score: 0.51 <- sum-termFrequencyScore: 5.00, length-ratio: 1.00
-			wantScore: 0.51,
+			// sum-termFrequencyScore: 5.00, length-ratio: 1.00
+			wantScore: 1.77,
 		},
 		{
 			// Matches only on filename, and content is missing
 			fileName: "a/b/c/config.go",
 			query:    &query.Substring{Pattern: "config.go"},
 			language: "Go",
-			// bm25-score: 0.60 <- sum-termFrequencyScore: 5.00, length-ratio: 0.00
-			wantScore: 0.60,
+			// sum-termFrequencyScore: 5.00, length-ratio: 0.00
+			wantScore: 2.07,
 		},
 	}
 


### PR DESCRIPTION
We remove IDF from our BM25 scoring, effectively treating it as constant. 

This is supported by our evaluations which showed that for keyword style queries, IDF can down-weight the score of important keywords too much, leading to a worse ranking. The intuition is that for code search, each keyword is important independently of how frequent it appears in the corpus.

Removing IDF allows us to apply BM25 scoring to a wider range of query types. Previously, BM25 was limited to queries with individual terms combined using OR, as IDF was calculated on the fly at query time.

Test plan:
updated tests