### PR TITLE
fix: only sample spans where parent is sampled

### DIFF
--- a/internal/tracer/opentelemetry.go
+++ b/internal/tracer/opentelemetry.go
@@ -57,7 +57,7 @@ func configureOpenTelemetry(resource sglog.Resource) (opentracing.Tracer, error)
 			semconv.ServiceNameKey.String(resource.Name),
 			semconv.ServiceInstanceIDKey.String(resource.InstanceID),
 			semconv.ServiceVersionKey.String(resource.Version))),
-		oteltracesdk.WithSampler(oteltracesdk.AlwaysSample()),
+		oteltracesdk.WithSampler(oteltracesdk.ParentBased(oteltracesdk.NeverSample())),
 		oteltracesdk.WithSpanProcessor(processor),
 	)
 


### PR DESCRIPTION
Currently, Zoekt samples _all_ spans, even if the incoming request is not recording. This PR uses the builtin `ParentBased` sampler to only sample spans when the parent span is recording. Whether the remote span is recording is propagated by the default otel propagators.

Contributes to SRC-1226