### PR TITLE
indexserver: truncate failure messages in status updates

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -258,7 +258,7 @@ const noOutputTimeout = 30 * time.Minute
 
 const (
 	maxFailureMessageBytes         = 12 * 1024
-	failureMessageTruncationMarker = "\n\n[Error message truncated]"
+	failureMessageTruncationMarker = "\n\n[Error message truncated]\n\n"
 )
 
 func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) (err error) {
@@ -752,7 +752,11 @@ func truncateFailureMessageForSourcegraph(s string) string {
 		return s
 	}
 
-	return utf8PrefixBytes(s, maxFailureMessageBytes-len(failureMessageTruncationMarker)) + failureMessageTruncationMarker
+	budget := maxFailureMessageBytes - len(failureMessageTruncationMarker)
+	headBytes := budget / 2
+	tailBytes := budget - headBytes
+
+	return utf8PrefixBytes(s, headBytes) + failureMessageTruncationMarker + utf8SuffixBytes(s, tailBytes)
 }
 
 func utf8PrefixBytes(s string, maxBytes int) string {
@@ -769,6 +773,23 @@ func utf8PrefixBytes(s string, maxBytes int) string {
 	}
 
 	return s[:maxBytes]
+}
+
+func utf8SuffixBytes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+
+	if maxBytes <= 0 {
+		return ""
+	}
+
+	start := len(s) - maxBytes
+	for start < len(s) && !utf8.RuneStart(s[start]) {
+		start++
+	}
+
+	return s[start:]
 }
 
 func sglogBranches(key string, branches []zoekt.RepositoryBranch) sglog.Field {

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -44,6 +44,7 @@ import (
 	"sync"
 	"text/tabwriter"
 	"time"
+	"unicode/utf8"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/retry"
@@ -254,6 +255,11 @@ var (
 // time."  famous last words. A client was indexing a monorepo with 42
 // cores... 5m was not enough.
 const noOutputTimeout = 30 * time.Minute
+
+const (
+	maxFailureMessageBytes         = 12 * 1024
+	failureMessageTruncationMarker = "\n\n[Error message truncated]"
+)
 
 func (s *Server) loggedRun(tr trace.Trace, cmd *exec.Cmd) (err error) {
 	out := &synchronizedBuffer{}
@@ -707,7 +713,7 @@ func updateIndexStatusOnSourcegraph(c gitIndexConfig, args *indexArgs, sg Source
 	var indexTimeUnix int64
 	if indexErr != nil {
 		state = configv1.UpdateIndexStatusRequest_Repository_STATE_FAILURE
-		failureMessage = indexErr.Error()
+		failureMessage = truncateFailureMessageForSourcegraph(indexErr.Error())
 
 		// On failure, metadata may not exist yet. Include index time if we can,
 		// but do not block reporting the failure status.
@@ -739,6 +745,30 @@ func updateIndexStatusOnSourcegraph(c gitIndexConfig, args *indexArgs, sg Source
 	}
 
 	return nil
+}
+
+func truncateFailureMessageForSourcegraph(s string) string {
+	if len(s) <= maxFailureMessageBytes {
+		return s
+	}
+
+	return utf8PrefixBytes(s, maxFailureMessageBytes-len(failureMessageTruncationMarker)) + failureMessageTruncationMarker
+}
+
+func utf8PrefixBytes(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+
+	if maxBytes <= 0 {
+		return ""
+	}
+
+	for maxBytes > 0 && !utf8.RuneStart(s[maxBytes]) {
+		maxBytes--
+	}
+
+	return s[:maxBytes]
 }
 
 func sglogBranches(key string, branches []zoekt.RepositoryBranch) sglog.Field {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -57,6 +57,19 @@ func TestIndexNoTenant(t *testing.T) {
 	require.ErrorIs(t, err, tenant.ErrMissingTenant)
 }
 
+func TestTruncateFailureMessageForSourcegraph(t *testing.T) {
+	t.Run("preserves short message", func(t *testing.T) {
+		require.Equal(t, "boom", truncateFailureMessageForSourcegraph("boom"))
+	})
+
+	t.Run("truncates oversized utf8 message", func(t *testing.T) {
+		input := strings.Repeat("é", maxFailureMessageBytes) + "tail"
+		want := strings.Repeat("é", (maxFailureMessageBytes-len(failureMessageTruncationMarker))/len("é")) + failureMessageTruncationMarker
+
+		require.Equal(t, want, truncateFailureMessageForSourcegraph(input))
+	})
+}
+
 func TestServer_parallelism(t *testing.T) {
 	root, err := url.Parse("http://api.test")
 	if err != nil {

--- a/cmd/zoekt-sourcegraph-indexserver/main_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main_test.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp"
 	sglog "github.com/sourcegraph/log"
@@ -64,9 +65,17 @@ func TestTruncateFailureMessageForSourcegraph(t *testing.T) {
 
 	t.Run("truncates oversized utf8 message", func(t *testing.T) {
 		input := strings.Repeat("é", maxFailureMessageBytes) + "tail"
-		want := strings.Repeat("é", (maxFailureMessageBytes-len(failureMessageTruncationMarker))/len("é")) + failureMessageTruncationMarker
 
-		require.Equal(t, want, truncateFailureMessageForSourcegraph(input))
+		got := truncateFailureMessageForSourcegraph(input)
+		parts := strings.Split(got, failureMessageTruncationMarker)
+
+		require.Len(t, parts, 2)
+		require.LessOrEqual(t, len(got), maxFailureMessageBytes)
+		require.True(t, utf8.ValidString(got))
+		require.NotEmpty(t, parts[0])
+		require.True(t, strings.HasPrefix(input, parts[0]))
+		require.Contains(t, parts[1], "tail")
+		require.Less(t, len(parts[0])+len(parts[1]), len(input))
 	})
 }
 


### PR DESCRIPTION
Truncate failure messages to 12 KiB before sending index status updates to Sourcegraph. This limit is modeled after Kubernetes, which similarly truncates termination messages on the assumption that complete failure details are available in container logs.