### PR TITLE
index: use ID based shard names only on multi-tenant instances

### DIFF
--- a/index/builder.go
+++ b/index/builder.go
@@ -336,8 +336,9 @@ func (o *Options) shardName(n int) string {
 func (o *Options) shardNameVersion(version, n int) string {
 	var prefix string
 
-	// If tenant enforcement is enabled and we have tenant/repo IDs, use those to generate the prefix
-	if o.RepositoryDescription.TenantID != 0 && o.RepositoryDescription.ID != 0 && tenant.EnforceTenant() {
+	// Sourcegraph specific: We use IDs in shard names on multi-tenant
+	// instances to prevent conflicts.
+	if tenant.UseIDBasedShardNames() {
 		prefix = fmt.Sprintf("%09d_%09d", o.RepositoryDescription.TenantID, o.RepositoryDescription.ID)
 	} else {
 		prefix = o.RepositoryDescription.Name

--- a/internal/tenant/enforcement.go
+++ b/internal/tenant/enforcement.go
@@ -1,6 +1,8 @@
 package tenant
 
 import (
+	"os"
+
 	"github.com/sourcegraph/zoekt/internal/tenant/internal/enforcement"
 )
 
@@ -11,4 +13,24 @@ func EnforceTenant() bool {
 	default:
 		return false
 	}
+}
+
+// UseIDBasedShardNames returns true if the on disk layout of shards should
+// instead use tenant ID and repository IDs in the names instead of the actual
+// repository names.
+//
+// It is possible for repositories to have the same name, but have different
+// content in a multi-tenant setup. As such, this implementation only returns
+// true in those situations.
+//
+// Note: We could migrate all on-disk layout to only be ID based. However,
+// ID's are a Sourcegraph specific feature so we will always need the two code
+// paths. As such we only return true in multitenant setups.
+//
+// This is Sourcegraph specific.
+func UseIDBasedShardNames() bool {
+	// We use the presence of this environment variable to tell if we are in a
+	// multi-tenant setup. This is the same check that is done in the
+	// Sourcegraph monorepo.
+	return os.Getenv("WORKSPACES_API_URL") != ""
 }


### PR DESCRIPTION
We only want to use ID based shard names on multi-tenant instances.
Before this change we decided this based on if tenant enforcement was
turned on. However, we would like to always have tenant enforcment on at
Sourcegraph but not migrate all shards to the new naming scheme (just
yet).

This change is quite simple. However, it works since we never actually
read the filenames to extract tenant ID or repository ID. We only ever
use the data that is persisted inside of the shard to do the
enforcement.

The environment variable we read (WORKSPACES_API_URL) is the same one we
use in the Sourcegraph codebase to determine multi-tenant specific code.

Test Plan: Added a unit test. Will do a much larger manual E2E test
with the Sourcegraph project.

Closes https://linear.app/sourcegraph/issue/DINF-940/zoekt-enforcetenant-turned-on-works-for-non-workspace-instances