### PR TITLE
Support Gitea in the indexserver

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -38,6 +38,9 @@ type ConfigEntry struct {
 	GitilesURL             string
 	CGitURL                string
 	BitBucketServerURL     string
+	GiteaURL               string
+	GiteaUser              string
+	GiteaOrg               string
 	DisableTLS             bool
 	CredentialPath         string
 	ProjectType            string
@@ -54,6 +57,7 @@ type ConfigEntry struct {
 	GerritFetchMetaConfig  bool
 	GerritRepoNameFormat   string
 	ExcludeUserRepos       bool
+	Forks                  bool
 }
 
 func randomize(entries []ConfigEntry) []ConfigEntry {
@@ -200,6 +204,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			if !c.KeepDeleted {
 				cmd.Args = append(cmd.Args, "-delete")
 			}
+			if c.Forks {
+				cmd.Args = append(cmd.Args, "-forks")
+			}
 		} else if c.GitilesURL != "" {
 			cmd = exec.Command("zoekt-mirror-gitiles",
 				"-dest", repoDir, "-name", c.Name)
@@ -288,6 +295,40 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 				cmd.Args = append(cmd.Args, "-delete")
 			}
 			cmd.Args = append(cmd.Args, c.GerritApiURL)
+		} else if c.GiteaURL != "" {
+			cmd = exec.Command("zoekt-mirror-gitea", "-dest", repoDir)
+			if c.GiteaURL != "" {
+				cmd.Args = append(cmd.Args, "-url", c.GiteaURL)
+			}
+			if c.GiteaUser != "" {
+				cmd.Args = append(cmd.Args, "-user", c.GiteaUser)
+			} else if c.GiteaOrg != "" {
+				cmd.Args = append(cmd.Args, "-org", c.GiteaOrg)
+			}
+			if c.Name != "" {
+				cmd.Args = append(cmd.Args, "-name", c.Name)
+			}
+			if c.Exclude != "" {
+				cmd.Args = append(cmd.Args, "-exclude", c.Exclude)
+			}
+			if c.CredentialPath != "" {
+				cmd.Args = append(cmd.Args, "-token", c.CredentialPath)
+			}
+			for _, topic := range c.Topics {
+				cmd.Args = append(cmd.Args, "-topic", topic)
+			}
+			for _, topic := range c.ExcludeTopics {
+				cmd.Args = append(cmd.Args, "-exclude_topic", topic)
+			}
+			if c.NoArchived {
+				cmd.Args = append(cmd.Args, "-no_archived")
+			}
+			if !c.KeepDeleted {
+				cmd.Args = append(cmd.Args, "-delete")
+			}
+			if c.Forks {
+				cmd.Args = append(cmd.Args, "-forks")
+			}
 		} else {
 			log.Printf("executeMirror: ignoring config, because it does not contain any valid repository definition: %v", c)
 			continue

--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -90,7 +90,7 @@ func main() {
 			log.Fatal(err)
 		}
 		contentStr := string(content)
-		// Editors tend to insert newlines that make the string invalid, so clean it up
+		// Editors tend to insert newlines that make the token invalid, so clean it up
 		contentStr = strings.TrimSpace(contentStr)
 		clientOptions = append(clientOptions, gitea.SetToken(contentStr))
 	}

--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -90,10 +90,8 @@ func main() {
 			log.Fatal(err)
 		}
 		contentStr := string(content)
-		if strings.Contains(contentStr, "\n") {
-			// The user has to pass in the token via a file, so catch this common bug.
-			log.Fatal("Invalid token - remove the EOL from the file")
-		}
+		// Editors tend to insert newlines that make the string invalid, so clean it up
+		contentStr = strings.TrimSpace(contentStr)
 		clientOptions = append(clientOptions, gitea.SetToken(contentStr))
 	}
 	client, err := gitea.NewClient(*giteaURL, clientOptions...)

--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -94,7 +94,7 @@ func main() {
 			// The user has to pass in the token via a file, so catch this common bug.
 			log.Fatal("Invalid token - remove the EOL from the file")
 		}
-		clientOptions = append(clientOptions, gitea.SetToken(string(content)))
+		clientOptions = append(clientOptions, gitea.SetToken(contentStr))
 	}
 	client, err := gitea.NewClient(*giteaURL, clientOptions...)
 	if err != nil {

--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -89,6 +89,11 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		contentStr := string(content)
+		if strings.Contains(contentStr, "\n") {
+			// The user has to pass in the token via a file, so catch this common bug.
+			log.Fatal("Invalid token - remove the EOL from the file")
+		}
 		clientOptions = append(clientOptions, gitea.SetToken(string(content)))
 	}
 	client, err := gitea.NewClient(*giteaURL, clientOptions...)


### PR DESCRIPTION
I've confirmed that running the indexserver with

- this config.json
```json
[
  {
    "GiteaURL": "http://xxx.com",
    "GiteaOrg": "CareHarmony",
    "Name": "OurApp",
    "CredentialPath": "./token.txt"
  }
]

```

- Gitea server version 1.23.5

works.

All tests still pass.

This extends the work that was done in https://github.com/sourcegraph/zoekt/pull/844