### PR TITLE
Simplify `trace.New` method

### DIFF
--- a/internal/trace/opentracing.go
+++ b/internal/trace/opentracing.go
@@ -36,14 +36,3 @@ func GetOpenTracer(ctx context.Context, tracer opentracing.Tracer) opentracing.T
 	}
 	return tracer
 }
-
-// StartSpanFromContext starts a span using the tracer returned by invoking GetOpenTracer with the
-// passed-in tracer.
-func StartSpanFromContextWithTracer(ctx context.Context, tracer opentracing.Tracer, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return opentracing.StartSpanFromContextWithTracer(ctx, GetOpenTracer(ctx, tracer), operationName, opts...)
-}
-
-// StartSpanFromContext starts a span using the tracer returned by GetOpenTracer.
-func StartSpanFromContext(ctx context.Context, operationName string, opts ...opentracing.StartSpanOption) (opentracing.Span, context.Context) {
-	return StartSpanFromContextWithTracer(ctx, GetOpenTracer(ctx, nil), operationName, opts...)
-}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -17,26 +17,14 @@ import (
 	nettrace "golang.org/x/net/trace"
 )
 
-// A Tracer for trace creation, parameterised over an
-// opentracing.Tracer. Use this if you don't want to use
-// the global tracer.
-type Tracer struct {
-	Tracer opentracing.Tracer
-}
-
 func New(ctx context.Context, family, title string) (*Trace, context.Context) {
-	tr := Tracer{Tracer: GetOpenTracer(ctx, nil)}
-	return tr.New(ctx, family, title)
-}
-
-// New returns a new Trace with the specified family and title.
-func (t Tracer) New(ctx context.Context, family, title string) (*Trace, context.Context) {
-	span, ctx := StartSpanFromContextWithTracer(
-		ctx,
-		t.Tracer,
+	tracer := GetOpenTracer(ctx, nil)
+	span, ctx := opentracing.StartSpanFromContextWithTracer(ctx,
+		tracer,
 		family,
 		opentracing.Tag{Key: "title", Value: title},
 	)
+
 	tr := nettrace.New(family, title)
 	trace := &Trace{span: span, trace: tr, family: family}
 	if parent := TraceFromContext(ctx); parent != nil {


### PR DESCRIPTION
Small refactor to simplify the logic in `trace.New`. It inlines a couple public
methods that don't need to be exposed separately.