### PR TITLE
Fix unbalanced paren

### DIFF
--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -125,6 +125,24 @@ func TestParseQuery(t *testing.T) {
 		{"or abc", nil},
 		{"def or or abc", nil},
 
+		{"(", nil},
+		{"((", nil},
+		{"(((", nil},
+		{")", nil},
+		{"))", nil},
+		{")))", nil},
+		{"foo)", nil},
+		{"foo))", nil},
+		{"foo)))", nil},
+		{"(foo", nil},
+		{"((foo", nil},
+		{"(((foo", nil},
+		{"(foo))", nil},
+		{"(((foo))", nil},
+		{"((())", nil},
+		{"(( ) a", nil},
+		{"()()()()(()))", nil},
+
 		{"", &Const{Value: true}},
 	} {
 		got, err := Parse(c.in)

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -124,7 +124,8 @@ func TestParseQuery(t *testing.T) {
 		{"abc or", nil},
 		{"or abc", nil},
 		{"def or or abc", nil},
-
+		
+		// unbalanced parentheses
 		{"(", nil},
 		{"((", nil},
 		{"(((", nil},


### PR DESCRIPTION
This PR addresses #547. Previously, due to a mix of local and recursive tracking of parentheses balance, `(` and `)` were not parsed correctly (especially `)`).

# Changes Made
- Introduced a *single global* `parenBalance` variable to track parentheses across all expressions and sub-expressions.
- Changed the definition of `parseExprList()` to accept a pointer to `parenBalance`
- Updated calls to `parseExprList()` to use a pointer to the global `parenBalance`

This takes the parentheses logic, which previously existed only in `nextToken`, and moves it up to the `Parse` function.
