### PR TITLE
support both classical nix and flakes

### DIFF
--- a/ctag-overlay.nix
+++ b/ctag-overlay.nix
@@ -1,0 +1,17 @@
+self: super: rec {
+  my-universal-ctags = super.universal-ctags.overrideAttrs (old: rec {
+    version = "6.1.0";
+    src = super.fetchFromGitHub {
+      owner = "universal-ctags";
+      repo = "ctags";
+      rev = "v${version}";
+      sha256 = "sha256-f8+Ifjn7bhSYozOy7kn+zCLdHGrH3iFupHUZEGynz9Y=";
+    };
+    # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
+    doCheck = false;
+    checkFlags = [ ];
+  });
+
+  # Skip building if same ctags version as registry
+  universal-ctags = if super.universal-ctags.version == my-universal-ctags.version then super.universal-ctags else my-universal-ctags;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,22 +16,7 @@
           overlays = [ self.overlays.ctags ];
         };
       in { default = import ./shell.nix { inherit pkgs; }; });
-    # Pin a specific version of universal-ctags to the same version as in cmd/symbols/ctags-install-alpine.sh.
-    overlays.ctags = self: super: rec {
-      my-universal-ctags = super.universal-ctags.overrideAttrs (old: rec {
-        version = "6.1.0";
-        src = super.fetchFromGitHub {
-          owner = "universal-ctags";
-          repo = "ctags";
-          rev = "v${version}";
-          sha256 = "sha256-f8+Ifjn7bhSYozOy7kn+zCLdHGrH3iFupHUZEGynz9Y=";
-        };
-        # disable checks, else we get `make[1]: *** No rule to make target 'optlib/cmake.c'.  Stop.`
-        doCheck = false;
-        checkFlags = [ ];
-      });
-      # Skip building if same ctags version as registry
-      universal-ctags = if super.universal-ctags.version == my-universal-ctags.version then super.universal-ctags else my-universal-ctags;
-    };
+    # Pin a specific version of universal-ctags to the same version as in ./install-ctags-alpine.sh.
+    overlays.ctags = import ./ctag-overlay.nix;
   };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,8 @@
-{ pkgs }:
+{ pkgs ? import <nixpkgs> {
+  overlays = [
+    (import ./ctag-overlay.nix)
+  ];
+}}:
 let
   # pkgs.universal-ctags installs the binary as "ctags", not "universal-ctags"
   # like zoekt expects.


### PR DESCRIPTION
`{ pkgs }:` means the `shell.nix` file expects to be called with an already initialized version of nixpkgs, which is not the case when using the `nix-shell` command. The flake.nix / `nix develop` avoids this by passing an already initialized version.
This change makes the `shell.nix` check if its caller is calling it with a pkgs attribute and if that's not the case it just imports pkgs from the nixpkgs channel.