### PR TITLE
Correct the compound shards metric

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1235,7 +1235,7 @@ func setShardsCounter(indexDir string) {
 			compoundFns = append(compoundFns, fn)
 		}
 	}
-	metricNumberCompoundShards.Set(float64(len(fns)))
+	metricNumberCompoundShards.Set(float64(len(compoundFns)))
 }
 
 func rootCmd() *ffcli.Command {


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/sourcegraph/zoekt/pull/891.