### PR TITLE
gitindex: unmarshal tenantID from git config

### DIFF
--- a/internal/gitindex/index.go
+++ b/internal/gitindex/index.go
@@ -248,6 +248,8 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 	id, _ := strconv.ParseUint(sec.Options.Get("repoid"), 10, 32)
 	desc.ID = uint32(id)
 
+	desc.TenantID, _ = strconv.Atoi(sec.Options.Get("tenantID"))
+
 	if desc.RawConfig == nil {
 		desc.RawConfig = map[string]string{}
 	}


### PR DESCRIPTION
I'm not sure if I broke this in my refactors or we somehow set the tenantID at a later stage in the build pipeline, but now we set this.