### PR TITLE
Migrate error comparisons to errors.Is/errors.As

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -308,7 +308,7 @@ func main() {
 			err = srv.ListenAndServe()
 		}
 
-		if err != http.ErrServerClosed {
+		if !errors.Is(err, http.ErrServerClosed) {
 			// Fatal otherwise shutdownOnSignal will block
 			log.Fatalf("ListenAndServe: %v", err)
 		}

--- a/gitindex/catfile.go
+++ b/gitindex/catfile.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -235,8 +236,8 @@ func (cr *catfileReader) Close() error {
 
 // isKilledErr reports whether err is an exec.ExitError caused by SIGKILL.
 func isKilledErr(err error) bool {
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
 		return false
 	}
 	ws, ok := exitErr.Sys().(syscall.WaitStatus)

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -823,7 +823,7 @@ func catfileFilterSpec(opts Options) string {
 
 func newIgnoreMatcher(tree *object.Tree) (*ignore.Matcher, error) {
 	ignoreFile, err := tree.File(ignore.IgnoreFile)
-	if err == object.ErrFileNotFound {
+	if errors.Is(err, object.ErrFileNotFound) {
 		return &ignore.Matcher{}, nil
 	}
 	if err != nil {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,7 +115,7 @@ func newZipArchive(r io.Reader, closer io.Closer) (*zipArchive, error) {
 func detectContentType(r io.Reader) (string, io.Reader, error) {
 	var buf [512]byte
 	n, err := io.ReadFull(r, buf[:])
-	if err != nil && err != io.ErrUnexpectedEOF {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return "", nil, err
 	}
 

--- a/search/watcher.go
+++ b/search/watcher.go
@@ -15,6 +15,7 @@
 package search
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -244,7 +245,7 @@ func (s *DirectoryWatcher) watch() error {
 			case err := <-watcher.Errors:
 				// Ignore ErrEventOverflow since we rely on the presence of events so
 				// safe to ignore.
-				if err != nil && err != fsnotify.ErrEventOverflow {
+				if err != nil && !errors.Is(err, fsnotify.ErrEventOverflow) {
 					log.Println("[ERROR] watcher error:", err)
 				}
 


### PR DESCRIPTION
This change migrates direct error comparisons and error type assertions to the
modern `errors` package idioms:

- `err == SentinelErr` / `err != SentinelErr` -> `errors.Is(err, SentinelErr)` / `!errors.Is(...)`
  for sentinels such as `sql.ErrNoRows`, `context.Canceled`, `context.DeadlineExceeded`,
  `http.ErrServerClosed`, `io.ErrUnexpectedEOF`, `os.ErrNotExist`, etc.
- Error type assertions and `switch err.(type)` classification -> `errors.As`.

Excluded by design: `io.EOF` comparisons (idiomatic in reader loops) and `_test.go` files.

This makes error checks robust to wrapped errors (`fmt.Errorf("...: %w", err)`).

Generated by a Sourcegraph batch change.

[_Created by Sourcegraph batch change `robert/58006530-3ddc-4c11-ad42-8d8eed8bc63f`._](https://sourcegraph.sourcegraph.com/users/robert/batch-changes/58006530-3ddc-4c11-ad42-8d8eed8bc63f)