### PR TITLE
ranking: add phrase boosting to BM25

### DIFF
--- a/index/eval.go
+++ b/index/eval.go
@@ -316,8 +316,7 @@ nextFileMatch:
 		}
 
 		if opts.UseBM25Scoring {
-			tf := cp.calculateTermFrequency(finalCands)
-			d.scoreFilesUsingBM25(&fileMatch, nextDoc, tf, opts)
+			d.scoreFilesUsingBM25(&fileMatch, nextDoc, finalCands, cp, opts)
 		} else {
 			// Use the standard, non-experimental scoring method by default
 			d.scoreFile(&fileMatch, nextDoc, mt, known, opts)

--- a/index/score.go
+++ b/index/score.go
@@ -226,9 +226,9 @@ func (p *contentProvider) scoreLineBM25(ms []*candidateMatch, lineNumber int) (f
 	var symbolInfo []*zoekt.Symbol
 	for _, m := range ms {
 		// In addition to boosting the term frequency, we adjust the final score to
-		// ensure that exact phrases matches get a high line score. This is necessary,
+		// ensure that exact phrase matches get a high line score. Thissymotion-prefix)g is necessary,
 		// because phrases are often the only match on a line and a term's contribution
-		// is limited by (k+1) and quickly saturates with increasing frequency.
+		// is limited by (k+1) and quickly saturates with term increasing frequency.
 		if !epsilonEqualsOne(m.scoreWeight) {
 			score = score * m.scoreWeight
 		}

--- a/index/score.go
+++ b/index/score.go
@@ -223,8 +223,7 @@ func (p *contentProvider) scoreLineBM25(ms []*candidateMatch, lineNumber int) (f
 		score += tfScore(k, b, L, f)
 	}
 
-	// Check if any index comes from a symbol match tree, and if so hydrate in
-	// symbol information
+	// Check if any index comes from a symbol match tree, and if so hydrate in symbol information
 	var symbolInfo []*zoekt.Symbol
 	for _, m := range ms {
 		if m.symbol {

--- a/internal/e2e/scoring_test.go
+++ b/internal/e2e/scoring_test.go
@@ -110,6 +110,23 @@ func TestBM25(t *testing.T) {
 			wantScore: 3.33,
 			// line 59: if (System.nanoTime() > System.currentTimeMillis()) {
 			wantBestLineMatch: 59,
+		}, {
+			// phrase boosting
+			fileName: "example.java",
+			query: &query.Or{Children: []query.Q{
+				&query.Boost{Child: &query.Substring{Pattern: "public string apply"}, Boost: 20},
+				&query.And{Children: []query.Q{
+					&query.Substring{Pattern: "public"},
+					&query.Substring{Pattern: "string"},
+					&query.Substring{Pattern: "apply"},
+				}},
+			}},
+			content:  exampleJava,
+			language: "Java",
+			// sum-termFrequencies: 12, length-ratio: 1.00
+			wantScore: 7.81,
+			// public String apply(String s) {
+			wantBestLineMatch: 81,
 		},
 		{
 			// Matches only on filename

--- a/internal/e2e/scoring_test.go
+++ b/internal/e2e/scoring_test.go
@@ -123,7 +123,7 @@ func TestBM25(t *testing.T) {
 			}},
 			content:  exampleJava,
 			language: "Java",
-			// sum-termFrequencies: 12, length-ratio: 1.00
+			// sum-termFrequencies: 44, length-ratio: 1.00
 			wantScore: 7.81,
 			// public String apply(String s) {
 			wantBestLineMatch: 81,

--- a/internal/e2e/scoring_test.go
+++ b/internal/e2e/scoring_test.go
@@ -123,8 +123,8 @@ func TestBM25(t *testing.T) {
 			}},
 			content:  exampleJava,
 			language: "Java",
-			// sum-termFrequencies: 44, length-ratio: 1.00
-			wantScore: 7.81,
+			// sum-termFrequencies: sum-termFrequencies: 40, length-ratio: 1.00
+			wantScore: 140.80,
 			// public String apply(String s) {
 			wantBestLineMatch: 81,
 		},


### PR DESCRIPTION
Relates to SPLF-838

With this change we recognize boosted queries in our BM25 scoring and adjust the overall score accordingly.

We need to take care of 2 parts: The overall BM25 score of the document, and the line score determining the order in which we return the chunks.

Test plan:
- new scoring test
- Evaluations look good. I will post them in the ticket