### PR TITLE
Avoid setting git author name in test

### DIFF
--- a/internal/gitindex/index_test.go
+++ b/internal/gitindex/index_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -135,7 +134,8 @@ func TestIndexTinyRepo(t *testing.T) {
 func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
 	cmd.Dir = dir
 	cmd.Env = []string{
-		"GIT_CONFIG=" + path.Join(dir, ".git", "config"),
+		"GIT_CONFIG_GLOBAL=",
+		"GIT_CONFIG_SYSTEM=",
 		"GIT_COMMITTER_NAME=Kierkegaard",
 		"GIT_COMMITTER_EMAIL=soren@apache.com",
 		"GIT_AUTHOR_NAME=Kierkegaard",

--- a/internal/gitindex/index_test.go
+++ b/internal/gitindex/index_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -133,9 +134,13 @@ func TestIndexTinyRepo(t *testing.T) {
 
 func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_CONFIG_USER_NAME=Soren Kierkegaard",
-		"GIT_CONFIG_USER_EMAIL=soren@apache.com")
+	cmd.Env = []string{
+		"GIT_CONFIG=" + path.Join(dir, ".git", "config"),
+		"GIT_COMMITTER_NAME=Kierkegaard",
+		"GIT_COMMITTER_EMAIL=soren@apache.com",
+		"GIT_AUTHOR_NAME=Kierkegaard",
+		"GIT_AUTHOR_EMAIL=soren@apache.com",
+	}
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("cmd.Run: %v", err)
 	}

--- a/internal/gitindex/index_test.go
+++ b/internal/gitindex/index_test.go
@@ -92,9 +92,6 @@ func TestIndexTinyRepo(t *testing.T) {
 	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
 
 	repoDir := filepath.Join(dir, "repo")
-	executeCommand(t, repoDir, exec.Command("git", "config", "--local", "user.name", "Thomas"))
-	executeCommand(t, repoDir, exec.Command("git", "config", "--local", "user.email", "thomas@google.com"))
-
 	if err := os.WriteFile(filepath.Join(repoDir, "file1.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
@@ -136,6 +133,9 @@ func TestIndexTinyRepo(t *testing.T) {
 
 func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_USER_NAME=Soren Kierkegaard",
+		"GIT_CONFIG_USER_EMAIL=soren@apache.com")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("cmd.Run: %v", err)
 	}


### PR DESCRIPTION
This fixes an annoying problem where after running `go test ./...` locally, your local git `user.name` would be set to `thomas`. 

I accidentally introduced this problem in https://github.com/sourcegraph/zoekt/pull/852.