### PR TITLE
Fix compilation on 32 bit architectures

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index.go
@@ -115,7 +115,7 @@ func (o *indexArgs) BuildOptions() *index.Options {
 		// nothing needs to be done.
 		RepositoryDescription: zoekt.Repository{
 			TenantID: o.TenantID,
-			ID:       uint32(o.IndexOptions.RepoID),
+			ID:       o.IndexOptions.RepoID,
 			Name:     o.Name,
 			Branches: o.Branches,
 			RawConfig: map[string]string{

--- a/index/bits_test.go
+++ b/index/bits_test.go
@@ -17,13 +17,13 @@ package index
 import (
 	"encoding/binary"
 	"log"
+	"math"
 	"math/rand"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 	"testing/quick"
-
-	"slices"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -99,7 +99,7 @@ func TestNextFileIndex(t *testing.T) {
 		ends         []uint32
 		want         uint32
 	}{
-		{maxUInt32, 0, []uint32{34}, 1},
+		{math.MaxUint32, 0, []uint32{34}, 1},
 		{9, 0, []uint32{34}, 0},
 		{450, 0, []uint32{100, 200, 300, 400, 500, 600}, 4},
 	} {
@@ -150,7 +150,7 @@ func TestCompressedPostingIterator(t *testing.T) {
 
 		var nums []uint32
 		i := newCompressedPostingIterator(data, stringToNGram("abc"))
-		for i.first() != maxUInt32 {
+		for i.first() != math.MaxUint32 {
 			nums = append(nums, i.first())
 			i.next(i.first())
 		}

--- a/index/indexdata.go
+++ b/index/indexdata.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash/crc64"
 	"log"
+	"math"
 	"math/bits"
 	"slices"
 	"unicode/utf8"
@@ -354,12 +355,10 @@ func findSelectiveNgrams(ngramOffs []runeNgramOff, indexMap []int, frequencies [
 	return
 }
 
-const maxUInt32 = 0xffffffff
-
 func minFrequencyNgramOffsets(ngramOffs []runeNgramOff, frequencies []uint32) (first, last runeNgramOff) {
 	// Find the two lowest frequency ngrams.
 	idx0, idx1 := 0, 0
-	min0, min1 := uint32(maxUInt32), uint32(maxUInt32)
+	min0, min1 := uint32(math.MaxUint32), uint32(math.MaxUint32)
 	for i, x := range frequencies {
 		if x <= min0 {
 			idx0, idx1 = i, idx0

--- a/index/indexfile.go
+++ b/index/indexfile.go
@@ -19,6 +19,7 @@ package index
 import (
 	"fmt"
 	"log"
+	"math"
 	"os"
 
 	"golang.org/x/sys/unix"
@@ -62,7 +63,7 @@ func NewIndexFile(f *os.File) (IndexFile, error) {
 	}
 
 	sz := fi.Size()
-	if sz >= maxUInt32 {
+	if sz >= math.MaxUint32 {
 		return nil, fmt.Errorf("file %s too large: %d", f.Name(), sz)
 	}
 	r := &mmapedIndexFile{

--- a/index/matchiter.go
+++ b/index/matchiter.go
@@ -17,6 +17,7 @@ package index
 import (
 	"bytes"
 	"fmt"
+	"math"
 
 	"github.com/sourcegraph/zoekt"
 )
@@ -95,7 +96,7 @@ func (t *noMatchTree) candidates() []*candidateMatch {
 }
 
 func (t *noMatchTree) nextDoc() uint32 {
-	return maxUInt32
+	return math.MaxUint32
 }
 
 func (t *noMatchTree) prepare(uint32) {}
@@ -148,7 +149,7 @@ func nextFileIndex(offset, f uint32, ends []uint32) uint32 {
 func (i *ngramDocIterator) nextDoc() uint32 {
 	i.fileIdx = nextFileIndex(i.iter.first(), i.fileIdx, i.ends)
 	if i.fileIdx >= uint32(len(i.ends)) {
-		return maxUInt32
+		return math.MaxUint32
 	}
 	return i.fileIdx
 }
@@ -190,7 +191,7 @@ func (i *ngramDocIterator) candidates() []*candidateMatch {
 	var candidates []*candidateMatch
 	for {
 		p1 := i.iter.first()
-		if p1 == maxUInt32 || p1 >= i.ends[i.fileIdx] {
+		if p1 == math.MaxUint32 || p1 >= i.ends[i.fileIdx] {
 			break
 		}
 		i.iter.next(p1)

--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math"
 	"regexp/syntax"
 	"strings"
 	"unicode/utf8"
@@ -442,7 +443,7 @@ func (t *docMatchTree) nextDoc() uint32 {
 			return i
 		}
 	}
-	return maxUInt32
+	return math.MaxUint32
 }
 
 func (t *bruteForceMatchTree) nextDoc() uint32 {
@@ -464,7 +465,7 @@ func (t *andMatchTree) nextDoc() uint32 {
 }
 
 func (t *orMatchTree) nextDoc() uint32 {
-	min := uint32(maxUInt32)
+	min := uint32(math.MaxUint32)
 	for _, c := range t.children {
 		m := c.nextDoc()
 		if m < min {
@@ -497,7 +498,7 @@ func (t *branchQueryMatchTree) nextDoc() uint32 {
 			return i
 		}
 	}
-	return maxUInt32
+	return math.MaxUint32
 }
 
 // all String methods
@@ -672,7 +673,7 @@ func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matc
 	// can return MatchesFound.
 
 	// find child with fewest candidates
-	min := maxUInt32
+	minCount := math.MaxInt
 	fewestChildren := 0
 	for ix, child := range t.children {
 		v, ok := child.(*substrMatchTree)
@@ -681,8 +682,8 @@ func (t *andLineMatchTree) matches(cp *contentProvider, cost int, known map[matc
 		if !ok || v.fileName {
 			return matchesFound
 		}
-		if len(v.current) < min {
-			min = len(v.current)
+		if len(v.current) < minCount {
+			minCount = len(v.current)
 			fewestChildren = ix
 		}
 	}

--- a/index/matchtree_test.go
+++ b/index/matchtree_test.go
@@ -15,6 +15,7 @@
 package index
 
 import (
+	"math"
 	"reflect"
 	"regexp/syntax"
 	"testing"
@@ -304,7 +305,7 @@ func TestRepoSet(t *testing.T) {
 		}
 		mt.prepare(nextDoc)
 	}
-	if mt.nextDoc() != maxUInt32 {
+	if mt.nextDoc() != math.MaxUint32 {
 		t.Fatalf("expected %d document, but got at least 1 more", len(want))
 	}
 }
@@ -327,7 +328,7 @@ func TestRepo(t *testing.T) {
 		}
 		mt.prepare(nextDoc)
 	}
-	if mt.nextDoc() != maxUInt32 {
+	if mt.nextDoc() != math.MaxUint32 {
 		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
 	}
 }
@@ -360,7 +361,7 @@ func TestBranchesRepos(t *testing.T) {
 		mt.prepare(nextDoc)
 	}
 
-	if mt.nextDoc() != maxUInt32 {
+	if mt.nextDoc() != math.MaxUint32 {
 		t.Fatalf("expect %d documents, but got at least 1 more", len(want))
 	}
 }
@@ -383,7 +384,7 @@ func TestRepoIDs(t *testing.T) {
 		}
 		mt.prepare(nextDoc)
 	}
-	if mt.nextDoc() != maxUInt32 {
+	if mt.nextDoc() != math.MaxUint32 {
 		t.Fatalf("expected %d document, but got at least 1 more", len(want))
 	}
 }


### PR DESCRIPTION
This PR fixes a bug where Zoekt would not compile on 32-bit architectures. It
also takes the opportunity to start using the `math` library everywhere instead
of our own constants like `maxUInt32` to help prevent this sort of issue in the
future by encouraging devs to select the most accurate "max" type for their
specific situation.

Closes https://github.com/sourcegraph/zoekt/issues/935