### PR TITLE
Add regexp raw pattern API

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -79,6 +79,11 @@ type Regexp struct {
 	CaseSensitive bool
 }
 
+// RegexpString returns the marshaled raw regexp pattern for q.
+func (q *Regexp) RegexpString() string {
+	return syntaxutil.RegexpString(q.Regexp)
+}
+
 func (q *Regexp) String() string {
 	pref := ""
 	if q.FileName {
@@ -87,7 +92,7 @@ func (q *Regexp) String() string {
 	if q.CaseSensitive {
 		pref = "case_" + pref
 	}
-	return fmt.Sprintf("%sregex:%q", pref, syntaxutil.RegexpString(q.Regexp))
+	return fmt.Sprintf("%sregex:%q", pref, q.RegexpString())
 }
 
 // gobRegexp wraps Regexp to make it gob-encodable/decodable. Regexp contains syntax.Regexp, which
@@ -100,7 +105,7 @@ type gobRegexp struct {
 
 // GobEncode implements gob.Encoder.
 func (q Regexp) GobEncode() ([]byte, error) {
-	gobq := gobRegexp{Regexp: q, RegexpString: syntaxutil.RegexpString(q.Regexp)}
+	gobq := gobRegexp{Regexp: q, RegexpString: q.RegexpString()}
 	gobq.Regexp.Regexp = nil // can't be gob-encoded/decoded
 	return json.Marshal(gobq)
 }

--- a/query/query_proto.go
+++ b/query/query_proto.go
@@ -115,7 +115,7 @@ func RegexpFromProto(p *webserverv1.Regexp) (*Regexp, error) {
 
 func (r *Regexp) ToProto() *webserverv1.Regexp {
 	return &webserverv1.Regexp{
-		Regexp:        r.Regexp.String(),
+		Regexp:        r.RegexpString(),
 		FileName:      r.FileName,
 		Content:       r.Content,
 		CaseSensitive: r.CaseSensitive,

--- a/query/query_proto_test.go
+++ b/query/query_proto_test.go
@@ -103,6 +103,15 @@ func TestQueryRoundtrip(t *testing.T) {
 	}
 }
 
+func TestRegexpProtoUsesRegexpString(t *testing.T) {
+	q := &Regexp{Regexp: regexpMustParse(`a.*b`)}
+	protoQ := q.ToProto()
+
+	if got, want := protoQ.GetRegexp(), q.RegexpString(); got != want {
+		t.Fatalf("ToProto().Regexp = %q, want %q", got, want)
+	}
+}
+
 func regexpMustParse(s string) *syntax.Regexp {
 	re, err := syntax.Parse(s, syntax.Perl)
 	if err != nil {

--- a/query/regexp_test.go
+++ b/query/regexp_test.go
@@ -101,3 +101,25 @@ func TestOptimize(t *testing.T) {
 		})
 	}
 }
+
+func TestRegexpRegexpString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: `abc`, want: `abc`},
+		{in: `a.*b`, want: `a(?-s:.)*b`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			q := &Regexp{Regexp: mustParseRE(tt.in)}
+			if got := q.RegexpString(); got != tt.want {
+				t.Fatalf("RegexpString(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if got := q.String(); got == tt.want {
+				t.Fatalf("String(%q) = raw pattern %q, want query formatting", tt.in, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Some downstream callers need to marshal or recompile query regexps and were reaching into `q.Regexp.String()`, which is the underlying syntax tree debug string rather than an official query API.

This adds `query.Regexp.RegexpString()` as the public API for getting the marshaled raw regexp pattern. Existing `query.Regexp` string and gob serialization paths now route through that method.

`query.Regexp.String()` remains query/debug formatting and still includes wrappers like `regex:"..."`.