### PR TITLE
query: remove TestMetaSimplify

### DIFF
--- a/query/query_test.go
+++ b/query/query_test.go
@@ -178,13 +178,3 @@ func TestExpandFileContent(t *testing.T) {
 		})
 	}
 }
-
-func TestMetaSimplify(t *testing.T) {
-	re := regexp.MustCompile("v1")
-	q := &Meta{Field: "version", Value: re}
-
-	simplified := q.Simplify()
-	if !reflect.DeepEqual(q, simplified) {
-		t.Errorf("Meta.Simplify() = %v, want %v", simplified, q)
-	}
-}


### PR DESCRIPTION
This was a leftover from the commit merged yesterday for code that was removed.

Test Plan: go test ./...