### PR TITLE
gitindex: support Bitbucket Cloud and Azure DevOps URL templates

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -143,6 +143,18 @@ func setTemplates(repo *zoekt.Repository, u *url.URL, typ string) error {
 		repo.CommitURLTemplate = urlJoinPath("commits", varVersion)
 		repo.FileURLTemplate = urlJoinPath(varPath) + "?at={{.Version}}"
 		repo.LineFragmentTemplate = "#{{.LineNumber}}"
+	case "bitbucket-cloud":
+		// https://bitbucket.org/<workspace>/<repo_slug>/commits/<version>
+		// https://bitbucket.org/<workspace>/<repo_slug>/src/<version>/<path>
+		repo.CommitURLTemplate = urlJoinPath("commits", varVersion)
+		repo.FileURLTemplate = urlJoinPath("src", varVersion, varPath)
+		repo.LineFragmentTemplate = "#{{.LineNumber}}"
+	case "azuredevops":
+		// https://dev.azure.com/<organization>/<project>/_git/<repo>/commit/<version>
+		// https://dev.azure.com/<organization>/<project>/_git/<repo>?path=/<path>&version=GC<version>
+		repo.CommitURLTemplate = urlJoinPath("commit", varVersion)
+		repo.FileURLTemplate = urlJoinPath() + "?path=/{{.Path}}&version=GC{{.Version}}&_a=contents"
+		repo.LineFragmentTemplate = "&line={{.LineNumber}}&lineEnd={{.LineNumber}}&lineStartColumn=1&lineEndColumn=200"
 	case "gitlab":
 		// https://gitlab.com/gitlab-org/omnibus-gitlab/-/commit/b152c864303dae0e55377a1e2c53c9592380ffed
 		// https://gitlab.com/gitlab-org/omnibus-gitlab/-/blob/aad04155b3f6fc50ede88aedaee7fc624d481149/files/gitlab-config-template/gitlab.rb.template

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -1098,6 +1098,16 @@ func TestSetTemplates(t *testing.T) {
 		file:   "https://example.com/repo/name/dir/name.txt?at=VERSION",
 		line:   "#10",
 	}, {
+		typ:    "bitbucket-cloud",
+		commit: "https://example.com/repo/name/commits/VERSION",
+		file:   "https://example.com/repo/name/src/VERSION/dir/name.txt",
+		line:   "#10",
+	}, {
+		typ:    "azuredevops",
+		commit: "https://example.com/repo/name/commit/VERSION",
+		file:   "https://example.com/repo/name?path=/dir/name.txt&version=GCVERSION&_a=contents",
+		line:   "&line=10&lineEnd=10&lineStartColumn=1&lineEndColumn=200",
+	}, {
 		typ:    "gitlab",
 		commit: "https://example.com/repo/name/-/commit/VERSION",
 		file:   "https://example.com/repo/name/-/blob/VERSION/dir/name.txt",


### PR DESCRIPTION
This adds gitindex URL templates for Bitbucket Cloud and Azure DevOps so indexed repositories from those hosts can link search results back to their native commit and file views.
