### PR TITLE
sourcegraph-indexserver: GRPC, implement DeleteAllData

### DIFF
--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -8,10 +8,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/index"
 	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMerge(t *testing.T) {
@@ -62,7 +64,7 @@ func TestExplode(t *testing.T) {
 
 	cs, err := filepath.Glob(filepath.Join(dir, "compound-*.zoekt"))
 	require.NoError(t, err)
-	err = explode(dir, cs[0])
+	err = index.Explode(dir, cs[0])
 	require.NoError(t, err)
 
 	cs, err = filepath.Glob(filepath.Join(dir, "compound-*.zoekt"))

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1074,6 +1074,7 @@ func (s *Server) DeleteAllData(ctx context.Context, _ *indexserverv1.DeleteAllDa
 
 			err := cmd.Run()
 			if err != nil {
+				errorLog.Printf("explode failed: %v (stderr: %s)", err, stderrBuf.String())
 				return err
 			}
 

--- a/cmd/zoekt-sourcegraph-indexserver/purge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/purge.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/multierr"
+
+	"github.com/sourcegraph/zoekt/index"
+	"github.com/sourcegraph/zoekt/internal/tenant"
+)
+
+// purgeTenantShards removes all shards from dir on a best-effort basis.  It
+// returns an error if there is no tenant in the context or if it encounters an
+// error while removing a shard.
+func purgeTenantShards(ctx context.Context, dir string) error {
+	tnt, err := tenant.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+
+	var merr error
+	for _, n := range names {
+		path := filepath.Join(dir, n)
+		fi, err := os.Stat(path)
+		if err != nil {
+			merr = multierr.Append(merr, err)
+			continue
+		}
+		if fi.IsDir() || filepath.Ext(path) != ".zoekt" {
+			continue
+		}
+
+		// Skip compound shards. We assume shard merging is disabled for
+		// multi-tenant instances.
+		if strings.HasPrefix(filepath.Base(path), "compound-") {
+			continue
+		}
+
+		repos, _, err := index.ReadMetadataPath(path)
+		if err != nil {
+			merr = multierr.Append(merr, err)
+			continue
+		}
+		// Since we excluded compound shards, we know there is exactly one repo
+		if repos[0].TenantID == tnt.ID() {
+			paths, err := index.IndexFilePaths(path)
+			if err != nil {
+				merr = multierr.Append(merr, err)
+				continue
+			}
+			for _, p := range paths {
+				if err := os.Remove(p); err != nil {
+					merr = multierr.Append(merr, err)
+				}
+			}
+		}
+	}
+
+	return merr
+}

--- a/cmd/zoekt-sourcegraph-indexserver/purge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/purge.go
@@ -12,9 +12,9 @@ import (
 	"github.com/sourcegraph/zoekt/internal/tenant"
 )
 
-// purgeTenantShards removes all shards from dir on a best-effort basis.  It
-// returns an error if there is no tenant in the context or if it encounters an
-// error while removing a shard.
+// purgeTenantShards removes all simple shards from dir on a best-effort basis.
+// It returns an error if there is no tenant in the context or if it encounters
+// an error while removing a shard.
 func purgeTenantShards(ctx context.Context, dir string) error {
 	tnt, err := tenant.FromContext(ctx)
 	if err != nil {
@@ -44,8 +44,7 @@ func purgeTenantShards(ctx context.Context, dir string) error {
 			continue
 		}
 
-		// Skip compound shards. We assume shard merging is disabled for
-		// multi-tenant instances.
+		// Skip compound shards.
 		if strings.HasPrefix(filepath.Base(path), "compound-") {
 			continue
 		}

--- a/cmd/zoekt-sourcegraph-indexserver/purge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/purge_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/internal/tenant/tenanttest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPurgeTenantShards(t *testing.T) {
+	// TestPurgeTenantShards verifies both the basic shard purging functionality
+	// and proper isolation between tenants. It ensures that:
+	// 1. Shards are only purged when a valid tenant context is provided
+	// 2. Only shards belonging to the specified tenant are purged
+	// 3. Compound shards are preserved regardless of tenant
+	// 4. Other tenants' shards remain untouched
+	dir := t.TempDir()
+
+	// Create test shards for different tenants
+	tenant1Ctx := tenanttest.NewTestContext()
+	tenant2Ctx := tenanttest.NewTestContext()
+
+	// Helper to set tenant ID for test shards
+	setTenantID := func(id int) func(in *zoekt.Repository) {
+		return func(in *zoekt.Repository) {
+			in.TenantID = id
+		}
+	}
+
+	// Create test shards for tenant 1
+	tenant1Shard1 := filepath.Join(dir, "tenant1_repo1.zoekt")
+	tenant1Shard2 := filepath.Join(dir, "tenant1_repo2.zoekt")
+	createTestShard(t, "tenant1_repo1", 1, tenant1Shard1, setTenantID(1))
+	createTestShard(t, "tenant1_repo2", 2, tenant1Shard2, setTenantID(1))
+
+	// Create test shards for tenant 2
+	tenant2Shard := filepath.Join(dir, "tenant2_repo1.zoekt")
+	createTestShard(t, "tenant2_repo1", 3, tenant2Shard, setTenantID(2))
+
+	// Create a compound shard (should be skipped)
+	compoundShard := filepath.Join(dir, "compound-1234.zoekt")
+	createTestShard(t, "compound_repo", 4, compoundShard, setTenantID(1))
+
+	// Test cases
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		wantErr bool
+		check   func(t *testing.T, dir string)
+	}{
+		{
+			name:    "no tenant in context",
+			ctx:     context.Background(),
+			wantErr: true,
+			check: func(t *testing.T, dir string) {
+				// All files should still exist
+				require.FileExists(t, tenant1Shard1)
+				require.FileExists(t, tenant1Shard2)
+				require.FileExists(t, tenant2Shard)
+				require.FileExists(t, compoundShard)
+			},
+		},
+		{
+			name: "purge tenant 1 shards",
+			ctx:  tenant1Ctx,
+			check: func(t *testing.T, dir string) {
+				// Tenant 1 shards should be deleted
+				require.NoFileExists(t, tenant1Shard1)
+				require.NoFileExists(t, tenant1Shard2)
+				// Other shards should still exist
+				require.FileExists(t, tenant2Shard)
+				require.FileExists(t, compoundShard)
+			},
+		},
+		{
+			name: "purge tenant 2 shards",
+			ctx:  tenant2Ctx,
+			check: func(t *testing.T, dir string) {
+				// Tenant 2 shard should be deleted
+				require.NoFileExists(t, tenant2Shard)
+				// Compound shard should still exist
+				require.FileExists(t, compoundShard)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := purgeTenantShards(tt.ctx, dir)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			tt.check(t, dir)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -130,7 +130,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/otel/metric v1.33.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/text v0.21.0 // indirect


### PR DESCRIPTION
Relates to #920
Relates to SPLF-874

This implements `DeleteAllData`. We hold the global lock while deleting all simple shards belonging to a tenant. We also handle compound shards by disassembling them first. 

Note that this "only" deletes persisted data. Updating the queue, for example, seems fragile because it might immediately get updated by Sourcegraph. This implies that Sourcegraph first has to delete the tenant in the Sourcegraph DB first and then call this new endpoint. Even if the queue still has a reference to a deleted tenant, indexserver won't be able to retrieve index options or clone the repo from gitserver.

Test plan: 
- new unit tests
- manual testing
  - I ran this together with Sourcegraph and triggered a delete by calling `DeleteAllData` directly. I confirmed that all shards, including compound shards are deleted.