### PR TITLE
fix empty branch names getting returned by using uint64 id

### DIFF
--- a/index/eval.go
+++ b/index/eval.go
@@ -498,7 +498,7 @@ func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTr
 	}
 
 	var branches []string
-	id := uint32(1)
+	id := uint64(1)
 	branchNames := d.branchNames[d.repos[docID]]
 	for mask != 0 {
 		if mask&0x1 != 0 {


### PR DESCRIPTION
Hi Zoekt-Team,

I would like to contribute a fix for empty branch names getting returned when there are more than 32 branches in a result. The gatherBranches() function shifts a mask of type uint64 until it is 0, but uses an id for accessing a map of type uint32. This results in empty branch names getting returned from this function. It can be fixed by changing the type of id to also be uint64.

Regards,
Daniel