### PR TITLE
switch to github.com/sourcegraph/cody-public-snapshot for e2e test

### DIFF
--- a/internal/e2e/e2e_rank_test.go
+++ b/internal/e2e/e2e_rank_test.go
@@ -42,7 +42,7 @@ func TestRanking(t *testing.T) {
 	archiveURLs := []string{
 		"https://github.com/sourcegraph/sourcegraph-public-snapshot/tree/v5.2.2", // Nov 1 2023
 		"https://github.com/golang/go/tree/go1.21.4",                             // Nov 7 2023
-		"https://github.com/sourcegraph/cody/tree/vscode-v0.14.5",                // Nov 8 2023
+		"https://github.com/sourcegraph/cody-public-snapshot/tree/vscode-v0.14.5", // Nov 8 2023
 		// The commit before ranking e2e tests were added to avoid matching
 		// content inside our golden files.
 		"https://github.com/sourcegraph/zoekt/commit/ef907c2371176aa3f97713d5bf182983ef090c6a", // Nov 17 2023
@@ -65,8 +65,8 @@ func TestRanking(t *testing.T) {
 		q("Repository metadata Write rbac", "github.com/sourcegraph/sourcegraph-public-snapshot/internal/rbac/constants.go"), // unsure if this is the best doc?
 
 		// cody
-		q("generate unit test", "github.com/sourcegraph/cody/lib/shared/src/chat/recipes/generate-test.ts"),
-		q("r:cody sourcegraph url", "github.com/sourcegraph/cody/lib/shared/src/sourcegraph-api/graphql/client.ts"),
+		q("generate unit test", "github.com/sourcegraph/cody-public-snapshot/lib/shared/src/chat/recipes/generate-test.ts"),
+		q("r:cody sourcegraph url", "github.com/sourcegraph/cody-public-snapshot/lib/shared/src/sourcegraph-api/graphql/client.ts"),
 
 		// zoekt
 		q("zoekt searcher", "github.com/sourcegraph/zoekt/api.go"),

--- a/internal/e2e/testdata/r_cody_sourcegraph_url.txt
+++ b/internal/e2e/testdata/r_cody_sourcegraph_url.txt
@@ -2,36 +2,36 @@ queryString: r:cody sourcegraph url
 query: (and repo:cody substr:"sourcegraph" substr:"url")
 targetRank: 1
 
-**github.com/sourcegraph/cody/lib/shared/src/sourcegraph-api/graphql/client.ts**
+**github.com/sourcegraph/cody-public-snapshot/lib/shared/src/sourcegraph-api/graphql/client.ts**
 611:        const url = buildGraphQLUrl({ request: query, baseUrl: this.config.serverEndpoint })
 626:        const url = buildGraphQLUrl({ request: query, baseUrl: this.dotcomUrl.href })
 641:        const url = 'http://localhost:49300/.api/testLogging'
 hidden 51 more line matches
 
-github.com/sourcegraph/cody/vscode/src/completions/client.ts
+github.com/sourcegraph/cody-public-snapshot/vscode/src/completions/client.ts
 85:        const url = getCodeCompletionsEndpoint()
 1:import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
 5:} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 hidden 6 more line matches
 
-github.com/sourcegraph/cody/vscode/scripts/download-wasm-modules.ts
+github.com/sourcegraph/cody-public-snapshot/vscode/scripts/download-wasm-modules.ts
 83:    for (const url of urls) {
 93:function getFilePathFromURL(url: string): string {
 20:const urls = [
 hidden 21 more line matches
 
-github.com/sourcegraph/cody/slack/src/services/local-vector-store.ts
+github.com/sourcegraph/cody-public-snapshot/slack/src/services/local-vector-store.ts
 18:    const { content, url } = codyNotice
 9:        owner: 'sourcegraph',
 24:            fileName: url,
 
-github.com/sourcegraph/cody/lib/shared/src/sourcegraph-api/completions/client.ts
+github.com/sourcegraph/cody-public-snapshot/lib/shared/src/sourcegraph-api/completions/client.ts
 23:export abstract class SourcegraphCompletionsClient {
 21: * Access the chat based LLM APIs via a Sourcegraph server instance.
 36:        return new URL('/.api/completions/stream', this.config.serverEndpoint).href
 hidden 1 more line matches
 
-github.com/sourcegraph/cody/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+github.com/sourcegraph/cody-public-snapshot/lib/shared/src/sourcegraph-api/completions/browserClient.ts
 8:export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
 5:import { SourcegraphCompletionsClient } from './client'
 20:            headersInstance.set('X-Sourcegraph-Should-Trace', 'true')

--- a/internal/e2e/testdata/test_server.txt
+++ b/internal/e2e/testdata/test_server.txt
@@ -14,7 +14,7 @@ github.com/golang/go/src/net/rpc/server.go
 197:func NewServer() *Server {
 hidden 104 more line matches
 
-github.com/sourcegraph/cody/vscode/test/fixtures/mock-server.ts
+github.com/sourcegraph/cody-public-snapshot/vscode/test/fixtures/mock-server.ts
 126:    const server = app.listen(SERVER_PORT, () => {
 19:const SERVER_PORT = 49300
 21:export const SERVER_URL = 'http://localhost:49300'


### PR DESCRIPTION
e2e tests were failing because github.com/sourcegraph/cody repository has been set to private and all tags were removed

Test plan:
CI