### PR TITLE
cmd/zoekt-mirror-gitea: skip GetUserInfo when no user or org is specified

### DIFF
--- a/cmd/zoekt-mirror-gitea/main.go
+++ b/cmd/zoekt-mirror-gitea/main.go
@@ -112,7 +112,7 @@ func main() {
 		repos, err = getUserRepos(client, *user, reposFilters)
 	default:
 		log.Printf("no user or org specified, cloning all repos.")
-		repos, err = getUserRepos(client, "", reposFilters)
+		repos, err = getAllRepos(client, reposFilters)
 	}
 
 	if err != nil {
@@ -219,6 +219,27 @@ func getOrgRepos(client *gitea.Client, org string, reposFilters reposFilters) ([
 		searchOptions.Page = resp.NextPage
 		repos = filterRepositories(repos, *reposFilters.noArchived)
 		allRepos = append(allRepos, repos...)
+		if resp.NextPage == 0 {
+			break
+		}
+	}
+	return allRepos, nil
+}
+
+func getAllRepos(client *gitea.Client, reposFilters reposFilters) ([]*gitea.Repository, error) {
+	var allRepos []*gitea.Repository
+	searchOptions := &gitea.SearchRepoOptions{}
+	for {
+		repos, resp, err := client.SearchRepos(*searchOptions)
+		if err != nil {
+			return nil, err
+		}
+		if len(repos) == 0 {
+			break
+		}
+		repos = filterRepositories(repos, *reposFilters.noArchived)
+		allRepos = append(allRepos, repos...)
+		searchOptions.Page = resp.NextPage
 		if resp.NextPage == 0 {
 			break
 		}


### PR DESCRIPTION
# Problem

When `zoekt-mirror-gitea` is configured with only a GiteaURL (without a specific user or organization), the tool attempts to fetch repositories by calling `getUserRepos(client, "", ...)` with an empty user string which causes the tool to fail with `failed: exit status 1`.

# Fix

Add `getAllRepos` method.

# Test

Verified on a self-hosted Gitea instance (v1.25.2), the tool successfully iterates through all paginated repository results, and begins the mirroring process as expected.