### PR TITLE
Handle git indexing path correctly for Git worktrees

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -182,6 +182,13 @@ func getCommit(repo *git.Repository, prefix, ref string) (*object.Commit, error)
 	return commitObj, nil
 }
 
+func plainOpenRepo(repoDir string) (*git.Repository, error) {
+	return git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	})
+}
+
 func configLookupRemoteURL(cfg *config.Config, key string) string {
 	rc := cfg.Remotes[key]
 	if rc == nil || len(rc.URLs) == 0 {
@@ -193,7 +200,7 @@ func configLookupRemoteURL(cfg *config.Config, key string) string {
 var sshRelativeURLRegexp = regexp.MustCompile(`^([^@]+)@([^:]+):(.*)$`)
 
 func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := plainOpenRepo(repoDir)
 	if err != nil {
 		return err
 	}
@@ -451,9 +458,9 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 	var repo *git.Repository
 	legacyRepoOpen := cmp.Or(os.Getenv("ZOEKT_DISABLE_GOGIT_OPTIMIZATION"), "false")
 	if b, err := strconv.ParseBool(legacyRepoOpen); b || err != nil {
-		repo, err = git.PlainOpen(opts.RepoDir)
+		repo, err = plainOpenRepo(opts.RepoDir)
 		if err != nil {
-			return false, fmt.Errorf("git.PlainOpen: %w", err)
+			return false, fmt.Errorf("plainOpenRepo: %w", err)
 		}
 	} else {
 		var repoCloser io.Closer

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -712,7 +712,6 @@ func indexCatfileBlobs(cr *catfileReader, keys []fileKey, repos map[fileKey]Blob
 // It copies the relevant logic from git.PlainOpen, and tweaks certain filesystem options.
 func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 	fs := osfs.New(repoDir)
-	wt := fs
 
 	// Check if the root directory exists.
 	if _, err := fs.Stat(""); err != nil {
@@ -721,6 +720,27 @@ func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 		}
 		return nil, nil, err
 	}
+
+	fi, err := fs.Stat(git.GitDirName)
+	if err == nil && !fi.IsDir() {
+		return openCompatibleRepo(repoDir)
+	}
+
+	return openOptimizedRepo(repoDir)
+}
+
+func openCompatibleRepo(repoDir string) (*git.Repository, io.Closer, error) {
+	repo, err := plainOpenRepo(repoDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return repo, noopCloser{}, nil
+}
+
+func openOptimizedRepo(repoDir string) (*git.Repository, io.Closer, error) {
+	fs := osfs.New(repoDir)
+	wt := fs
 
 	// If there's a .git directory, use that as the new root.
 	if fi, err := fs.Stat(git.GitDirName); err == nil && fi.IsDir() {
@@ -738,6 +758,10 @@ func openRepo(repoDir string) (*git.Repository, io.Closer, error) {
 	repo, err := git.Open(s, wt)
 	return repo, s, err
 }
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
 
 func newIgnoreMatcher(tree *object.Tree) (*ignore.Matcher, error) {
 	ignoreFile, err := tree.File(ignore.IgnoreFile)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -210,6 +210,19 @@ func setTemplatesFromConfig(desc *zoekt.Repository, repoDir string) error {
 		return err
 	}
 
+	return setTemplatesFromRepoConfig(desc, cfg)
+}
+
+func setTemplatesFromRepo(desc *zoekt.Repository, repo *git.Repository, repoDir string) error {
+	cfg, err := repo.Config()
+	if err == nil {
+		return setTemplatesFromRepoConfig(desc, cfg)
+	}
+
+	return setTemplatesFromConfig(desc, repoDir)
+}
+
+func setTemplatesFromRepoConfig(desc *zoekt.Repository, cfg *config.Config) error {
 	sec := cfg.Raw.Section("zoekt")
 
 	webURLStr := sec.Options.Get("web-url")
@@ -471,8 +484,8 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 		defer repoCloser.Close()
 	}
 
-	if err := setTemplatesFromConfig(&opts.BuildOptions.RepositoryDescription, opts.RepoDir); err != nil {
-		log.Printf("setTemplatesFromConfig(%s): %s", opts.RepoDir, err)
+	if err := setTemplatesFromRepo(&opts.BuildOptions.RepositoryDescription, repo, opts.RepoDir); err != nil {
+		log.Printf("setTemplatesFromRepo(%s): %s", opts.RepoDir, err)
 	}
 
 	branches, err := expandBranches(repo, opts.Branches, opts.BranchPrefix)

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -132,6 +132,39 @@ func TestIndexTinyRepo(t *testing.T) {
 	}
 }
 
+func TestIndexGitRepo_Worktree(t *testing.T) {
+	_, worktreeDir := initGitWorktree(t, "file1.go", "package main\n\nfunc main() {}\n")
+	indexDir := t.TempDir()
+
+	opts := Options{
+		RepoDir:  worktreeDir,
+		Branches: []string{"HEAD"},
+		BuildOptions: index.Options{
+			RepositoryDescription: zoekt.Repository{Name: "repo"},
+			IndexDir:              indexDir,
+		},
+	}
+
+	if _, err := IndexGitRepo(opts); err != nil {
+		t.Fatalf("IndexGitRepo(worktree): %v", err)
+	}
+
+	searcher, err := search.NewDirectorySearcher(indexDir)
+	if err != nil {
+		t.Fatal("NewDirectorySearcher", err)
+	}
+	defer searcher.Close()
+
+	results, err := searcher.Search(context.Background(), &query.Const{Value: true}, &zoekt.SearchOptions{})
+	if err != nil {
+		t.Fatal("search failed", err)
+	}
+
+	if len(results.Files) != 1 {
+		t.Fatalf("got search result %v, want 1 file", results.Files)
+	}
+}
+
 func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
 	cmd.Dir = dir
 	cmd.Env = []string{
@@ -146,6 +179,26 @@ func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
 		t.Fatalf("cmd.Run: %v", err)
 	}
 	return cmd
+}
+
+func initGitWorktree(t *testing.T, fileName, content string) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
+
+	repoDir := filepath.Join(dir, "repo")
+	if err := os.WriteFile(filepath.Join(repoDir, fileName), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	executeCommand(t, repoDir, exec.Command("git", "config", "remote.origin.url", "git@github.com:sourcegraph/zoekt.git"))
+	executeCommand(t, repoDir, exec.Command("git", "add", "."))
+	executeCommand(t, repoDir, exec.Command("git", "commit", "-m", "initial commit"))
+
+	worktreeDir := filepath.Join(dir, "wt")
+	executeCommand(t, repoDir, exec.Command("git", "worktree", "add", "-b", "worktree-branch", worktreeDir))
+
+	return repoDir, worktreeDir
 }
 
 func TestIndexDeltaBasic(t *testing.T) {
@@ -833,6 +886,19 @@ func TestSetTemplates_e2e(t *testing.T) {
 	desc := zoekt.Repository{}
 	if err := setTemplatesFromConfig(&desc, repositoryDir); err != nil {
 		t.Fatalf("setTemplatesFromConfig: %v", err)
+	}
+
+	if got, want := desc.FileURLTemplate, `{{URLJoinPath "https://github.com/sourcegraph/zoekt" "blob" .Version .Path}}`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSetTemplates_Worktree(t *testing.T) {
+	_, worktreeDir := initGitWorktree(t, "hello.go", "package main\n")
+	desc := zoekt.Repository{}
+
+	if err := setTemplatesFromConfig(&desc, worktreeDir); err != nil {
+		t.Fatalf("setTemplatesFromConfig(worktree): %v", err)
 	}
 
 	if got, want := desc.FileURLTemplate, `{{URLJoinPath "https://github.com/sourcegraph/zoekt" "blob" .Version .Path}}`; got != want {


### PR DESCRIPTION
## Problem
Zoekt’s git indexing path does not correctly handle Git worktrees.

In a worktree, the repository metadata is split:
- the worktree has its own git dir
- refs / objects / config may live in the shared common git dir

The existing plain-open path uses the default go-git repo opening behavior, which does not fully resolve this split layout. As a result, worktree repositories can fail during indexing with errors like missing refs or repository-open failures, even though normal Git commands work fine.

This shows up especially when tools built on top of `gitindex` try to index committed content from a worktree checkout.

## Solution

This PR updates the relevant `gitindex` plain-open paths to use a dedicated helper:

- `plainOpenRepo(...)`
- implemented with `git.PlainOpenWithOptions(...)`
- enables:
  - `DetectDotGit: true`
  - `EnableDotGitCommonDir: true`

That gives go-git the correct view of worktree repositories, including access to the shared common-dir metadata.

The helper is now used in:
- repository opening for indexing
- repository opening for config/template resolution

Zoekt's optimized repository opener assumes a standard checkout where `.git` is a directory. Git worktrees expose `.git` as a file pointing at the worktree git dir, so that code path misidentifies the repository layout and fails to open it correctly. This change adds an explicit worktree-aware fallback while preserving the existing optimized path for normal repositories.

## Why this fix
This is the smallest native fix that makes Zoekt worktree-aware without changing indexing behavior for normal repositories.

## Result
Zoekt can now open and index Git worktrees correctly through the plain-open path, while preserving existing behavior for standard repositories.