### PR TITLE
Move shards package to root and rename to 'search'

### DIFF
--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/sourcegraph/zoekt/search"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
 )
 
@@ -32,7 +32,7 @@ func TestMerge(t *testing.T) {
 	// stable
 	require.Equal(t, filepath.Base(cs), "compound-ea9613e2ffba7d7361856aebfca75fb714856509_v17.00000.zoekt")
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	require.NoError(t, err)
 	defer ss.Close()
 
@@ -81,7 +81,7 @@ func TestExplode(t *testing.T) {
 		t.Fatalf("the number of simple shards before %d and after %d should be the same", len(testShards), len(exploded))
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	require.NoError(t, err)
 	defer ss.Close()
 

--- a/cmd/zoekt-test/main.go
+++ b/cmd/zoekt-test/main.go
@@ -33,8 +33,8 @@ import (
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 func readTree(dir string) (map[string][]byte, error) {
@@ -107,7 +107,7 @@ func compare(dir, patfile string, caseSensitive bool) error {
 	if err != nil {
 		return err
 	}
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func testLoadIndexDir(indexDir string) {
 	runtime.GC()
 	runtime.ReadMemStats(&a)
 	start := time.Now()
-	s, err := shards.NewDirectorySearcher(indexDir)
+	s, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		return
 	}

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -56,10 +56,10 @@ import (
 	"github.com/sourcegraph/zoekt/index"
 	"github.com/sourcegraph/zoekt/internal/debugserver"
 	"github.com/sourcegraph/zoekt/internal/profiler"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/internal/trace"
 	"github.com/sourcegraph/zoekt/internal/tracer"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 	"github.com/sourcegraph/zoekt/web"
 )
 
@@ -203,7 +203,7 @@ func main() {
 	// Do not block on loading shards so we can become partially available
 	// sooner. Otherwise on large instances zoekt can be unavailable on the
 	// order of minutes.
-	searcher, err := shards.NewDirectorySearcherFast(*indexDir)
+	searcher, err := search.NewDirectorySearcherFast(*indexDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/zoekt/main.go
+++ b/cmd/zoekt/main.go
@@ -31,8 +31,8 @@ import (
 	"github.com/felixge/fgprof"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 func displayMatches(files []zoekt.FileMatch, pat string, withRepo bool, list bool) {
@@ -191,7 +191,7 @@ func main() {
 	if *shard != "" {
 		searcher, err = loadShard(*shard, *verbose)
 	} else {
-		searcher, err = shards.NewDirectorySearcher(*index)
+		searcher, err = search.NewDirectorySearcher(*index)
 	}
 
 	if err != nil {

--- a/internal/archive/e2e_test.go
+++ b/internal/archive/e2e_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 	"github.com/stretchr/testify/require"
 )
 
@@ -178,7 +178,7 @@ func testIndexIncrementally(t *testing.T, format string) {
 			t.Fatalf("error creating index: %v", err)
 		}
 
-		ss, err := shards.NewDirectorySearcher(indexDir)
+		ss, err := search.NewDirectorySearcher(indexDir)
 		if err != nil {
 			t.Fatalf("NewDirectorySearcher(%s): %v", indexDir, err)
 		}

--- a/internal/e2e/e2e_index_test.go
+++ b/internal/e2e/e2e_index_test.go
@@ -34,10 +34,10 @@ import (
 	"github.com/grafana/regexp"
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/internal/tenant"
 	"github.com/sourcegraph/zoekt/internal/tenant/tenanttest"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,7 +92,7 @@ func TestBasicIndexing(t *testing.T) {
 		}
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -215,7 +215,7 @@ func TestSearchTenant(t *testing.T) {
 		}
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -271,7 +271,7 @@ func TestListTenant(t *testing.T) {
 		t.Fatalf("want a shard, got %v", fs)
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -359,7 +359,7 @@ func TestLargeFileOption(t *testing.T) {
 		t.Errorf("Finish: %v", err)
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -406,7 +406,7 @@ func TestUpdate(t *testing.T) {
 			t.Errorf("Finish: %v", err)
 		}
 	}
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -582,7 +582,7 @@ func TestEmptyContent(t *testing.T) {
 		t.Fatalf("want a shard, got %v", fs)
 	}
 
-	ss, err := shards.NewDirectorySearcher(dir)
+	ss, err := search.NewDirectorySearcher(dir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 	}
@@ -767,7 +767,7 @@ func TestDeltaShards(t *testing.T) {
 					t.Errorf("unexpected diff in index state (-want +got):\n%s", diff)
 				}
 
-				ss, err := shards.NewDirectorySearcher(indexDir)
+				ss, err := search.NewDirectorySearcher(indexDir)
 				if err != nil {
 					t.Fatalf("step %q: NewDirectorySearcher(%s): %s", step.name, indexDir, err)
 				}

--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
 	"github.com/sourcegraph/zoekt/internal/archive"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 var update = flag.Bool("update", false, "update golden file")
@@ -96,7 +96,7 @@ func TestRanking(t *testing.T) {
 		}
 	}
 
-	ss, err := shards.NewDirectorySearcher(indexDir)
+	ss, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatalf("NewDirectorySearcher(%s): %v", indexDir, err)
 	}

--- a/internal/e2e/scoring_test.go
+++ b/internal/e2e/scoring_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
 	"github.com/sourcegraph/zoekt/internal/ctags"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 type scoreCase struct {
@@ -709,7 +709,7 @@ func checkScoring(t *testing.T, c scoreCase, useBM25 bool, parserType ctags.CTag
 			t.Fatalf("Finish: %v", err)
 		}
 
-		ss, err := shards.NewDirectorySearcher(dir)
+		ss, err := search.NewDirectorySearcher(dir)
 		if err != nil {
 			t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 		}
@@ -818,7 +818,7 @@ func TestRepoRanks(t *testing.T) {
 				t.Fatalf("Finish: %v", err)
 			}
 
-			ss, err := shards.NewDirectorySearcher(dir)
+			ss, err := search.NewDirectorySearcher(dir)
 			if err != nil {
 				t.Fatalf("NewDirectorySearcher(%s): %v", dir, err)
 			}

--- a/internal/gitindex/ignore_test.go
+++ b/internal/gitindex/ignore_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 func createSourcegraphignoreRepo(dir string) error {
@@ -76,7 +76,7 @@ func TestIgnore(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}

--- a/internal/gitindex/index_test.go
+++ b/internal/gitindex/index_test.go
@@ -35,8 +35,8 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/ignore"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 func TestIndexEmptyRepo(t *testing.T) {
@@ -116,7 +116,7 @@ func TestIndexTinyRepo(t *testing.T) {
 			t.Fatalf("unexpected error %v", err)
 		}
 
-		searcher, err := shards.NewDirectorySearcher(dir)
+		searcher, err := search.NewDirectorySearcher(dir)
 		if err != nil {
 			t.Fatal("NewDirectorySearcher", err)
 		}
@@ -724,7 +724,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 					//
 					// then, compare returned set of documents with the expected set for the step and see if they agree
 
-					ss, err := shards.NewDirectorySearcher(indexDir)
+					ss, err := search.NewDirectorySearcher(indexDir)
 					if err != nil {
 						t.Fatalf("NewDirectorySearcher(%s): %s", indexDir, err)
 					}

--- a/internal/gitindex/tree_test.go
+++ b/internal/gitindex/tree_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/ignore"
 	"github.com/sourcegraph/zoekt/index"
-	"github.com/sourcegraph/zoekt/internal/shards"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
 )
 
 func createSubmoduleRepo(dir string) error {
@@ -218,7 +218,7 @@ func TestSubmoduleIndex(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}
@@ -322,7 +322,7 @@ func TestSearchSymlinkByContent(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}
@@ -449,7 +449,7 @@ func TestBranchWildcard(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}
@@ -528,7 +528,7 @@ func TestFullAndShortRefNames(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}
@@ -578,7 +578,7 @@ func TestLatestCommit(t *testing.T) {
 		t.Fatalf("IndexGitRepo: %v", err)
 	}
 
-	searcher, err := shards.NewDirectorySearcher(indexDir)
+	searcher, err := search.NewDirectorySearcher(indexDir)
 	if err != nil {
 		t.Fatal("NewDirectorySearcher", err)
 	}

--- a/search/aggregate.go
+++ b/search/aggregate.go
@@ -1,11 +1,10 @@
-package shards
+package search
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
-
-	"maps"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"

--- a/search/eval.go
+++ b/search/eval.go
@@ -1,4 +1,4 @@
-package shards
+package search
 
 import (
 	"context"

--- a/search/eval_test.go
+++ b/search/eval_test.go
@@ -1,4 +1,4 @@
-package shards
+package search
 
 import (
 	"context"

--- a/search/sched.go
+++ b/search/sched.go
@@ -1,4 +1,4 @@
-package shards
+package search
 
 import (
 	"context"

--- a/search/sched_test.go
+++ b/search/sched_test.go
@@ -1,4 +1,4 @@
-package shards
+package search
 
 import (
 	"context"

--- a/search/shards.go
+++ b/search/shards.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shards
+package search
 
 import (
 	"context"

--- a/search/shards_test.go
+++ b/search/shards_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shards
+package search
 
 import (
 	"bytes"

--- a/search/watcher.go
+++ b/search/watcher.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shards
+package search
 
 import (
 	"fmt"

--- a/search/watcher_test.go
+++ b/search/watcher_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shards
+package search
 
 import (
 	"fmt"


### PR DESCRIPTION
In https://github.com/sourcegraph/zoekt/pull/901 I moved several packages to 'internal' to clean up the exported API. This PR moves the `shards` package back to root, since it contains important methods like `NewDirectorySearcher`. It also renames the `shards` package to `search` to clarify the usage.

Relates to https://github.com/sourcegraph/zoekt/pull/901#issuecomment-2703171432, https://github.com/sourcegraph/zoekt/discussions/927