### PR TITLE
fix: reindex is not working due to incorrect ctx propagation

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -912,7 +912,7 @@ func (s *Server) handleReindex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go func() { s.forceIndex(r.Context(), uint32(id)) }()
+	go func() { s.forceIndex(context.Background(), uint32(id)) }()
 
 	// 202 Accepted
 	w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
ref https://app.plain.com/workspace/w_01K95VFHPKPY4ERZD73YRRR0RH/thread/th_01KQSHJ734488GMP83EP44GSJ2/



during reindex, the background operation is canceled alone with the completion of http request. need to start its own context. hence, user clicking "reindex" never really works.

tested locally and confirmed clicking "Reindex now" created a new index file on disk:

> notes the timstamp

<img width="643" height="168" alt="CleanShot 2026-05-27 at 21 05 33" src="https://github.com/user-attachments/assets/d36298af-bcce-4b49-a134-af29fb5ded3d" />


also validated the previous behaviour, the file stayed unchanged after clicking "Reindex now".