### PR TITLE
zoekt-mirror-gerrit: Don't remove /a/ prefix from git clone URLs

### DIFF
--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -147,8 +147,6 @@ func main() {
 			projectURL = schemeInfo.URL
 			if s == "http" && schemeInfo.IsAuthRequired {
 				projectURL = addPassword(projectURL, rootURL.User)
-				// remove "/a/" prefix needed for API call with basic auth but not with git command → cleaner repo name
-				projectURL = strings.Replace(projectURL, "/a/${project}", "/${project}", 1)
 			}
 			break
 		}


### PR DESCRIPTION
The `/a/` prefix is required for authenticated git operations in default Gerrit configurations. Gerrit's HttpScheme intentionally includes `/a/` in clone URLs to trigger authentication.

## Problem

The code was removing `/a/` from git clone URLs with the assumption it's only needed for REST API calls. However, Gerrit's default configuration explicitly adds `/a/` to authenticated HTTP git clone URLs.

## Root Cause

Looking at [Gerrit's HttpScheme implementation](https://github.com/GerritCodeReview/plugins_download-commands/blob/master/src/main/java/com/googlesource/gerrit/plugins/download/scheme/HttpScheme.java#L84), when `gerrit.gitHttpUrl` is not configured, Gerrit uses `canonicalWebUrl` and hardcodes the `/a/` prefix:

```java
r.append(base.substring(s));
r.append("a/");  // <-- Hardcoded /a/ prefix
r.append(project);
```

This was added intentionally in 2015 to trigger authentication for git operations (see [commit 63e7cf5](https://github.com/GerritCodeReview/plugins_download-commands/commit/63e7cf5f24045ede2ee9e5a220e594716b2b6ce4)).

## Solution

Use the URL from Gerrit's ServerInfo API as-is. Gerrit already returns the correct URL format based on its configuration, so we shouldn't modify it.

Fixes #989

https://ampcode.com/threads/T-6944ab20-837d-4e78-a9ad-51083263baec