### PR TITLE
index: inline tenant.SrcPrefix

### DIFF
--- a/index/builder.go
+++ b/index/builder.go
@@ -338,7 +338,7 @@ func (o *Options) shardNameVersion(version, n int) string {
 
 	// If tenant enforcement is enabled and we have tenant/repo IDs, use those to generate the prefix
 	if o.RepositoryDescription.TenantID != 0 && o.RepositoryDescription.ID != 0 && tenant.EnforceTenant() {
-		prefix = tenant.SrcPrefix(o.RepositoryDescription.TenantID, o.RepositoryDescription.ID)
+		prefix = fmt.Sprintf("%09d_%09d", o.RepositoryDescription.TenantID, o.RepositoryDescription.ID)
 	} else {
 		prefix = o.RepositoryDescription.Name
 	}

--- a/internal/tenant/shards.go
+++ b/internal/tenant/shards.go
@@ -1,9 +1,0 @@
-package tenant
-
-import "fmt"
-
-// SrcPrefix returns the Sourcegraph prefix of a shard. We put it here to avoid
-// circular dependencies.
-func SrcPrefix(tenantID int, repoID uint32) string {
-	return fmt.Sprintf("%09d_%09d", tenantID, repoID)
-}


### PR DESCRIPTION
It had exactly one call site and the logic was super simple. So I think
it is clearer to just inline the logic here.

Test Plan: mechanical refactor so just CI. In a future PR I will be
adding better test coverage just on this function.
