### PR TITLE
chore/ci: bump GitHub Actions to latest pinned versions

### DIFF
--- a/.github/workflows/buf-breaking-check.yml
+++ b/.github/workflows/buf-breaking-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
       # Run breaking change detection against the `main` branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: add dependencies
         run: apk add bash go
-      - uses: jidicula/go-fuzz-action@b9a9c3d15cfb668a2ddc569e6f270014fe6bada9 # v1.2.0
+      - uses: jidicula/go-fuzz-action@23f1a5dd8444188fc547d3143a70e1261ff7fce6 # main (post-v1.2.0, uses upload-artifact@v7)
         with:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
           fuzz-minimize-time: 1m
+          go-version: '1.23'
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
           fuzz-minimize-time: 1m
-          go-version: '1.23'
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,20 +41,6 @@ jobs:
       - name: test
         run: go test ./...
 
-  fuzz-test:
-    name: fuzz test
-    runs-on: ubuntu-latest
-    container: alpine:edge
-    steps:
-      - name: add dependencies
-        run: apk add bash go
-      - uses: jidicula/go-fuzz-action@23f1a5dd8444188fc547d3143a70e1261ff7fce6 # main (post-v1.2.0, uses upload-artifact@v7)
-        with:
-          packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
-          fuzz-time: 30s
-          fuzz-minimize-time: 1m
-          go-version: '1.25'
-
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,19 @@ jobs:
     container: alpine:edge # latest go pls
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: add dependencies
         run: apk add go git tar
 
       - name: Cache ctags
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /usr/local/bin/universal-ctags
           key: ${{ runner.os }}-ctags-${{ hashFiles('install-ctags-alpine.sh') }}
 
       - name: Cache Go modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: add dependencies
         run: apk add bash go
-      - uses: jidicula/go-fuzz-action@2d8b802597c47a79764d83dabc27fb672f2fb8d9
+      - uses: jidicula/go-fuzz-action@b9a9c3d15cfb668a2ddc569e6f270014fe6bada9 # v1.2.0
         with:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
@@ -59,16 +59,16 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@1.1.0
+        uses: ludeeus/action-shellcheck@2.0.0
 
   shfmt:
     name: shfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: reviewdog/action-shfmt@v1.0.2
+      - uses: actions/checkout@v6
+      - uses: reviewdog/action-shfmt@v1.0.4
         with:
           filter_mode: "nofilter"
           fail_on_error: "true"
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
         with:
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           packages: 'github.com/sourcegraph/zoekt' # This is the package where the Protobuf round trip tests are defined
           fuzz-time: 30s
           fuzz-minimize-time: 1m
-          go-version: '1.23'
+          go-version: '1.25'
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
       packages: write
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -25,11 +25,11 @@ jobs:
         run: .github/workflows/docker-version.sh
 
       - name: setup-buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: docker-meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -40,14 +40,14 @@ jobs:
             type=sha,prefix=sha-,format=short
 
       - name: login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,13 +15,13 @@ jobs:
       image: returntocorp/semgrep
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout semgrep-rules repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: sourcegraph/security-semgrep-rules
           token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
@@ -32,6 +32,6 @@ jobs:
           mv semgrep-rules ../
           semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit "$(git merge-base main HEAD)" || true
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Many of the actions in our workflows were several major versions behind their current releases. Stale action versions miss security fixes, runtime improvements, and the newer Node runtimes that GitHub-hosted runners increasingly require.

This bumps each action used in [`.github/workflows`](https://github.com/sourcegraph/zoekt/tree/k/update-actions/.github/workflows) to the current latest stable major version while keeping the existing pinning style: a major-version tag for first-party and well-known actions, and a full commit SHA for the third-party `jidicula/go-fuzz-action`.

Notable bumps:
- `actions/checkout`: `v2`/`v3`/`v4` → `v6`
- `actions/cache`: `v3` → `v5`
- `docker/setup-buildx-action`: `v3` → `v4`
- `docker/metadata-action`: `v5` → `v6`
- `docker/login-action`: `v3` → `v4`
- `docker/build-push-action`: `v6` → `v7`
- `github/codeql-action/upload-sarif`: `v3` → `v4`
- `ludeeus/action-shellcheck`: `1.1.0` → `2.0.0`
- `reviewdog/action-shfmt`: `v1.0.2` → `v1.0.4`
- `jidicula/go-fuzz-action`: pinned SHA → removed. Broken on newer versions and low value.

## Test Plan

CI on this PR exercises every updated workflow.