### PR TITLE
fix wildcards not getting expanded in delta build

### DIFF
--- a/internal/gitindex/index.go
+++ b/internal/gitindex/index.go
@@ -689,10 +689,15 @@ func prepareDeltaBuild(options Options, repository *git.Repository) (repos map[f
 	// branch => (path, sha1) => repo.
 	repos = map[fileKey]BlobLocation{}
 
-	// branch name -> git worktree at most current commit
-	branchToCurrentTree := make(map[string]*object.Tree, len(options.Branches))
+	branches, err := expandBranches(repository, options.Branches, options.BranchPrefix)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("expandBranches: %w", err)
+	}
 
-	for _, b := range options.Branches {
+	// branch name -> git worktree at most current commit
+	branchToCurrentTree := make(map[string]*object.Tree, len(branches))
+
+	for _, b := range branches {
 		commit, err := getCommit(repository, options.BranchPrefix, b)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("getting last current commit for branch %q: %w", b, err)

--- a/internal/gitindex/index_test.go
+++ b/internal/gitindex/index_test.go
@@ -449,6 +449,31 @@ func TestIndexDeltaBasic(t *testing.T) {
 			},
 		},
 		{
+			name:     "should expand branches correctly when using wildcards in branch names",
+			branches: []string{"release/1", "release/2"},
+			steps: []step{
+				{
+					name: "setup",
+					addedDocuments: branchToDocumentMap{
+						"release/1": []index.Document{fruitV1},
+						"release/2": []index.Document{fruitV2},
+					},
+
+					expectedDocuments: []index.Document{fruitV1, fruitV2},
+				},
+				{
+					name: "try delta build with wildcard in branches",
+					optFn: func(t *testing.T, o *Options) {
+						// use a wildcard here
+						o.Branches = []string{"HEAD", "release/*"}
+						o.BuildOptions.IsDelta = true
+					},
+
+					expectedDocuments: []index.Document{fruitV1, fruitV2},
+				},
+			},
+		},
+		{
 			name:     "should fallback to normal build if one or more index options updates requires a full build",
 			branches: []string{"main"},
 			steps: []step{


### PR DESCRIPTION
Hi zoekt-Team,

when testing with our local instance I noticed that it seemed that delta builds where not correctly indexing only the delta that I expected, but much more. I looked at `prepareDeltaBuild()` and `prepareNormalBuild()` and found that `prepareNormalBuild()` expands the branches before processing them with `expandBranches()`, but `prepareDeltaBuild()` does not. This leads to a lot more indexing, because `prepareDeltaBuild()` can't find any known branches (that match the wildcard).
I added a call of `expandBranches()` to `prepareDeltaBuild()` to fix this and also added a test.

Regards,
Daniel