### PR TITLE
Add README for proto directories

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/grpc/protos/README.md
+++ b/cmd/zoekt-sourcegraph-indexserver/grpc/protos/README.md
@@ -1,0 +1,9 @@
+# Sourcegraph indexserver protobuf definitions
+
+This directory contains protobuf definitions for the indexserver gRPC API.
+
+To generate the Go code, run this script from the repository root:
+
+```sh
+./gen-proto.sh
+```

--- a/cmd/zoekt-sourcegraph-indexserver/grpc/protos/README.md
+++ b/cmd/zoekt-sourcegraph-indexserver/grpc/protos/README.md
@@ -7,3 +7,5 @@ To generate the Go code, run this script from the repository root:
 ```sh
 ./gen-proto.sh
 ```
+
+Note: this script will regenerate all protos in the project, not just the ones in this directory.

--- a/grpc/protos/README.md
+++ b/grpc/protos/README.md
@@ -1,0 +1,9 @@
+# Webserver protobuf definitions
+
+This directory contains protobuf definitions for the webserver gRPC API.
+
+To generate the Go code, run this script from the repository root:
+
+```sh
+./gen-proto.sh
+```

--- a/grpc/protos/README.md
+++ b/grpc/protos/README.md
@@ -7,3 +7,5 @@ To generate the Go code, run this script from the repository root:
 ```sh
 ./gen-proto.sh
 ```
+
+Note: this script will regenerate all protos in the project, not just the ones in this directory.


### PR DESCRIPTION
Somehow I just found out about `gen-proto.sh` recently, after many months of working on Zoekt! This PR adds brief `README` files in the proto directories to guide people (and LLMs) to it.