### PR TITLE
feat/webserver: support serving over Unix sockets

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -131,6 +131,7 @@ func main() {
 	logRefresh := flag.Duration("log_refresh", 24*time.Hour, "if using --log_dir, start writing a new file this often.")
 
 	listen := flag.String("listen", ":6070", "listen on this address.")
+	listenUnix := flag.String("listen_unix", "", "listen on this Unix socket path instead of TCP")
 	indexDir := flag.String("index", index.DefaultDir, "set index directory to use")
 	html := flag.Bool("html", true, "enable HTML interface")
 	enableRPC := flag.Bool("rpc", false, "enable go/net RPC")
@@ -278,10 +279,18 @@ func main() {
 	if *sslCert != "" || *sslKey != "" {
 		watchdogAddr = "https://" + *listen
 	}
+	watchdogUnixSocket := ""
+	if *listenUnix != "" {
+		watchdogUnixSocket = *listenUnix
+		watchdogAddr = "http://unix"
+		if *sslCert != "" || *sslKey != "" {
+			watchdogAddr = "https://unix"
+		}
+	}
 	watchdogAddr += "/healthz"
 
 	if watchdogErrCount > 0 && watchdogTick > 0 {
-		go watchdog(watchdogTick, watchdogErrCount, watchdogAddr)
+		go watchdog(watchdogTick, watchdogErrCount, watchdogAddr, watchdogUnixSocket)
 	} else {
 		log.Println("watchdog disabled")
 	}
@@ -300,13 +309,8 @@ func main() {
 	}
 
 	go func() {
-		sglog.Scoped("server").Info("starting server", sglog.Stringp("address", listen))
-		var err error
-		if *sslCert != "" || *sslKey != "" {
-			err = srv.ListenAndServeTLS(*sslCert, *sslKey)
-		} else {
-			err = srv.ListenAndServe()
-		}
+		sglog.Scoped("server").Info("starting server", sglog.Stringp("address", listen), sglog.Stringp("unixSocket", listenUnix))
+		err := serveHTTP(srv, *listenUnix, *sslCert, *sslKey)
 
 		if err != http.ErrServerClosed {
 			// Fatal otherwise shutdownOnSignal will block
@@ -326,6 +330,48 @@ func main() {
 			log.Fatalf("http.Server.Shutdown: %v", err)
 		}
 	}
+}
+
+func serveHTTP(srv *http.Server, unixSocket, sslCert, sslKey string) error {
+	if unixSocket != "" {
+		l, err := listenUnixSocket(unixSocket)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(unixSocket)
+
+		if sslCert != "" || sslKey != "" {
+			return srv.ServeTLS(l, sslCert, sslKey)
+		}
+		return srv.Serve(l)
+	}
+
+	if sslCert != "" || sslKey != "" {
+		return srv.ListenAndServeTLS(sslCert, sslKey)
+	}
+	return srv.ListenAndServe()
+}
+
+func listenUnixSocket(socket string) (net.Listener, error) {
+	// We cannot bind a socket to an existing pathname.
+	if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("error removing socket file: %s", socket)
+	}
+
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on socket %s: %w", socket, err)
+	}
+
+	// nginx and zoekt-webserver often run as different users. Make the socket
+	// broadly connectable like the indexserver socket used by this binary's
+	// reverse proxy support.
+	if err := os.Chmod(socket, 0o777); err != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("failed to change permission of socket %s: %w", socket, err)
+	}
+
+	return l, nil
 }
 
 // addProxyHandler adds a handler to "mux" that proxies all requests with base
@@ -424,9 +470,15 @@ func watchdogOnce(ctx context.Context, client *http.Client, addr string) error {
 	return nil
 }
 
-func watchdog(dt time.Duration, maxErrCount int, addr string) {
+func watchdog(dt time.Duration, maxErrCount int, addr, unixSocket string) {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	if unixSocket != "" {
+		tr.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, "unix", unixSocket)
+		}
 	}
 	client := &http.Client{
 		Transport: tr,

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -310,7 +310,6 @@ func main() {
 
 	serveErrCh := make(chan error, 1)
 	go func() {
-		sglog.Scoped("server").Info("starting server", sglog.Stringp("address", listen), sglog.Stringp("unixSocket", listenUnix))
 		err := serveHTTP(srv, *listenUnix, *sslCert, *sslKey)
 
 		if err != http.ErrServerClosed {
@@ -336,14 +335,17 @@ func main() {
 }
 
 func serveHTTP(srv *http.Server, unixSocket, sslCert, sslKey string) error {
+	logger := sglog.Scoped("server")
 	if unixSocket != "" {
 		l, err := listenUnixSocket(unixSocket)
 		if err != nil {
 			return err
 		}
+		logger.Info("starting server", sglog.String("unixSocket", unixSocket))
 		return srv.Serve(l)
 	}
 
+	logger.Info("starting server", sglog.String("address", srv.Addr))
 	if sslCert != "" || sslKey != "" {
 		return srv.ListenAndServeTLS(sslCert, sslKey)
 	}

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -341,7 +341,6 @@ func serveHTTP(srv *http.Server, unixSocket, sslCert, sslKey string) error {
 		if err != nil {
 			return err
 		}
-		defer os.Remove(unixSocket)
 		return srv.Serve(l)
 	}
 

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -308,6 +308,7 @@ func main() {
 		Handler: handler,
 	}
 
+	serveErrCh := make(chan error, 1)
 	go func() {
 		sglog.Scoped("server").Info("starting server", sglog.Stringp("address", listen), sglog.Stringp("unixSocket", listenUnix))
 		err := serveHTTP(srv, *listenUnix, *sslCert, *sslKey)
@@ -316,6 +317,7 @@ func main() {
 			// Fatal otherwise shutdownOnSignal will block
 			log.Fatalf("ListenAndServe: %v", err)
 		}
+		serveErrCh <- err
 	}()
 
 	if s.RPC {
@@ -330,6 +332,7 @@ func main() {
 			log.Fatalf("http.Server.Shutdown: %v", err)
 		}
 	}
+	<-serveErrCh
 }
 
 func serveHTTP(srv *http.Server, unixSocket, sslCert, sslKey string) error {

--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -183,6 +183,9 @@ func main() {
 		// caller to divert stderr output if necessary.
 		go divertLogs(*logDir, *logRefresh)
 	}
+	if *listenUnix != "" && (*sslCert != "" || *sslKey != "") {
+		log.Fatal("-listen_unix cannot be combined with -ssl_cert or -ssl_key")
+	}
 
 	// Tune GOMAXPROCS to match Linux container CPU quota.
 	_, _ = maxprocs.Set()
@@ -283,9 +286,6 @@ func main() {
 	if *listenUnix != "" {
 		watchdogUnixSocket = *listenUnix
 		watchdogAddr = "http://unix"
-		if *sslCert != "" || *sslKey != "" {
-			watchdogAddr = "https://unix"
-		}
 	}
 	watchdogAddr += "/healthz"
 
@@ -339,10 +339,6 @@ func serveHTTP(srv *http.Server, unixSocket, sslCert, sslKey string) error {
 			return err
 		}
 		defer os.Remove(unixSocket)
-
-		if sslCert != "" || sslKey != "" {
-			return srv.ServeTLS(l, sslCert, sslKey)
-		}
 		return srv.Serve(l)
 	}
 

--- a/cmd/zoekt-webserver/main_test.go
+++ b/cmd/zoekt-webserver/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestServeHTTPUnixSocket(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "zoekt.sock")
+	if err := os.WriteFile(socket, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/healthz" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = io.WriteString(w, "ok")
+		}),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- serveHTTP(srv, socket, "", "")
+	}()
+
+	client := &http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "unix", socket)
+			},
+		},
+	}
+
+	var resp *http.Response
+	var err error
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err = client.Get("http://unix/healthz")
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("GET over unix socket failed: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("got body %q, want %q", string(body), "ok")
+	}
+	if mode := socketMode(t, socket); mode != 0o777 {
+		t.Fatalf("got socket mode %o, want 777", mode)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-errCh; !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("serveHTTP returned %v, want %v", err, http.ErrServerClosed)
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("socket was not removed after shutdown: %v", err)
+	}
+}
+
+func socketMode(t *testing.T, socket string) os.FileMode {
+	t.Helper()
+	fi, err := os.Stat(socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi.Mode().Perm()
+}


### PR DESCRIPTION
zoekt-webserver already knew how to proxy to the indexserver over `<index>/indexserver.sock`, but the webserver itself could only bind the TCP address from `-listen`. This adds a dedicated `-listen_unix` flag for deployments that want nginx or another local proxy to connect through a Unix domain socket instead of a TCP listener.

When `-listen_unix` is set, the webserver removes any stale socket path before binding, listens on the Unix socket, chmods it so a proxy running as a different user can connect, and relies on Go's Unix listener cleanup when the server shuts down. The health watchdog also dials the Unix socket in this mode, so the usual self-check keeps working.

Unix socket serving is intentionally plain HTTP only. These sockets are local and permission-protected, and supporting TLS on top of them adds complexity without helping the nginx handoff use case; combining `-listen_unix` with `-ssl_cert` or `-ssl_key` now fails fast. I kept this as a dedicated flag rather than overloading `-listen` with a `unix://` pseudo-address so the existing TCP listen address flag does not need scheme parsing or ambiguous precedence rules.

Closes #1057.

## Test Plan

`go test ./cmd/zoekt-webserver/...`

Formal code review run after the follow-up fixes; no blocking issues remained.

## Changelog

`zoekt-webserver` now supports serving HTTP and gRPC over a Unix domain socket with `-listen_unix`.
