### PR TITLE
Fix zoekt-mirror-gitea documentation

### DIFF
--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Command zoekt-mirror-gerrit fetches all repos of a gitea user or organization
+// Command zoekt-mirror-gitea fetches all repos of a gitea user or organization
 // and clones them. It is strongly recommended to get a personal API token from
 // https://gitea.com/user/settings/applications, save the token in a file, and point
 // the --token option to it.


### PR DESCRIPTION
This had likely been copied from the `zoekt-mirror-gerrit` documentation.