### PR TITLE
ci: fix fmt string errors

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -385,7 +385,7 @@ func (s *Server) Run() {
 		// "pkill -SIGUSR1 zoekt-sourcegra"
 		for range jitterTicker(s.Interval, unix.SIGUSR1) {
 			if paused, msg := isIndexingPaused(s.IndexDir); paused {
-				infoLog.Printf(msg)
+				infoLog.Printf("%s", msg)
 				continue
 			}
 

--- a/cmd/zoekt-sourcegraph-indexserver/queue_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/queue_test.go
@@ -190,7 +190,7 @@ func TestQueue_Integration_DebugQueue(t *testing.T) {
 	// test: send a request to the queue's debug endpoint
 	response, err := http.Get(server.URL)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatalf("%s", err.Error())
 	}
 
 	defer response.Body.Close()


### PR DESCRIPTION
I think these snuck in as we changed go versions