### PR TITLE
tenant: unexport EnforceTenant

### DIFF
--- a/internal/tenant/context.go
+++ b/internal/tenant/context.go
@@ -27,6 +27,10 @@ func FromContext(ctx context.Context) (*tenanttype.Tenant, error) {
 // Log logs the tenant ID to the trace. If tenant logging is enabled, it also
 // logs a stack trace to a pprof profile.
 func Log(ctx context.Context, tr *trace.Trace) {
+	if !enforceTenant() {
+		return
+	}
+
 	if systemtenant.Is(ctx) {
 		tr.LazyPrintf("tenant: system")
 		return

--- a/internal/tenant/enforcement.go
+++ b/internal/tenant/enforcement.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sourcegraph/zoekt/internal/tenant/internal/enforcement"
 )
 
-func EnforceTenant() bool {
+func enforceTenant() bool {
 	switch enforcement.EnforcementMode.Load() {
 	case "strict":
 		return true

--- a/internal/tenant/query.go
+++ b/internal/tenant/query.go
@@ -9,7 +9,7 @@ import (
 // HasAccess returns true if the tenant ID in the context matches the
 // given ID. If tenant enforcement is disabled, it always returns true.
 func HasAccess(ctx context.Context, id int) bool {
-	if !EnforceTenant() {
+	if !enforceTenant() {
 		return true
 	}
 	if systemtenant.Is(ctx) {

--- a/search/eval.go
+++ b/search/eval.go
@@ -20,9 +20,7 @@ func (s *typeRepoSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Se
 	tr, ctx := trace.New(ctx, "typeRepoSearcher.Search", "")
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %+v", opts)
-	if tenant.EnforceTenant() {
-		tenant.Log(ctx, tr)
-	}
+	tenant.Log(ctx, tr)
 	defer func() {
 		if sr != nil {
 			tr.LazyPrintf("num files: %d", len(sr.Files))
@@ -47,9 +45,7 @@ func (s *typeRepoSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zo
 	tr, ctx := trace.New(ctx, "typeRepoSearcher.StreamSearch", "")
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %+v", opts)
-	if tenant.EnforceTenant() {
-		tenant.Log(ctx, tr)
-	}
+	tenant.Log(ctx, tr)
 	var stats zoekt.Stats
 	defer func() {
 		tr.LazyPrintf("stats: %+v", stats)
@@ -75,9 +71,7 @@ func (s *typeRepoSearcher) List(ctx context.Context, q query.Q, opts *zoekt.List
 	tr, ctx := trace.New(ctx, "typeRepoSearcher.List", "")
 	tr.LazyLog(q, true)
 	tr.LazyPrintf("opts: %s", opts)
-	if tenant.EnforceTenant() {
-		tenant.Log(ctx, tr)
-	}
+	tenant.Log(ctx, tr)
 	defer func() {
 		if rl != nil {
 			tr.LazyPrintf("repos.size=%d reposmap.size=%d crashes=%d stats=%+v", len(rl.Repos), len(rl.ReposMap), rl.Crashes, rl.Stats)


### PR DESCRIPTION
The only place this was called outside of the tenant package was for
deciding if we should call tenant.Log. However, we can inline that check
and both simplify the tenant exported API as well as how you call
tenant.Log.

Test Plan: CI
