### PR TITLE
ci: cross-platform test matrix with git version testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,21 +63,23 @@ jobs:
 
           NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
-          # On macOS, Homebrew keg-only packages (openssl, curl, gettext) are
-          # not linked into the default search paths. Git's config.mak.uname
-          # gained Homebrew auto-detection around v2.47, but older versions
-          # (2.34.1, 2.39.5) lack it. Git's Makefile overrides CFLAGS and
-          # LDFLAGS env vars, so we pass them on the make command line where
-          # they take precedence over Makefile assignments.
-          MAKE_ARGS="prefix=$HOME/git-install"
+          # On macOS, Homebrew keg-only packages (openssl, curl, expat,
+          # gettext) are not linked into the default search paths.
+          # Git's config.mak.uname has partial Homebrew auto-detection:
+          #   - gettext: since git 2.27 (Intel), 2.44 (ARM)
+          #   - openssl, curl, expat: NOT auto-detected in any version
+          # Git's Makefile uses -include config.mak (silently skipped if
+          # absent), so we write paths there. Uses += to append to flags.
           if [ "$RUNNER_OS" = "macOS" ]; then
             BREW_PREFIX=$(brew --prefix)
-            MAKE_ARGS="$MAKE_ARGS CPPFLAGS=-I${BREW_PREFIX}/opt/openssl/include\ -I${BREW_PREFIX}/opt/curl/include\ -I${BREW_PREFIX}/opt/expat/include\ -I${BREW_PREFIX}/opt/gettext/include"
-            MAKE_ARGS="$MAKE_ARGS LDFLAGS=-L${BREW_PREFIX}/opt/openssl/lib\ -L${BREW_PREFIX}/opt/curl/lib\ -L${BREW_PREFIX}/opt/expat/lib\ -L${BREW_PREFIX}/opt/gettext/lib"
+            printf '%s\n' \
+              "CPPFLAGS += -I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include" \
+              "LDFLAGS += -L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib" \
+              > config.mak
           fi
 
-          make $MAKE_ARGS -j"$NPROC" all
-          make $MAKE_ARGS install
+          make prefix="$HOME/git-install" -j"$NPROC" all
+          make prefix="$HOME/git-install" install
 
       - name: Verify git build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     outputs:
       runners: ${{ steps.matrix.outputs.runners }}
       git-versions: ${{ steps.matrix.outputs.git-versions }}
+      ctags-versions: ${{ steps.matrix.outputs.ctags-versions }}
     steps:
       - name: Define matrix
         id: matrix
@@ -22,6 +23,10 @@ jobs:
           #   2.47.3 — Debian 13 (Trixie) + Alpine 3.21, ships 1:2.47.3-0+deb13u1, also failing in #1029
           #   2.53.0 — Latest stable (2026-02-02), first version with cat-file --batch --filter= (added in 2.50.0)
           echo 'git-versions=["2.34.1","2.39.5","2.47.3","2.53.0"]' >> "$GITHUB_OUTPUT"
+          # Universal-ctags versions to test against:
+          #   p5.9.20210829.0 — Ubuntu 22.04/24.04 LTS, ships 5.9.20210829.0-1 (2021-08-29 snapshot)
+          #   v6.2.1 — Latest stable, matches Homebrew and Alpine Edge
+          echo 'ctags-versions=["p5.9.20210829.0","v6.2.1"]' >> "$GITHUB_OUTPUT"
 
   build-git:
     needs: init
@@ -79,15 +84,68 @@ jobs:
           path: ~/git-install
           retention-days: 1
 
+  build-ctags:
+    needs: init
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(needs.init.outputs.runners) }}
+        ctags-version: ${{ fromJSON(needs.init.outputs.ctags-versions) }}
+    runs-on: ${{ matrix.runner }}
+    name: build-ctags (${{ matrix.runner }}, ctags ${{ matrix.ctags-version }})
+    steps:
+      - name: Cache ctags build
+        id: cache-ctags
+        uses: actions/cache@v5.0.4
+        with:
+          path: ~/ctags-install
+          key: ctags-${{ matrix.ctags-version }}-${{ matrix.runner }}
+
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux' && steps.cache-ctags.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc make pkg-config autoconf automake libjansson-dev libyaml-dev libxml2-dev
+
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS' && steps.cache-ctags.outputs.cache-hit != 'true'
+        run: brew install autoconf automake pkg-config jansson libyaml pcre2
+
+      - name: Build universal-ctags from source
+        if: steps.cache-ctags.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL "https://github.com/universal-ctags/ctags/archive/refs/tags/${{ matrix.ctags-version }}.tar.gz" | tar xz
+          cd ctags-*/
+
+          NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+
+          ./autogen.sh
+          ./configure --prefix="$HOME/ctags-install" --program-prefix=universal- --enable-json
+          make -j"$NPROC"
+          make install
+
+      - name: Verify ctags build
+        run: |
+          "$HOME/ctags-install/bin/universal-ctags" --version
+          "$HOME/ctags-install/bin/universal-ctags" --version | grep -q "Universal Ctags"
+
+      - name: Upload ctags binaries
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: ctags-${{ matrix.ctags-version }}-${{ matrix.runner }}
+          path: ~/ctags-install
+          retention-days: 1
+
   test:
-    needs: [init, build-git]
+    needs: [init, build-git, build-ctags]
     strategy:
       fail-fast: false
       matrix:
         runner: ${{ fromJSON(needs.init.outputs.runners) }}
         git-version: ${{ fromJSON(needs.init.outputs.git-versions) }}
+        ctags-version: ${{ fromJSON(needs.init.outputs.ctags-versions) }}
     runs-on: ${{ matrix.runner }}
-    name: test (${{ matrix.runner }}, git ${{ matrix.git-version }})
+    name: test (${{ matrix.runner }}, git ${{ matrix.git-version }}, ctags ${{ matrix.ctags-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -108,20 +166,31 @@ jobs:
           chmod -R +x "$HOME/git-install/bin" "$HOME/git-install/libexec"
           echo "$HOME/git-install/bin" >> "$GITHUB_PATH"
 
-      - name: Install universal-ctags (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y universal-ctags
+      - name: Download ctags binaries
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: ctags-${{ matrix.ctags-version }}-${{ matrix.runner }}
+          path: ~/ctags-install
 
-      - name: Install universal-ctags (macOS)
+      - name: Add ctags to PATH
+        run: |
+          chmod -R +x "$HOME/ctags-install/bin"
+          echo "$HOME/ctags-install/bin" >> "$GITHUB_PATH"
+
+      - name: Install ctags runtime dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libjansson4 libyaml-0-2 libxml2
+
+      - name: Install ctags runtime dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install universal-ctags
+        run: brew install jansson libyaml pcre2
 
       - name: Print versions
         run: |
           go version
           git --version
           git --version | grep -q "${{ matrix.git-version }}"
-          universal-ctags --version || true
+          universal-ctags --version
 
       - name: Test
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,12 @@ jobs:
           # not linked into the default search paths. Git's config.mak.uname
           # gained Homebrew auto-detection for gettext around v2.47, but older
           # versions in our matrix (2.34.1, 2.39.5) lack it and fail with
-          # 'libintl.h' not found. Explicit CFLAGS/LDFLAGS ensure all versions
-          # build consistently. See: git INSTALL docs, config.mak.uname.
+          # 'libintl.h' not found. We use CPPFLAGS/LDFLAGS (not CFLAGS) because
+          # git's Makefile overrides CFLAGS but preserves CPPFLAGS via
+          # ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS).
           if [ "$RUNNER_OS" = "macOS" ]; then
             BREW_PREFIX=$(brew --prefix)
-            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
+            export CPPFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
             export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS' && steps.cache-git.outputs.cache-hit != 'true'
-        run: brew install openssl curl expat
+        run: brew install openssl curl expat gettext
 
       - name: Build git from source
         if: steps.cache-git.outputs.cache-hit != 'true'
@@ -65,8 +65,8 @@ jobs:
 
           if [ "$RUNNER_OS" = "macOS" ]; then
             BREW_PREFIX=$(brew --prefix)
-            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include"
-            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib"
+            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
+            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib"
           fi
 
           make prefix="$HOME/git-install" -j"$NPROC" all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           - macos-15-intel
           - macos-26-intel
         git-version:
-          - "2.34.1"
-          - "2.39.5"
-          - "2.47.3"
-          - "2.53.0"
+          - "2.34.1" # Ubuntu 22.04 LTS (Jammy) — oldest supported LTS, ships 1:2.34.1-1ubuntu1
+          - "2.39.5" # Debian 12 (Bookworm) — ships 1:2.39.5-0+deb12u3, reported failing in #1029
+          - "2.47.3" # Debian 13 (Trixie) + Alpine 3.21 — ships 1:2.47.3-0+deb13u1, also failing in #1029
+          - "2.53.0" # Latest stable (2026-02-02) — first version in matrix with cat-file --batch --filter= (added in 2.50.0)
     runs-on: ${{ matrix.runner }}
     name: build-git (${{ matrix.runner }}, git ${{ matrix.git-version }})
     steps:
@@ -88,10 +88,10 @@ jobs:
           - macos-15-intel
           - macos-26-intel
         git-version:
-          - "2.34.1"
-          - "2.39.5"
-          - "2.47.3"
-          - "2.53.0"
+          - "2.34.1" # Ubuntu 22.04 LTS (Jammy) — oldest supported LTS, ships 1:2.34.1-1ubuntu1
+          - "2.39.5" # Debian 12 (Bookworm) — ships 1:2.39.5-0+deb12u3, reported failing in #1029
+          - "2.47.3" # Debian 13 (Trixie) + Alpine 3.21 — ships 1:2.47.3-0+deb13u1, also failing in #1029
+          - "2.53.0" # Latest stable (2026-02-02) — first version in matrix with cat-file --batch --filter= (added in 2.50.0)
     runs-on: ${{ matrix.runner }}
     name: test (${{ matrix.runner }}, git ${{ matrix.git-version }})
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,24 +6,30 @@ on:
   workflow_dispatch:
 name: CI
 jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.matrix.outputs.runners }}
+      git-versions: ${{ steps.matrix.outputs.git-versions }}
+    steps:
+      - name: Define matrix
+        id: matrix
+        run: |
+          echo 'runners=["ubuntu-24.04","ubuntu-22.04","ubuntu-24.04-arm","ubuntu-22.04-arm","macos-15","macos-26","macos-15-intel","macos-26-intel"]' >> "$GITHUB_OUTPUT"
+          # Git versions to test against:
+          #   2.34.1 — Ubuntu 22.04 LTS (Jammy), oldest supported LTS, ships 1:2.34.1-1ubuntu1
+          #   2.39.5 — Debian 12 (Bookworm), ships 1:2.39.5-0+deb12u3, reported failing in #1029
+          #   2.47.3 — Debian 13 (Trixie) + Alpine 3.21, ships 1:2.47.3-0+deb13u1, also failing in #1029
+          #   2.53.0 — Latest stable (2026-02-02), first version with cat-file --batch --filter= (added in 2.50.0)
+          echo 'git-versions=["2.34.1","2.39.5","2.47.3","2.53.0"]' >> "$GITHUB_OUTPUT"
+
   build-git:
+    needs: init
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-24.04
-          - ubuntu-22.04
-          - ubuntu-24.04-arm
-          - ubuntu-22.04-arm
-          - macos-15
-          - macos-26
-          - macos-15-intel
-          - macos-26-intel
-        git-version:
-          - "2.34.1" # Ubuntu 22.04 LTS (Jammy) — oldest supported LTS, ships 1:2.34.1-1ubuntu1
-          - "2.39.5" # Debian 12 (Bookworm) — ships 1:2.39.5-0+deb12u3, reported failing in #1029
-          - "2.47.3" # Debian 13 (Trixie) + Alpine 3.21 — ships 1:2.47.3-0+deb13u1, also failing in #1029
-          - "2.53.0" # Latest stable (2026-02-02) — first version in matrix with cat-file --batch --filter= (added in 2.50.0)
+        runner: ${{ fromJSON(needs.init.outputs.runners) }}
+        git-version: ${{ fromJSON(needs.init.outputs.git-versions) }}
     runs-on: ${{ matrix.runner }}
     name: build-git (${{ matrix.runner }}, git ${{ matrix.git-version }})
     steps:
@@ -74,24 +80,12 @@ jobs:
           retention-days: 1
 
   test:
-    needs: build-git
+    needs: [init, build-git]
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-24.04
-          - ubuntu-22.04
-          - ubuntu-24.04-arm
-          - ubuntu-22.04-arm
-          - macos-15
-          - macos-26
-          - macos-15-intel
-          - macos-26-intel
-        git-version:
-          - "2.34.1" # Ubuntu 22.04 LTS (Jammy) — oldest supported LTS, ships 1:2.34.1-1ubuntu1
-          - "2.39.5" # Debian 12 (Bookworm) — ships 1:2.39.5-0+deb12u3, reported failing in #1029
-          - "2.47.3" # Debian 13 (Trixie) + Alpine 3.21 — ships 1:2.47.3-0+deb13u1, also failing in #1029
-          - "2.53.0" # Latest stable (2026-02-02) — first version in matrix with cat-file --batch --filter= (added in 2.50.0)
+        runner: ${{ fromJSON(needs.init.outputs.runners) }}
+        git-version: ${{ fromJSON(needs.init.outputs.git-versions) }}
     runs-on: ${{ matrix.runner }}
     name: test (${{ matrix.runner }}, git ${{ matrix.git-version }})
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,18 @@ jobs:
 
           NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
+          # On macOS, Homebrew keg-only packages (openssl, curl, gettext) are
+          # not linked into the default search paths. Git's config.mak.uname
+          # gained Homebrew auto-detection for gettext around v2.47, but older
+          # versions in our matrix (2.34.1, 2.39.5) lack it and fail with
+          # 'libintl.h' not found. Explicit CFLAGS/LDFLAGS ensure all versions
+          # build consistently. See: git INSTALL docs, config.mak.uname.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            BREW_PREFIX=$(brew --prefix)
+            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
+            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib"
+          fi
+
           make prefix="$HOME/git-install" -j"$NPROC" all
           make prefix="$HOME/git-install" install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,19 +65,19 @@ jobs:
 
           # On macOS, Homebrew keg-only packages (openssl, curl, gettext) are
           # not linked into the default search paths. Git's config.mak.uname
-          # gained Homebrew auto-detection for gettext around v2.47, but older
-          # versions in our matrix (2.34.1, 2.39.5) lack it and fail with
-          # 'libintl.h' not found. We use CPPFLAGS/LDFLAGS (not CFLAGS) because
-          # git's Makefile overrides CFLAGS but preserves CPPFLAGS via
-          # ALL_CFLAGS = $(CPPFLAGS) $(CFLAGS).
+          # gained Homebrew auto-detection around v2.47, but older versions
+          # (2.34.1, 2.39.5) lack it. Git's Makefile overrides CFLAGS and
+          # LDFLAGS env vars, so we pass them on the make command line where
+          # they take precedence over Makefile assignments.
+          MAKE_ARGS="prefix=$HOME/git-install"
           if [ "$RUNNER_OS" = "macOS" ]; then
             BREW_PREFIX=$(brew --prefix)
-            export CPPFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
-            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib"
+            MAKE_ARGS="$MAKE_ARGS CPPFLAGS=-I${BREW_PREFIX}/opt/openssl/include\ -I${BREW_PREFIX}/opt/curl/include\ -I${BREW_PREFIX}/opt/expat/include\ -I${BREW_PREFIX}/opt/gettext/include"
+            MAKE_ARGS="$MAKE_ARGS LDFLAGS=-L${BREW_PREFIX}/opt/openssl/lib\ -L${BREW_PREFIX}/opt/curl/lib\ -L${BREW_PREFIX}/opt/expat/lib\ -L${BREW_PREFIX}/opt/gettext/lib"
           fi
 
-          make prefix="$HOME/git-install" -j"$NPROC" all
-          make prefix="$HOME/git-install" install
+          make $MAKE_ARGS -j"$NPROC" all
+          make $MAKE_ARGS install
 
       - name: Verify git build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,6 @@ jobs:
 
           NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            BREW_PREFIX=$(brew --prefix)
-            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include -I${BREW_PREFIX}/opt/gettext/include"
-            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib -L${BREW_PREFIX}/opt/gettext/lib"
-          fi
-
           make prefix="$HOME/git-install" -j"$NPROC" all
           make prefix="$HOME/git-install" install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,39 +6,130 @@ on:
   workflow_dispatch:
 name: CI
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    container: alpine:edge # latest go pls
+  build-git:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-15
+          - macos-26
+          - macos-15-intel
+          - macos-26-intel
+        git-version:
+          - "2.34.1"
+          - "2.39.5"
+          - "2.47.3"
+          - "2.53.0"
+    runs-on: ${{ matrix.runner }}
+    name: build-git (${{ matrix.runner }}, git ${{ matrix.git-version }})
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: add dependencies
-        run: apk add go git tar
-
-      - name: Cache ctags
-        uses: actions/cache@v3
+      - name: Cache git build
+        id: cache-git
+        uses: actions/cache@v5.0.4
         with:
-          path: /usr/local/bin/universal-ctags
-          key: ${{ runner.os }}-ctags-${{ hashFiles('install-ctags-alpine.sh') }}
+          path: ~/git-install
+          key: git-${{ matrix.git-version }}-${{ matrix.runner }}
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: install ctags
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux' && steps.cache-git.outputs.cache-hit != 'true'
         run: |
-          if [ ! -f /usr/local/bin/universal-ctags ]; then
-            ./install-ctags-alpine.sh
+          sudo apt-get update
+          sudo apt-get install -y make libssl-dev libcurl4-gnutls-dev libexpat1-dev libz-dev gettext
+
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS' && steps.cache-git.outputs.cache-hit != 'true'
+        run: brew install openssl curl expat
+
+      - name: Build git from source
+        if: steps.cache-git.outputs.cache-hit != 'true'
+        run: |
+          curl -fsSL "https://www.kernel.org/pub/software/scm/git/git-${{ matrix.git-version }}.tar.gz" | tar xz
+          cd "git-${{ matrix.git-version }}"
+
+          NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)
+
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            BREW_PREFIX=$(brew --prefix)
+            export CFLAGS="-I${BREW_PREFIX}/opt/openssl/include -I${BREW_PREFIX}/opt/curl/include -I${BREW_PREFIX}/opt/expat/include"
+            export LDFLAGS="-L${BREW_PREFIX}/opt/openssl/lib -L${BREW_PREFIX}/opt/curl/lib -L${BREW_PREFIX}/opt/expat/lib"
           fi
 
-      - name: test
+          make prefix="$HOME/git-install" -j"$NPROC" all
+          make prefix="$HOME/git-install" install
+
+      - name: Verify git build
+        run: |
+          "$HOME/git-install/bin/git" --version
+          "$HOME/git-install/bin/git" --version | grep -q "${{ matrix.git-version }}"
+
+      - name: Upload git binaries
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: git-${{ matrix.git-version }}-${{ matrix.runner }}
+          path: ~/git-install
+          retention-days: 1
+
+  test:
+    needs: build-git
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-22.04
+          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
+          - macos-15
+          - macos-26
+          - macos-15-intel
+          - macos-26-intel
+        git-version:
+          - "2.34.1"
+          - "2.39.5"
+          - "2.47.3"
+          - "2.53.0"
+    runs-on: ${{ matrix.runner }}
+    name: test (${{ matrix.runner }}, git ${{ matrix.git-version }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download git binaries
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: git-${{ matrix.git-version }}-${{ matrix.runner }}
+          path: ~/git-install
+
+      - name: Add git to PATH
+        run: |
+          chmod -R +x "$HOME/git-install/bin" "$HOME/git-install/libexec"
+          echo "$HOME/git-install/bin" >> "$GITHUB_PATH"
+
+      - name: Install universal-ctags (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y universal-ctags
+
+      - name: Install universal-ctags (macOS)
+        if: runner.os == 'macOS'
+        run: brew install universal-ctags
+
+      - name: Print versions
+        run: |
+          go version
+          git --version
+          git --version | grep -q "${{ matrix.git-version }}"
+          universal-ctags --version || true
+
+      - name: Test
         run: go test ./...
 
   fuzz-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,14 +45,14 @@ jobs:
           path: ~/git-install
           key: git-${{ matrix.git-version }}-${{ matrix.runner }}
 
-      - name: Install build dependencies (Linux)
-        if: runner.os == 'Linux' && steps.cache-git.outputs.cache-hit != 'true'
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y make libssl-dev libcurl4-gnutls-dev libexpat1-dev libz-dev gettext
 
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS' && steps.cache-git.outputs.cache-hit != 'true'
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
         run: brew install openssl curl expat gettext
 
       - name: Build git from source
@@ -101,14 +101,14 @@ jobs:
           path: ~/ctags-install
           key: ctags-${{ matrix.ctags-version }}-${{ matrix.runner }}
 
-      - name: Install build dependencies (Linux)
-        if: runner.os == 'Linux' && steps.cache-ctags.outputs.cache-hit != 'true'
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc make pkg-config autoconf automake libjansson-dev libyaml-dev libxml2-dev
 
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS' && steps.cache-ctags.outputs.cache-hit != 'true'
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
         run: brew install autoconf automake pkg-config jansson libyaml pcre2
 
       - name: Build universal-ctags from source


### PR DESCRIPTION
## Summary

- Replace the single Alpine-based `test` job with three decoupled jobs: `build-git`, `build-ctags`, and `test`
- Test across all 4 officially supported platforms: `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`, `x86_64-darwin` (8 runners)
- Test against multiple git versions built from kernel.org tarballs: `2.34.1`, `2.39.5`, `2.47.3`, `2.53.0`
- Test against multiple universal-ctags versions built from source: `p5.9.20210829.0`, `v6.2.1`
- Centralize all matrix variables in an `init` job, consumed via `fromJSON()` — single source of truth
- Pin GitHub Actions to latest semver tags

## Motivation

Issue #1029 revealed that the CI only tested on Alpine Edge (bleeding-edge git + ctags), masking a compatibility regression with `git cat-file --batch --filter=` on older git versions (Debian 12/13, Ubuntu 22.04). More broadly, the CI only covered a single platform/arch despite zoekt officially supporting four.

This PR strengthens the QA posture by testing across the full platform matrix and multiple dependency versions, catching system-level integration issues before they reach users.

## Design

| Job | Purpose |
|---|---|
| `init` | Defines runner, git-version, and ctags-version lists as JSON outputs — single source of truth |
| `build-git` | 8 runners × 4 git versions = 32 builds. Cached across runs, uploaded as artifacts |
| `build-ctags` | 8 runners × 2 ctags versions = 16 builds. Uses `--program-prefix=universal- --enable-json` matching existing `install-ctags-alpine.sh` |
| `test` | 8 runners × 4 git × 2 ctags = 64 combinations. Downloads both artifacts, runs `go test ./...` |

OS-specific steps use `if: runner.os == 'Linux'` / `if: runner.os == 'macOS'` conditionals.

### Git versions

| Version | Source | `--batch --filter=` |
|---|---|---|
| `2.34.1` | Ubuntu 22.04 LTS (Jammy) — `1:2.34.1-1ubuntu1` | No |
| `2.39.5` | Debian 12 (Bookworm) — `1:2.39.5-0+deb12u3`, reported failing in #1029 | No |
| `2.47.3` | Debian 13 (Trixie) + Alpine 3.21 — `1:2.47.3-0+deb13u1`, also failing in #1029 | No |
| `2.53.0` | Latest stable (2026-02-02) | Yes (added in 2.50.0) |

### Universal-ctags versions

| Version | Source |
|---|---|
| `p5.9.20210829.0` | Ubuntu 22.04/24.04 LTS — `5.9.20210829.0-1` (2021 snapshot) |
| `v6.2.1` | Latest stable, matches Homebrew and Alpine Edge |

## Test plan

- [ ] All 32 `build-git` jobs compile successfully
- [ ] All 16 `build-ctags` jobs compile successfully
- [ ] `test` jobs on git 2.53.0 pass — `--filter` is supported
- [ ] `test` jobs on git 2.34.1 / 2.39.5 / 2.47.3 surface expected `cat-file` failures — confirms the CI would have caught #1029
- [ ] Both ctags versions produce valid `universal-ctags` binaries with `+interactive`
- [ ] macOS builds use correct brew prefix (ARM vs Intel)

Related to #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)