### PR TITLE
index: decide between tenant and non-tenant shard name in one place

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -22,7 +22,7 @@ func TestCleanup(t *testing.T) {
 		return shard{
 			RepoID:        fakeID(name),
 			RepoName:      name,
-			Path:          index.ShardName("", name, 15, n),
+			Path:          fmt.Sprintf("%s_v%d.%05d.zoekt", name, 15, n),
 			ModTime:       mtime,
 			RepoTombstone: false,
 		}

--- a/index/builder.go
+++ b/index/builder.go
@@ -349,7 +349,7 @@ func (o *Options) shardNameVersion(version, n int) string {
 		prefix = o.RepositoryDescription.Name
 	}
 
-	return ShardName(o.IndexDir, prefix, version, n)
+	return shardName(o.IndexDir, prefix, version, n)
 }
 
 type IndexState string

--- a/index/merge.go
+++ b/index/merge.go
@@ -216,7 +216,7 @@ func explode(dstDir string, f IndexFile, ibFuncs ...shardBuilderFunc) (map[strin
 			prefix = ib.repoList[0].Name
 		}
 
-		shardName := ShardName(dstDir, prefix, ib.indexFormatVersion, 0)
+		shardName := shardName(dstDir, prefix, ib.indexFormatVersion, 0)
 		shardNameTmp := shardName + ".tmp"
 		shardNames[shardNameTmp] = shardName
 		return builderWriteAll(shardNameTmp, ib)

--- a/index/read_test.go
+++ b/index/read_test.go
@@ -368,7 +368,13 @@ func TestBackwardsCompat(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		outName := shardName("testdata/backcompat", "new", IndexFormatVersion, 0)
+		opts := Options{
+			IndexDir: "testdata/backcompat",
+			RepositoryDescription: zoekt.Repository{
+				Name: "new",
+			},
+		}
+		outName := opts.shardName(0)
 		t.Log("writing new file", outName)
 
 		err = os.WriteFile(outName, buf.Bytes(), 0o644)

--- a/index/read_test.go
+++ b/index/read_test.go
@@ -368,7 +368,7 @@ func TestBackwardsCompat(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		outName := ShardName("testdata/backcompat", "new", IndexFormatVersion, 0)
+		outName := shardName("testdata/backcompat", "new", IndexFormatVersion, 0)
 		t.Log("writing new file", outName)
 
 		err = os.WriteFile(outName, buf.Bytes(), 0o644)

--- a/index/shard_builder.go
+++ b/index/shard_builder.go
@@ -596,9 +596,9 @@ func (t *DocChecker) clearTrigrams(maxTrigramCount int) {
 	}
 }
 
-// ShardName returns the name of the shard for the given prefix, version, and
+// shardName returns the name of the shard for the given prefix, version, and
 // shard number.
-func ShardName(indexDir string, prefix string, version, n int) string {
+func shardName(indexDir string, prefix string, version, n int) string {
 	prefix = url.QueryEscape(prefix)
 	if len(prefix) > 200 {
 		prefix = prefix[:200] + hashString(prefix)[:8]

--- a/index/shard_builder_test.go
+++ b/index/shard_builder_test.go
@@ -40,7 +40,7 @@ func TestShardName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := ShardName(test.indexDir, test.prefix, test.version, test.shardNum)
+			actual := shardName(test.indexDir, test.prefix, test.version, test.shardNum)
 			if actual != test.expected {
 				t.Errorf("expected %q, got %q", test.expected, actual)
 			}


### PR DESCRIPTION
We have two places with duplicated logic around how it decides the layout of shards on disk. This now moves that decision into one place.

Additionally we can now unexport index.ShardName. It was only used in one place outside the package, and that was easy to replace with a hardcoded string since it is just a test.

Test Plan: Just CI. This has no actual change in functionality, just refactoring.
