### PR TITLE
zoekt-index: treat dirname as default name

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -124,7 +124,9 @@ func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error 
 		return err
 	}
 
-	opts.RepositoryDescription.Name = filepath.Base(dir)
+	if opts.RepositoryDescription.Name == "" {
+		opts.RepositoryDescription.Name = filepath.Base(dir)
+	}
 	builder, err := index.NewBuilder(opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow user to set the name via the meta option.

Fixes https://github.com/sourcegraph/zoekt/issues/1048