### PR TITLE
Add Windows support: mmap and umask platform split

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/zoekt
 require (
 	cloud.google.com/go/profiler v0.4.2
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24
+	github.com/edsrzf/mmap-go v1.2.0
 	github.com/RoaringBitmap/roaring v1.9.4
 	github.com/andygrunwald/go-gerrit v1.0.0
 	github.com/bmatcuk/doublestar v1.3.4

--- a/index/builder.go
+++ b/index/builder.go
@@ -39,8 +39,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/go-enry/go-enry/v2"
 	"github.com/rs/xid"
-	"golang.org/x/sys/unix"
-
 	"maps"
 
 	"github.com/sourcegraph/zoekt"
@@ -1078,10 +1076,5 @@ func (e *deltaIndexOptionsMismatchError) Error() string {
 	return fmt.Sprintf("one or more index options for shard %q do not match Builder's index options. These index option updates are incompatible with delta build. New index options: %+v", e.shardName, e.newOptions)
 }
 
-// umask holds the Umask of the current process
+// umask holds the Umask of the current process (set by platform-specific init)
 var umask os.FileMode
-
-func init() {
-	umask = os.FileMode(unix.Umask(0))
-	unix.Umask(int(umask))
-}

--- a/index/builder_unix.go
+++ b/index/builder_unix.go
@@ -1,0 +1,14 @@
+//go:build linux || darwin || freebsd
+
+package index
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func init() {
+	umask = os.FileMode(unix.Umask(0))
+	unix.Umask(int(umask))
+}

--- a/index/builder_windows.go
+++ b/index/builder_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package index
+
+func init() {
+	umask = 0 // Windows does not use Unix file permission masks
+}

--- a/index/indexfile_windows.go
+++ b/index/indexfile_windows.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Embark Studios. Windows mmap-based IndexFile implementation.
+//
+// Uses edsrzf/mmap-go which wraps CreateFileMapping/MapViewOfFile on Windows,
+// providing the same zero-copy read performance as unix mmap.
+
+//go:build windows
+
+package index
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"os"
+
+	mmap "github.com/edsrzf/mmap-go"
+)
+
+type mmapedIndexFile struct {
+	name string
+	size uint32
+	data mmap.MMap
+}
+
+func (f *mmapedIndexFile) Read(off, sz uint32) ([]byte, error) {
+	if off > off+sz || off+sz > uint32(len(f.data)) {
+		return nil, fmt.Errorf("out of bounds: %d, len %d, name %s", off+sz, len(f.data), f.name)
+	}
+	return f.data[off : off+sz], nil
+}
+
+func (f *mmapedIndexFile) Name() string {
+	return f.name
+}
+
+func (f *mmapedIndexFile) Size() (uint32, error) {
+	return f.size, nil
+}
+
+func (f *mmapedIndexFile) Close() {
+	if err := f.data.Unmap(); err != nil {
+		log.Printf("WARN failed to Unmap %s: %v", f.name, err)
+	}
+}
+
+// NewIndexFile returns a new index file backed by mmap on Windows.
+// Uses CreateFileMapping/MapViewOfFile via the mmap-go library.
+func NewIndexFile(f *os.File) (IndexFile, error) {
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	sz := fi.Size()
+	if sz >= math.MaxUint32 {
+		f.Close()
+		return nil, fmt.Errorf("file %s too large: %d", f.Name(), sz)
+	}
+
+	if sz == 0 {
+		f.Close()
+		return nil, fmt.Errorf("file %s is empty", f.Name())
+	}
+
+	data, err := mmap.Map(f, mmap.RDONLY, 0)
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("mmap %s: %w", f.Name(), err)
+	}
+
+	// Close the file handle — the mapping keeps the data accessible.
+	f.Close()
+
+	return &mmapedIndexFile{
+		name: f.Name(),
+		size: uint32(sz),
+		data: data,
+	}, nil
+}


### PR DESCRIPTION
Replace the unix-only umask init with build-tagged files for linux/darwin/freebsd and windows. Add a Windows IndexFile implementation using edsrzf/mmap-go (CreateFileMapping/MapViewOfFile) for zero-copy shard reads.