### PR TITLE
query: resolve type lifting after OR parsing

### DIFF
--- a/doc/query_syntax.md
+++ b/doc/query_syntax.md
@@ -111,6 +111,11 @@ This returns repository names instead of file matches. Valid values include:
 - `filename` - Returns only matching filenames
 - `repo` - Returns only repository names
 
+`type:` applies to the whole expression in its current scope, including `or`
+clauses. For example, `type:repo foo or bar` is equivalent to
+`type:repo (foo or bar)`. Use parentheses to scope `type:` to only one branch,
+for example `(type:repo foo) or bar`.
+
 ---
 
 ## Special Query Values

--- a/query/parse.go
+++ b/query/parse.go
@@ -375,7 +375,11 @@ func parseExprList(in []byte) ([]Q, int, error) {
 		return q
 	})
 	if typeT != 100 {
-		qs = []Q{&Type{Type: typeT, Child: NewAnd(qs...)}}
+		typedQ, err := parseOperators(qs)
+		if err != nil {
+			return nil, 0, err
+		}
+		qs = []Q{&Type{Type: typeT, Child: typedQ}}
 	}
 	return qs, len(in) - len(b), nil
 }

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -112,6 +112,7 @@ func TestParseQuery(t *testing.T) {
 		// type
 		{"type:repo abc", &Type{Type: TypeRepo, Child: &Substring{Pattern: "abc"}}},
 		{"type:file abc def", &Type{Type: TypeFileName, Child: NewAnd(&Substring{Pattern: "abc"}, &Substring{Pattern: "def"})}},
+		{"type:repo foo or bar", &Type{Type: TypeRepo, Child: NewOr(&Substring{Pattern: "foo"}, &Substring{Pattern: "bar"})}},
 		{"(type:repo abc) def", NewAnd(&Type{Type: TypeRepo, Child: &Substring{Pattern: "abc"}}, &Substring{Pattern: "def"})},
 
 		// errors.
@@ -124,6 +125,8 @@ func TestParseQuery(t *testing.T) {
 		{"abc or", nil},
 		{"or abc", nil},
 		{"def or or abc", nil},
+		{"type:repo or", nil},
+		{"or type:repo", nil},
 
 		// unbalanced parentheses
 		{"(", nil},


### PR DESCRIPTION
This change fixes a parser ordering bug where `type:` lifting happened before `or` placeholder resolution. In unparenthesized queries such as `type:repo foo or bar`, the parser could previously leave internal `orOp` sentinels inside a `Type` child instead of producing a valid `Or` subtree. That also let malformed queries like `type:repo or` and `or type:repo` get accepted in parsing even though they should fail early.

The fix resolves operators first for typed scopes and then wraps the resulting expression in `Type`, preserving existing top-level type lifting semantics while ensuring `or` is validated and represented correctly. I also added parser regressions that cover the previously broken `type` + `or` case and malformed edge cases.

The query syntax docs now explicitly describe `type:` scope with `or` to match parser behavior and reduce ambiguity.