### PR TITLE
Add support for indexing submodules without repocache

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -221,11 +221,13 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 	}
 
 	name := sec.Options.Get("name")
-	remoteURL := configLookupRemoteURL(cfg, "origin")
-
 	if name != "" {
 		desc.Name = name
-	} else if remoteURL != "" {
+	} else {
+		remoteURL := configLookupRemoteURL(cfg, "origin")
+		if remoteURL == "" {
+			return nil
+		}
 		if sm := sshRelativeURLRegexp.FindStringSubmatch(remoteURL); sm != nil {
 			user := sm[1]
 			host := sm[2]
@@ -241,8 +243,6 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 		if err := SetTemplatesFromOrigin(desc, u); err != nil {
 			return err
 		}
-	} else {
-		desc.Name = filepath.Base(repoDir)
 	}
 
 	id, _ := strconv.ParseUint(sec.Options.Get("repoid"), 10, 32)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -569,6 +569,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 // It copies the relevant logic from git.PlainOpen, and tweaks certain filesystem options.
 func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 	fs := osfs.New(repoDir)
+	wt := fs
 
 	// Check if the root directory exists.
 	if _, err := fs.Stat(""); err != nil {
@@ -591,7 +592,7 @@ func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 	})
 
 	// Because we're keeping descriptors open, we need to close the storage object when we're done.
-	repo, err := git.Open(s, fs)
+	repo, err := git.Open(s, wt)
 	return repo, s, err
 }
 

--- a/gitindex/tree.go
+++ b/gitindex/tree.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -93,6 +94,39 @@ func (rw *RepoWalker) parseModuleMap(t *object.Tree) error {
 	return nil
 }
 
+// This attempts to get a repo URL similar to the main repository template processing as in setTemplatesFromConfig()
+func normalizeSubmoduleRemoteURL(cfg *config.Config) (*url.URL, error) {
+	sec := cfg.Raw.Section("zoekt")
+	remoteURL := sec.Options.Get("web-url")
+	if remoteURL == "" {
+		// fall back to "origin" remote
+		remoteURL = configLookupRemoteURL(cfg, "origin")
+		if remoteURL == "" {
+			return nil, fmt.Errorf("no remote URL found in git config")
+		}
+	}
+
+	if sm := sshRelativeURLRegexp.FindStringSubmatch(remoteURL); sm != nil {
+		user := sm[1]
+		host := sm[2]
+		path := sm[3]
+
+		remoteURL = fmt.Sprintf("ssh+git://%s@%s/%s", user, host, path)
+	}
+
+	u, err := url.Parse(remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse remote URL %q: %w", remoteURL, err)
+	}
+
+	if u.Scheme == "ssh+git" {
+		u.Scheme = "https"
+		u.User = nil
+	}
+
+	return u, nil
+}
+
 // CollectFiles fetches the blob SHA1s for the tree. If repoCache is
 // non-nil, recurse into submodules. In addition, it returns a mapping
 // that indicates in which repo each SHA1 can be found.
@@ -159,6 +193,14 @@ func (rw *RepoWalker) handleSubmodule(p string, id *plumbing.Hash, branch string
 
 	subRepoVersions[p] = *id
 
+	cfg, err := subRepo.Config()
+	if err == nil {
+		subRemoteURL, err := normalizeSubmoduleRemoteURL(cfg)
+		if err == nil {
+			subURL = subRemoteURL
+		}
+	}
+
 	sw := NewRepoWalker(subRepo, subURL.String(), rw.repoCache)
 	subVersions, err := sw.CollectFiles(tree, branch, ig)
 	if err != nil {
@@ -178,9 +220,16 @@ func (rw *RepoWalker) handleSubmodule(p string, id *plumbing.Hash, branch string
 }
 
 func (rw *RepoWalker) handleEntry(p string, e *object.TreeEntry, branch string, subRepoVersions map[string]plumbing.Hash, ig *ignore.Matcher) error {
-	if e.Mode == filemode.Submodule && rw.repoCache != nil {
-		if err := rw.tryHandleSubmodule(p, &e.Hash, branch, subRepoVersions, ig); err != nil {
-			return fmt.Errorf("submodule %s: %v", p, err)
+	if e.Mode == filemode.Submodule {
+		if rw.repoCache != nil {
+			// Index the submodule using repo cache
+			if err := rw.tryHandleSubmodule(p, &e.Hash, branch, subRepoVersions, ig); err != nil {
+				return fmt.Errorf("submodule %s: %v", p, err)
+			}
+		} else {
+			// Record the commit ID for the submodule path
+			// This will be the submodule's commit hash, not the parent's
+			subRepoVersions[p] = e.Hash
 		}
 	}
 

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -268,7 +268,8 @@ func TestSubmoduleIndexWithoutRepocache(t *testing.T) {
 	indexDir := t.TempDir()
 
 	buildOpts := index.Options{
-		IndexDir: indexDir,
+		RepositoryDescription: zoekt.Repository{Name: "adir"},
+		IndexDir:              indexDir,
 	}
 	opts := Options{
 		RepoDir:      filepath.Join(dir, "adir"),


### PR DESCRIPTION
This PR aims to make git repo submodule indexing much more approachable, removing the requirement for a repo cache

Related discussion : https://github.com/sourcegraph/zoekt/issues/984

# Behavior changes:

- If `zoekt-git-index` is run with `-submodules=true` and `-repo-cache` is not empty, the behavior remains unchanged
- If `zoekt-git-index` is run with `-submodules=true` and `-repo-cache` is empty, recurse on submodules using `go-git` instead

This required 2 related bug fixes:

- https://github.com/sourcegraph/zoekt/commit/085b391077b2e90de6515f23c919abc390de50a9 fixes an issue where we incorrectly replicated `git.PlainOpen()` functionality when setting up filesystem storage. A side effect of this is that `go-git` refuses to return submodules (not sure if there are others).

  Side note: sent `go-git` a PR to avoid this code replication entirely: 
  https://github.com/go-git/go-git/pull/1686

- https://github.com/sourcegraph/zoekt/commit/f5f787720bee7947ae671accff567cb268d8afdb adds subrepository support to RepoURL and LineFragment treatment - without this, results involving subrepositories can't be used to construct correct remote URLs

# Functionality Example:

indexing [Chataigne](https://github.com/benkuper/Chataigne)

```
$ zoekt-git-index -submodules=true ~/dev/Chataigne

2025/10/08 12:21:31 adding subrepository files from: Modules/juce_timeline
2025/10/08 12:21:31 adding subrepository files from: asio
2025/10/08 12:21:31 adding subrepository files from: Modules/juce_simpleweb
2025/10/08 12:21:31 adding subrepository files from: Modules/juce_sharedtexture
2025/10/08 12:21:31 failed to open submodule repository: Modules/juce_serial, submodule not initialized
2025/10/08 12:21:31 adding subrepository files from: Modules/juce_dmx
2025/10/08 12:21:31 adding subrepository files from: Modules/juce_organicui
2025/10/08 12:21:31 attempting to index 3745 total files
2025/10/08 12:04:20 finished shard .zoekt/github.com%2Fbenkuper%2FChataigne_v16.00000.zoekt: 91189557 index bytes (overhead 2.7), 3745 files processed 
```

<details>
<summary>search query</summary>


```
$ curl -XPOST -d '{"Q":"juce"}' localhost:6070/api/search

...

     {
        "FileName": "Modules/juce_dmx/README.md",
        "Repository": "github.com/benkuper/Chataigne",
        "SubRepositoryName": "github.com/benkuper/juce_dmx",
        "SubRepositoryPath": "Modules/juce_dmx",
        "Version": "dba0680390873dd1a4b820aa77afff78d61894d9",
        "Language": "Markdown",
        "Branches": [
          "HEAD"
        ],
        "LineMatches": [

...

    "RepoURLs": {
      "github.com/benkuper/Chataigne": "{{URLJoinPath \"https://github.com/benkuper/Chataigne\" \"blob\" .Version .Path}}",
      "github.com/benkuper/asio": "{{URLJoinPath \"https://github.com/benkuper/asio\" \"blob\" .Version .Path}}",
      "github.com/benkuper/juce_dmx": "{{URLJoinPath \"https://github.com/benkuper/juce_dmx\" \"blob\" .Version .Path}}",
      "github.com/benkuper/juce_organicui": "{{URLJoinPath \"https://github.com/benkuper/juce_organicui\" \"blob\" .Version .Path}}",
      "github.com/benkuper/juce_sharedtexture": "{{URLJoinPath \"https://github.com/benkuper/juce_sharedtexture\" \"blob\" .Version .Path}}",
      "github.com/benkuper/juce_simpleweb": "{{URLJoinPath \"https://github.com/benkuper/juce_simpleweb\" \"blob\" .Version .Path}}",
      "github.com/benkuper/juce_timeline": "{{URLJoinPath \"https://github.com/benkuper/juce_timeline\" \"blob\" .Version .Path}}"
    },
    "LineFragments": {
      "github.com/benkuper/Chataigne": "#L{{.LineNumber}}",
      "github.com/benkuper/asio": "#L{{.LineNumber}}",
      "github.com/benkuper/juce_dmx": "#L{{.LineNumber}}",
      "github.com/benkuper/juce_organicui": "#L{{.LineNumber}}",
      "github.com/benkuper/juce_sharedtexture": "#L{{.LineNumber}}",
      "github.com/benkuper/juce_simpleweb": "#L{{.LineNumber}}",
      "github.com/benkuper/juce_timeline": "#L{{.LineNumber}}"
    }
...

```
</details>

<details>
<summary>repo list query</summary>

```
$ curl -XPOST -d '{}' localhost:6070/api/list

...
     {
        "Repository": {
          "TenantID": 0,
          "ID": 0,
          "Name": "github.com/benkuper/Chataigne",
          "URL": "https://github.com/benkuper/Chataigne",
          "Metadata": null,
          "Source": "/home/hemul/dev/Chataigne",
          "Branches": [
            {
              "Name": "HEAD",
              "Version": "e4f150fe5d7fde4c8a40937d3e91cfa1ba13accc"
            }
          ],
          "SubRepoMap": {
            "Modules/juce_dmx": {
              "TenantID": 0,
              "ID": 0,
              "Name": "github.com/benkuper/juce_dmx",
              "URL": "https://github.com/benkuper/juce_dmx",
              "Metadata": null,
              "Source": "",
              "Branches": [
                {
                  "Name": "HEAD",
                  "Version": "dba0680390873dd1a4b820aa77afff78d61894d9"
                }
              ],
              "SubRepoMap": null,
              "CommitURLTemplate": "{{URLJoinPath \"https://github.com/benkuper/juce_dmx\" \"commit\" .Version}}",
              "FileURLTemplate": "{{URLJoinPath \"https://github.com/benkuper/juce_dmx\" \"blob\" .Version .Path}}",
              "LineFragmentTemplate": "#L{{.LineNumber}}",
              "RawConfig": null,
              "Rank": 0,
              "IndexOptions": "",
              "HasSymbols": false,
              "Tombstone": false,
              "LatestCommitDate": "0001-01-01T00:00:00Z"
            },
            ...
```
</details>

# Followups

Some other features I'd like to follow up on in future PRs:

- Subrepo results are quite cumbersome: the submodule file path gets appended onto parent repo submodule path, this needs to be split to get a correct remote URL. It might be a good idea to add an option to index submodules as separate zoekt repos instead of subrepos, eg a `-submodule-treatment subrepository | repository (default: subrepository)` cli flag.
- supporting incremental/delta builds