### PR TITLE
fix: binary file check misses binary files where first byte is null

### DIFF
--- a/index/index_test.go
+++ b/index/index_test.go
@@ -3409,7 +3409,7 @@ func TestDocChecker(t *testing.T) {
 			t.Errorf("Check(%q): %v", text, skip)
 		}
 	}
-	for _, text := range []string{"zero\x00byte", "xx", "0123456789abcdefghi"} {
+	for _, text := range []string{"zero\x00byte", "\x00starts with null byte", "xx", "0123456789abcdefghi"} {
 		if skip := docChecker.Check([]byte(text), 15, false); skip == SkipReasonNone {
 			t.Errorf("Check(%q) succeeded", text)
 		}
@@ -3421,7 +3421,7 @@ func TestDocChecker(t *testing.T) {
 			t.Errorf("Check(%q): %v", text, skip)
 		}
 	}
-	for _, text := range []string{"zero\x00byte", "xx"} {
+	for _, text := range []string{"zero\x00byte", "\x00starts with null byte", "xx"} {
 		if skip := docChecker.Check([]byte(text), 15, true); skip == SkipReasonNone {
 			t.Errorf("Check(%q) succeeded", text)
 		}

--- a/index/shard_builder.go
+++ b/index/shard_builder.go
@@ -546,7 +546,7 @@ func (b *ShardBuilder) Add(doc Document) error {
 	// Skip binary check if already computed (e.g., by Builder.Add
 	// which calls DocChecker.Check before docs reach buildShard).
 	if doc.Category == FileCategoryMissing {
-		if index := bytes.IndexByte(doc.Content, 0); index > 0 {
+		if index := bytes.IndexByte(doc.Content, 0); index >= 0 {
 			doc.SkipReason = SkipReasonBinary
 		}
 	}
@@ -686,7 +686,7 @@ func (t *DocChecker) Check(content []byte, maxTrigramCount int, allowLargeFile b
 		return SkipReasonTooSmall
 	}
 
-	if index := bytes.IndexByte(content, 0); index > 0 {
+	if index := bytes.IndexByte(content, 0); index >= 0 {
 		return SkipReasonBinary
 	}
 


### PR DESCRIPTION
While searching for a short string of text, it returned some TTF files. I downloaded one from the source repo and checked it locally with a hex viewer to confirm. A bit of poking around revealed this logic bug.

I found a second more recent instance of the same bug that seems to be a copy/paste error.