### PR TITLE
gitindex: speed up tests

### DIFF
--- a/gitindex/catfile_hardening_test.go
+++ b/gitindex/catfile_hardening_test.go
@@ -185,8 +185,6 @@ func createManyBlobRepo(t *testing.T, fileCount, fileSize int) (string, []plumbi
 	repoDir := filepath.Join(dir, "repo")
 
 	runGit(t, dir, "init", "-b", "main", "repo")
-	runGit(t, repoDir, "config", "user.email", "test@test.com")
-	runGit(t, repoDir, "config", "user.name", "Test")
 
 	for i := 0; i < fileCount; i++ {
 		content := bytes.Repeat([]byte{byte(i)}, fileSize)

--- a/gitindex/catfile_hardening_test.go
+++ b/gitindex/catfile_hardening_test.go
@@ -19,6 +19,8 @@ import (
 // TestCatfileReader_DoubleClose verifies that Close is idempotent.
 // Calling Close twice must not deadlock or panic.
 func TestCatfileReader_DoubleClose(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["hello.txt"]}
 
@@ -54,6 +56,8 @@ func TestCatfileReader_DoubleClose(t *testing.T) {
 // multiple goroutines simultaneously does not panic, deadlock, or
 // corrupt state.
 func TestCatfileReader_ConcurrentClose(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{
 		blobs["hello.txt"],
@@ -103,6 +107,8 @@ func TestCatfileReader_ConcurrentClose(t *testing.T) {
 // immediately after creation (without reading any entries) completes
 // without hanging.
 func TestCatfileReader_CloseWithoutReading(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{
 		blobs["hello.txt"],
@@ -135,38 +141,11 @@ func TestCatfileReader_CloseWithoutReading(t *testing.T) {
 // termination (e.g., builder.Add error) with many unconsumed blobs.
 // Close should complete promptly — not drain the entire git output.
 func TestCatfileReader_CloseBeforeExhausted_ManyBlobs(t *testing.T) {
-	// Create a repo with many non-trivial files.
-	dir := t.TempDir()
-	repoDir := filepath.Join(dir, "repo")
+	t.Parallel()
 
-	script := `
-set -e
-git init -b main repo
-cd repo
-git config user.email "test@test.com"
-git config user.name "Test"
-for i in $(seq 1 200); do
-    dd if=/dev/urandom bs=1024 count=10 of="file_$i.bin" 2>/dev/null
-done
-git add -A
-git commit -m "many files"
-`
-	cmd := exec.Command("/bin/sh", "-c", script)
-	cmd.Dir = dir
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("create test repo: %v", err)
-	}
-
-	var ids []plumbing.Hash
-	for i := 1; i <= 200; i++ {
-		name := fmt.Sprintf("file_%d.bin", i)
-		out, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD:"+name).Output()
-		if err != nil {
-			t.Fatalf("rev-parse %s: %v", name, err)
-		}
-		ids = append(ids, plumbing.NewHash(string(out[:len(out)-1])))
-	}
+	// Create enough blobs to make a draining Close noticeable without spending
+	// most of the test runtime on shelling out for fixture setup.
+	repoDir, ids := createManyBlobRepo(t, 128, 4<<10)
 
 	cr, err := newCatfileReader(repoDir, ids, catfileReaderOptions{})
 	if err != nil {
@@ -199,11 +178,60 @@ git commit -m "many files"
 	}
 }
 
+func createManyBlobRepo(t *testing.T, fileCount, fileSize int) (string, []plumbing.Hash) {
+	t.Helper()
+
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "repo")
+
+	runGit(t, dir, "init", "-b", "main", "repo")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+
+	for i := 0; i < fileCount; i++ {
+		content := bytes.Repeat([]byte{byte(i)}, fileSize)
+		name := filepath.Join(repoDir, fmt.Sprintf("file_%03d.bin", i))
+		if err := os.WriteFile(name, content, 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", name, err)
+		}
+	}
+
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "many files")
+
+	out, err := exec.Command("git", "-C", repoDir, "ls-tree", "-r", "-z", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git ls-tree: %v", err)
+	}
+
+	ids := make([]plumbing.Hash, 0, fileCount)
+	for _, entry := range bytes.Split(out, []byte{0}) {
+		if len(entry) == 0 {
+			continue
+		}
+
+		fields := bytes.Fields(entry)
+		if len(fields) < 3 {
+			t.Fatalf("unexpected ls-tree entry %q", entry)
+		}
+
+		ids = append(ids, plumbing.NewHash(string(fields[2])))
+	}
+
+	if len(ids) != fileCount {
+		t.Fatalf("got %d blob IDs, want %d", len(ids), fileCount)
+	}
+
+	return repoDir, ids
+}
+
 // --- Read edge-case tests ---
 
 // TestCatfileReader_ReadWithoutNext verifies that calling Read
 // before calling Next returns io.EOF, not a panic or garbage data.
 func TestCatfileReader_ReadWithoutNext(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["hello.txt"]}
 
@@ -224,6 +252,8 @@ func TestCatfileReader_ReadWithoutNext(t *testing.T) {
 // calls after a blob is fully consumed return io.EOF, not duplicate
 // data or trailing LF bytes.
 func TestCatfileReader_ReadAfterFullConsumption(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["hello.txt"]}
 
@@ -253,6 +283,8 @@ func TestCatfileReader_ReadAfterFullConsumption(t *testing.T) {
 // and verifies the entire content is reconstructed correctly without
 // any trailing LF leaking into user content.
 func TestCatfileReader_SmallBufferReads(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["hello.txt"]}
 
@@ -291,6 +323,8 @@ func TestCatfileReader_SmallBufferReads(t *testing.T) {
 // content, then advances to the next entry. Verifies that the discard
 // of pending bytes doesn't corrupt the stream.
 func TestCatfileReader_PartialReadThenNext(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{
 		blobs["hello.txt"],  // 12 bytes: "hello world\n"
@@ -337,6 +371,8 @@ func TestCatfileReader_PartialReadThenNext(t *testing.T) {
 // 1 trailing LF). This stresses the boundary between content and LF
 // in the discard path.
 func TestCatfileReader_PartialReadExactlyOneByteShort(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{
 		blobs["hello.txt"],  // 12 bytes
@@ -384,6 +420,8 @@ func TestCatfileReader_PartialReadExactlyOneByteShort(t *testing.T) {
 // TestCatfileReader_EmptyIds verifies that an empty id slice produces
 // immediate EOF without errors.
 func TestCatfileReader_EmptyIds(t *testing.T) {
+	t.Parallel()
+
 	repoDir, _ := createTestRepo(t)
 
 	cr, err := newCatfileReader(repoDir, nil, catfileReaderOptions{})
@@ -402,6 +440,8 @@ func TestCatfileReader_EmptyIds(t *testing.T) {
 // handling for size-0 blobs. Git still outputs a LF after a 0-byte
 // blob body. Repeated empty blobs test the pending=1 discard path.
 func TestCatfileReader_MultipleEmptyBlobs(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	// Send the empty blob SHA 5 times — git outputs each independently.
@@ -438,6 +478,8 @@ func TestCatfileReader_MultipleEmptyBlobs(t *testing.T) {
 // through the io.Reader interface returns 0 bytes and io.EOF, and that
 // the trailing LF is consumed transparently.
 func TestCatfileReader_EmptyBlobRead(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{
 		blobs["empty.txt"], // 0 bytes
@@ -486,6 +528,8 @@ func TestCatfileReader_EmptyBlobRead(t *testing.T) {
 // missing objects is handled gracefully — no errors, no panics, just
 // missing=true for each followed by EOF.
 func TestCatfileReader_AllMissing(t *testing.T) {
+	t.Parallel()
+
 	repoDir, _ := createTestRepo(t)
 
 	ids := []plumbing.Hash{
@@ -522,6 +566,8 @@ func TestCatfileReader_AllMissing(t *testing.T) {
 // TestCatfileReader_AlternatingMissingPresent interleaves missing and
 // present objects, verifying that stream alignment is maintained.
 func TestCatfileReader_AlternatingMissingPresent(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	fake1 := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
@@ -599,6 +645,8 @@ func TestCatfileReader_AlternatingMissingPresent(t *testing.T) {
 // the stream. Missing objects have no content body, so there must be
 // no stale pending bytes interfering with the next header read.
 func TestCatfileReader_MissingThenSkip(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	fake := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
@@ -649,6 +697,8 @@ func TestCatfileReader_MissingThenSkip(t *testing.T) {
 // TestCatfileReader_RepeatedNextAfterEOF verifies that calling Next
 // after EOF keeps returning EOF — not a panic, not a different error.
 func TestCatfileReader_RepeatedNextAfterEOF(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["hello.txt"]}
 
@@ -684,6 +734,8 @@ func TestCatfileReader_RepeatedNextAfterEOF(t *testing.T) {
 // is read with byte-exact precision — no off-by-one from trailing LF
 // handling, no truncation, no extra bytes.
 func TestCatfileReader_LargeBlobBytePrecision(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["large.bin"]}
 
@@ -732,6 +784,8 @@ func TestCatfileReader_LargeBlobBytePrecision(t *testing.T) {
 // chunks (a prime number that doesn't align with any power-of-2 buffer)
 // to verify no byte is lost or duplicated across read boundaries.
 func TestCatfileReader_LargeBlobChunkedRead(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 	ids := []plumbing.Hash{blobs["large.bin"]}
 
@@ -778,6 +832,8 @@ func TestCatfileReader_LargeBlobChunkedRead(t *testing.T) {
 // SHA multiple times works — git cat-file --batch outputs the object
 // for each request independently.
 func TestCatfileReader_DuplicateSHAs(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	sha := blobs["hello.txt"]

--- a/gitindex/catfile_test.go
+++ b/gitindex/catfile_test.go
@@ -1,10 +1,12 @@
 package gitindex
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -17,43 +19,36 @@ func createTestRepo(t *testing.T) (string, map[string]plumbing.Hash) {
 	dir := t.TempDir()
 	repoDir := filepath.Join(dir, "repo")
 
-	script := `
-set -e
-git init -b main repo
-cd repo
-git config user.email "test@test.com"
-git config user.name "Test"
+	runGit(t, dir, "init", "-b", "main", "repo")
 
-# Normal text file
-echo "hello world" > hello.txt
-
-# Empty file
-touch empty.txt
-
-# Binary file with newlines embedded
-printf '\x00\x01\x02\nhello\nworld\n\x03\x04' > binary.bin
-
-# Large-ish file (64KB of data)
-dd if=/dev/urandom bs=1024 count=64 of=large.bin 2>/dev/null
-
-git add -A
-git commit -m "initial"
-`
-	cmd := exec.Command("/bin/sh", "-c", script)
-	cmd.Dir = dir
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("create test repo: %v", err)
+	files := []struct {
+		name    string
+		content []byte
+	}{
+		{name: "hello.txt", content: []byte("hello world\n")},
+		{name: "empty.txt"},
+		{name: "binary.bin", content: []byte{0x00, 0x01, 0x02, '\n', 'h', 'e', 'l', 'l', 'o', '\n', 'w', 'o', 'r', 'l', 'd', '\n', 0x03, 0x04}},
+		{name: "large.bin", content: bytes.Repeat([]byte("0123456789abcdef"), 4096)},
 	}
+
+	for _, file := range files {
+		if err := os.WriteFile(filepath.Join(repoDir, file.name), file.content, 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", file.name, err)
+		}
+	}
+
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial")
 
 	// Get blob SHAs for each file.
 	blobs := map[string]plumbing.Hash{}
-	for _, name := range []string{"hello.txt", "empty.txt", "binary.bin", "large.bin"} {
+	for _, file := range files {
+		name := file.name
 		out, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD:"+name).Output()
 		if err != nil {
 			t.Fatalf("rev-parse %s: %v", name, err)
 		}
-		sha := string(out[:len(out)-1]) // trim newline
+		sha := strings.TrimSpace(string(out))
 		blobs[name] = plumbing.NewHash(sha)
 	}
 

--- a/gitindex/catfile_test.go
+++ b/gitindex/catfile_test.go
@@ -61,6 +61,8 @@ git commit -m "initial"
 }
 
 func TestCatfileReader(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	ids := []plumbing.Hash{
@@ -147,6 +149,8 @@ func TestCatfileReader(t *testing.T) {
 }
 
 func TestCatfileReader_Skip(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	ids := []plumbing.Hash{
@@ -191,6 +195,8 @@ func TestCatfileReader_Skip(t *testing.T) {
 }
 
 func TestCatfileReader_Missing(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	fakeHash := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
@@ -242,6 +248,8 @@ func TestCatfileReader_Missing(t *testing.T) {
 }
 
 func TestCatfileReader_Excluded(t *testing.T) {
+	t.Parallel()
+
 	repoDir, blobs := createTestRepo(t)
 
 	ids := []plumbing.Hash{

--- a/gitindex/clone_test.go
+++ b/gitindex/clone_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestSetRemote(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	script := `mkdir orig

--- a/gitindex/delete_test.go
+++ b/gitindex/delete_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestDeleteRepos(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {

--- a/gitindex/ignore_test.go
+++ b/gitindex/ignore_test.go
@@ -48,6 +48,8 @@ git update-ref refs/meta/config HEAD
 }
 
 func TestIgnore(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSourcegraphignoreRepo(dir); err != nil {

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -851,13 +850,13 @@ func TestIndexDeltaBasic(t *testing.T) {
 			repositoryDir := t.TempDir()
 
 			// setup: initialize the repository and all of its branches
-			runScript(t, repositoryDir, "git init -b master")
-			runScript(t, repositoryDir, fmt.Sprintf("git config user.email %q", "you@example.com"))
-			runScript(t, repositoryDir, fmt.Sprintf("git config user.name %q", "Your Name"))
+			runGit(t, repositoryDir, "init", "-b", "master")
+			runGit(t, repositoryDir, "config", "user.email", "you@example.com")
+			runGit(t, repositoryDir, "config", "user.name", "Your Name")
 
 			for _, b := range test.branches {
-				runScript(t, repositoryDir, fmt.Sprintf("git checkout -b %q", b))
-				runScript(t, repositoryDir, fmt.Sprintf("git commit --allow-empty -m %q", "empty commit"))
+				runGit(t, repositoryDir, "checkout", "-b", b)
+				runGit(t, repositoryDir, "commit", "--allow-empty", "-m", "empty commit")
 			}
 
 			for _, step := range test.steps {
@@ -867,7 +866,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 
 						hadChange := false
 
-						runScript(t, repositoryDir, fmt.Sprintf("git checkout %q", b))
+						runGit(t, repositoryDir, "checkout", b)
 
 						for _, d := range step.deletedDocuments[b] {
 							hadChange = true
@@ -878,8 +877,6 @@ func TestIndexDeltaBasic(t *testing.T) {
 							if err != nil {
 								t.Fatalf("deleting file %q: %s", d.Name, err)
 							}
-
-							runScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
 						}
 
 						for _, d := range step.addedDocuments[b] {
@@ -896,15 +893,14 @@ func TestIndexDeltaBasic(t *testing.T) {
 							if err != nil {
 								t.Fatalf("writing file %q: %s", d.Name, err)
 							}
-
-							runScript(t, repositoryDir, fmt.Sprintf("git add %q", file))
 						}
 
 						if !hadChange {
 							continue
 						}
 
-						runScript(t, repositoryDir, fmt.Sprintf("git commit -m %q", step.name))
+						runGit(t, repositoryDir, "add", "-A")
+						runGit(t, repositoryDir, "commit", "-m", step.name)
 					}
 
 					// setup: prepare indexOptions with given overrides
@@ -1020,7 +1016,7 @@ func TestIndexDeltaBasic(t *testing.T) {
 	}
 }
 
-func runScript(t *testing.T, cwd string, script string) {
+func runGit(t *testing.T, cwd string, args ...string) {
 	t.Helper()
 
 	err := os.MkdirAll(cwd, 0o755)
@@ -1028,7 +1024,7 @@ func runScript(t *testing.T, cwd string, script string) {
 		t.Fatalf("ensuring path %q exists: %s", cwd, err)
 	}
 
-	cmd := exec.Command("sh", "-euxc", script)
+	cmd := exec.Command("git", args...)
 	cmd.Dir = cwd
 	cmd.Env = append([]string{"GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM="}, os.Environ()...)
 
@@ -1043,8 +1039,8 @@ func TestSetTemplates_e2e(t *testing.T) {
 	repositoryDir := t.TempDir()
 
 	// setup: initialize the repository and all of its branches
-	runScript(t, repositoryDir, "git init -b master")
-	runScript(t, repositoryDir, "git config remote.origin.url git@github.com:sourcegraph/zoekt.git")
+	runGit(t, repositoryDir, "init", "-b", "master")
+	runGit(t, repositoryDir, "config", "remote.origin.url", "git@github.com:sourcegraph/zoekt.git")
 	desc := zoekt.Repository{}
 	if err := setTemplatesFromConfig(&desc, repositoryDir); err != nil {
 		t.Fatalf("setTemplatesFromConfig: %v", err)

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -41,6 +41,8 @@ import (
 )
 
 func TestIndexEmptyRepo(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	cmd := exec.Command("git", "init", "-b", "master", "repo")
@@ -67,6 +69,8 @@ func TestIndexEmptyRepo(t *testing.T) {
 }
 
 func TestIndexNonexistentRepo(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	desc := zoekt.Repository{
 		Name: "nonexistent",
@@ -88,6 +92,8 @@ func TestIndexNonexistentRepo(t *testing.T) {
 }
 
 func TestIndexTinyRepo(t *testing.T) {
+	t.Parallel()
+
 	// Create a repo with one file in it.
 	dir := t.TempDir()
 	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
@@ -133,6 +139,8 @@ func TestIndexTinyRepo(t *testing.T) {
 }
 
 func TestIndexGitRepo_Worktree(t *testing.T) {
+	t.Parallel()
+
 	_, worktreeDir := initGitWorktree(t, "file1.go", "package main\n\nfunc main() {}\n")
 	indexDir := t.TempDir()
 
@@ -166,6 +174,8 @@ func TestIndexGitRepo_Worktree(t *testing.T) {
 }
 
 func TestOpenRepoVariants(t *testing.T) {
+	t.Parallel()
+
 	repoDir, worktreeDir := initGitWorktree(t, "file1.go", "package main\n\nfunc main() {}\n")
 	bareDir := cloneBareRepo(t, repoDir)
 
@@ -217,6 +227,8 @@ func TestOpenRepoVariants(t *testing.T) {
 	for _, opener := range openers {
 		for _, tc := range paths {
 			t.Run(opener.name+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+
 				repo := opener.open(t, tc.path)
 
 				head, err := repo.Head()
@@ -269,6 +281,8 @@ func TestIndexGitRepo_BareRepo_LegacyRepoOpen(t *testing.T) {
 }
 
 func TestCatfileFilterSpec(t *testing.T) {
+	t.Parallel()
+
 	for _, tc := range []struct {
 		name string
 		opts Options
@@ -291,6 +305,8 @@ func TestCatfileFilterSpec(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			if got := catfileFilterSpec(tc.opts); got != tc.want {
 				t.Fatalf("catfileFilterSpec() = %q, want %q", got, tc.want)
 			}
@@ -344,6 +360,8 @@ func cloneBareRepo(t *testing.T, repoDir string) string {
 }
 
 func TestIndexDeltaBasic(t *testing.T) {
+	t.Parallel()
+
 	type branchToDocumentMap map[string][]index.Document
 
 	type step struct {
@@ -1020,6 +1038,8 @@ func runScript(t *testing.T, cwd string, script string) {
 }
 
 func TestSetTemplates_e2e(t *testing.T) {
+	t.Parallel()
+
 	repositoryDir := t.TempDir()
 
 	// setup: initialize the repository and all of its branches
@@ -1036,6 +1056,8 @@ func TestSetTemplates_e2e(t *testing.T) {
 }
 
 func TestSetTemplates_Worktree(t *testing.T) {
+	t.Parallel()
+
 	_, worktreeDir := initGitWorktree(t, "hello.go", "package main\n")
 	desc := zoekt.Repository{}
 
@@ -1049,6 +1071,8 @@ func TestSetTemplates_Worktree(t *testing.T) {
 }
 
 func TestSetTemplates(t *testing.T) {
+	t.Parallel()
+
 	base := "https://example.com/repo/name"
 	version := "VERSION"
 	path := "dir/name.txt"
@@ -1102,6 +1126,8 @@ func TestSetTemplates(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.typ, func(t *testing.T) {
+			t.Parallel()
+
 			assertOutput := func(templateText string, want string) {
 				t.Helper()
 

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -95,14 +95,14 @@ func TestIndexTinyRepo(t *testing.T) {
 
 	// Create a repo with one file in it.
 	dir := t.TempDir()
-	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
+	runGit(t, dir, "init", "-b", "main", "repo")
 
 	repoDir := filepath.Join(dir, "repo")
 	if err := os.WriteFile(filepath.Join(repoDir, "file1.go"), []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	executeCommand(t, repoDir, exec.Command("git", "add", "."))
-	executeCommand(t, repoDir, exec.Command("git", "commit", "-m", "initial commit"))
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial commit")
 
 	// Test that indexing accepts both the repo directory, and the .git subdirectory.
 	for _, testDir := range []string{"repo", "repo/.git"} {
@@ -313,38 +313,22 @@ func TestCatfileFilterSpec(t *testing.T) {
 	}
 }
 
-func executeCommand(t *testing.T, dir string, cmd *exec.Cmd) *exec.Cmd {
-	cmd.Dir = dir
-	cmd.Env = []string{
-		"GIT_CONFIG_GLOBAL=",
-		"GIT_CONFIG_SYSTEM=",
-		"GIT_COMMITTER_NAME=Kierkegaard",
-		"GIT_COMMITTER_EMAIL=soren@apache.com",
-		"GIT_AUTHOR_NAME=Kierkegaard",
-		"GIT_AUTHOR_EMAIL=soren@apache.com",
-	}
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("cmd.Run: %v", err)
-	}
-	return cmd
-}
-
 func initGitWorktree(t *testing.T, fileName, content string) (string, string) {
 	t.Helper()
 
 	dir := t.TempDir()
-	executeCommand(t, dir, exec.Command("git", "init", "-b", "main", "repo"))
+	runGit(t, dir, "init", "-b", "main", "repo")
 
 	repoDir := filepath.Join(dir, "repo")
 	if err := os.WriteFile(filepath.Join(repoDir, fileName), []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	executeCommand(t, repoDir, exec.Command("git", "config", "remote.origin.url", "git@github.com:sourcegraph/zoekt.git"))
-	executeCommand(t, repoDir, exec.Command("git", "add", "."))
-	executeCommand(t, repoDir, exec.Command("git", "commit", "-m", "initial commit"))
+	runGit(t, repoDir, "config", "remote.origin.url", "git@github.com:sourcegraph/zoekt.git")
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "initial commit")
 
 	worktreeDir := filepath.Join(dir, "wt")
-	executeCommand(t, repoDir, exec.Command("git", "worktree", "add", "-b", "worktree-branch", worktreeDir))
+	runGit(t, repoDir, "worktree", "add", "-b", "worktree-branch", worktreeDir)
 
 	return repoDir, worktreeDir
 }
@@ -353,7 +337,7 @@ func cloneBareRepo(t *testing.T, repoDir string) string {
 	t.Helper()
 
 	bareDir := filepath.Join(t.TempDir(), "repo.git")
-	executeCommand(t, filepath.Dir(repoDir), exec.Command("git", "clone", "--bare", repoDir, bareDir))
+	runGit(t, filepath.Dir(repoDir), "clone", "--bare", repoDir, bareDir)
 
 	return bareDir
 }
@@ -851,8 +835,6 @@ func TestIndexDeltaBasic(t *testing.T) {
 
 			// setup: initialize the repository and all of its branches
 			runGit(t, repositoryDir, "init", "-b", "master")
-			runGit(t, repositoryDir, "config", "user.email", "you@example.com")
-			runGit(t, repositoryDir, "config", "user.name", "Your Name")
 
 			for _, b := range test.branches {
 				runGit(t, repositoryDir, "checkout", "-b", b)
@@ -1026,7 +1008,14 @@ func runGit(t *testing.T, cwd string, args ...string) {
 
 	cmd := exec.Command("git", args...)
 	cmd.Dir = cwd
-	cmd.Env = append([]string{"GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM="}, os.Environ()...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=",
+		"GIT_CONFIG_SYSTEM=",
+		"GIT_COMMITTER_NAME=Kierkegaard",
+		"GIT_COMMITTER_EMAIL=soren@apache.com",
+		"GIT_AUTHOR_NAME=Kierkegaard",
+		"GIT_AUTHOR_EMAIL=soren@apache.com",
+	)
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("execution error: %v, output %s", err, out)

--- a/gitindex/main_test.go
+++ b/gitindex/main_test.go
@@ -1,0 +1,19 @@
+package gitindex
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+
+	os.Exit(m.Run())
+}

--- a/gitindex/repocache_test.go
+++ b/gitindex/repocache_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestListReposNonExistent(t *testing.T) {
+	t.Parallel()
+
 	u, err := url.Parse("https://gerrit.googlesource.com/")
 	if err != nil {
 		t.Fatalf("url.Parse: %v", err)
@@ -34,6 +36,8 @@ func TestListReposNonExistent(t *testing.T) {
 }
 
 func TestListRepos(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {

--- a/gitindex/submodule_test.go
+++ b/gitindex/submodule_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestParseGitModules(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		data string
 		want map[string]*SubmoduleEntry

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -106,6 +106,8 @@ EOF
 }
 
 func TestFindGitRepos(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -141,6 +143,8 @@ func TestFindGitRepos(t *testing.T) {
 }
 
 func TestCollectFiles(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -195,6 +199,8 @@ func TestCollectFiles(t *testing.T) {
 }
 
 func TestSubmoduleIndex(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -259,6 +265,8 @@ func TestSubmoduleIndex(t *testing.T) {
 }
 
 func TestSubmoduleIndexWithoutRepocache(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -363,6 +371,8 @@ EOF
 }
 
 func TestSearchSymlinkByContent(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSymlinkRepo(dir); err != nil {
@@ -420,6 +430,8 @@ func TestSearchSymlinkByContent(t *testing.T) {
 }
 
 func TestAllowMissingBranch(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -486,6 +498,8 @@ git update-ref refs/meta/config HEAD
 }
 
 func TestBranchWildcard(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createMultibranchRepo(dir); err != nil {
@@ -532,6 +546,8 @@ func TestBranchWildcard(t *testing.T) {
 }
 
 func TestSkipSubmodules(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createSubmoduleRepo(dir); err != nil {
@@ -564,6 +580,8 @@ func TestSkipSubmodules(t *testing.T) {
 }
 
 func TestFullAndShortRefNames(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 
 	if err := createMultibranchRepo(dir); err != nil {
@@ -609,6 +627,8 @@ func TestFullAndShortRefNames(t *testing.T) {
 }
 
 func TestUniq(t *testing.T) {
+	t.Parallel()
+
 	in := []string{"a", "b", "b", "c", "c"}
 	want := []string{"a", "b", "c"}
 	got := uniq(in)
@@ -618,6 +638,8 @@ func TestUniq(t *testing.T) {
 }
 
 func TestLatestCommit(t *testing.T) {
+	t.Parallel()
+
 	dir := t.TempDir()
 	indexDir := t.TempDir()
 


### PR DESCRIPTION
I noticed gitindex tests taking 16s to run on my mbp. They now take 4s. We speed them up via a generous sprinkling of t.Parallel(), as well as speeding up fixture setup via shelling out to git less and directly creating fixture files via go instead of shell commands.

Additionally we turn of stdlib logging unless tests are run in verbose mode.

https://ampcode.com/threads/T-019d42dd-0968-773b-8369-757e9e1bd5e6