### PR TITLE
ci: correctly cleanup ctags tmp in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,9 @@ FROM alpine:3
 RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget
 
 COPY --chmod=755 install-ctags-alpine.sh /usr/local/bin/install-ctags-alpine.sh
-RUN /usr/local/bin/install-ctags-alpine.sh && rm /usr/local/bin/install-ctags-alpine.sh
+RUN /usr/local/bin/install-ctags-alpine.sh && \
+    rm /usr/local/bin/install-ctags-alpine.sh \
+      /usr/local/bin/universal-optscript
 
 RUN addgroup -S zoekt && \
     adduser -S -G zoekt -h /home/zoekt zoekt && \

--- a/install-ctags-alpine.sh
+++ b/install-ctags-alpine.sh
@@ -45,6 +45,6 @@ CTAGS_TMPDIR=$(mktemp -d /tmp/ctags.XXXXXX)
 curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C "$CTAGS_TMPDIR"
 cd "$CTAGS_TMPDIR/$CTAGS_ARCHIVE_TOP_LEVEL_DIR"
 ./autogen.sh
-./configure --program-prefix=universal- --enable-json
+./configure --program-prefix=universal- --enable-json --disable-readcmd
 make -j"$NUMCPUS" --load-average="$NUMCPUS"
 make install

--- a/install-ctags-alpine.sh
+++ b/install-ctags-alpine.sh
@@ -9,10 +9,14 @@ CTAGS_ARCHIVE_TOP_LEVEL_DIR=ctags-6.1.0
 # When using commits you can rely on
 # CTAGS_ARCHIVE_TOP_LEVEL_DIR=ctags-$CTAGS_VERSION
 
+CTAGS_TMPDIR=
+
 cleanup() {
   apk --no-cache --purge del ctags-build-deps || true
   cd /
-  rm -rf /tmp/ctags-$CTAGS_VERSION
+  if [ -n "$CTAGS_TMPDIR" ]; then
+    rm -rf "$CTAGS_TMPDIR"
+  fi
 }
 
 trap cleanup EXIT
@@ -35,10 +39,11 @@ apk --no-cache add \
 apk --no-cache add jansson
 
 NUMCPUS=$(grep -c '^processor' /proc/cpuinfo)
+CTAGS_TMPDIR=$(mktemp -d /tmp/ctags.XXXXXX)
 
 # Installation
-curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
-cd /tmp/$CTAGS_ARCHIVE_TOP_LEVEL_DIR
+curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C "$CTAGS_TMPDIR"
+cd "$CTAGS_TMPDIR/$CTAGS_ARCHIVE_TOP_LEVEL_DIR"
 ./autogen.sh
 ./configure --program-prefix=universal- --enable-json
 make -j"$NUMCPUS" --load-average="$NUMCPUS"


### PR DESCRIPTION
I was exploring the built image and noticed a bug in our cleanup logic. We had the wrong path to remove the extracted ctags archive. Instead of fixing the path, we just use a tmpdir as the root to cleanup.