### PR TITLE
tracer: quiet routine OpenTelemetry exporter errors

### DIFF
--- a/internal/tracer/opentelemetry.go
+++ b/internal/tracer/opentelemetry.go
@@ -3,7 +3,6 @@ package tracer
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 
 	"github.com/opentracing/opentracing-go"
@@ -65,8 +64,9 @@ func configureOpenTelemetry(resource sglog.Resource) (opentracing.Tracer, error)
 	bridge, otelTracerProvider := otelbridge.NewTracerPair(provider.Tracer("tracer.global"))
 	bridge.SetTextMapPropagator(compositePropagator)
 	otel.SetTracerProvider(otelTracerProvider)
+	otelLogger := sglog.Scoped("otel")
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		log.Println("opentelemetry: ", err.Error())
+		otelLogger.Debug("error encountered", sglog.Error(err))
 	}))
 
 	// Done


### PR DESCRIPTION
Zoekt's OpenTelemetry tracer currently installs an SDK error handler that writes exporter errors directly with the standard logger. In environments where tracing is enabled but no collector is listening, such as local development, the exporter reports periodic connection failures that are expected but noisy.

This routes those SDK errors through sourcegraph/log at debug level instead, matching the behavior of Sourcegraph's monolith tracer. The diagnostics remain available when debug logging is enabled, while normal logs stay focused on actionable service output.