### PR TITLE
fix: Escape language queries correctly

### DIFF
--- a/web/templates.go
+++ b/web/templates.go
@@ -213,7 +213,7 @@ document.onkeydown=function(e){
 <title>Results for {{.QueryStr}}</title>
 <script>
   function zoektAddQ(atom) {
-      window.location.href = "/search?q=" + escape("{{.QueryStr}}" + " " + atom) +
+      window.location.href = "/search?q=" + encodeURIComponent("{{.QueryStr}}" + " " + atom) +
 	  "&" + "num=" + {{.Last.Num}};
   }
 </script>


### PR DESCRIPTION
`escape` escapes certain characters, but those don't include `+`, so clicking a `C++` language link will result in the `+`s not being escaped in the URL.  This causes the search to search for `"C  "` which finds no results.

`encodeURIComponent` is what should be used.