### PR TITLE
fix/query: preserve fields in parenthesized atoms

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -244,6 +244,12 @@ interpreted as regular expressions, otherwise they are used for grouping
     (abc def) => and[substring:"abc" substring:"def"]
     (abc\ def) => regexp:"(abc def)"
 
+Parenthesized field expressions are treated as grouping even without spaces,
+so field modifiers still apply:
+
+    (sym:foo) => Symbol:"foo"
+    (file:java) => Substring_file:"java"
+
 there is an implicit "AND" between elements of a parenthesized list.
 There is an "OR" operator, which has lower priority than the implicit
 "AND":

--- a/doc/query_syntax.md
+++ b/doc/query_syntax.md
@@ -59,6 +59,9 @@ Negate an expression using the `-` symbol.
 ### 3. **Grouping**
 
 Group queries using parentheses `()` to create complex logic.
+Parentheses around field expressions preserve the field semantics, so
+`(sym:MyFunction)` is equivalent to `sym:MyFunction` rather than a content
+search for the literal text `sym:MyFunction`.
 
 #### Examples:
 - Match either of two repositories:

--- a/query/parse.go
+++ b/query/parse.go
@@ -109,6 +109,19 @@ func isSpace(c byte) bool {
 	return c == ' ' || c == '\t'
 }
 
+func startsQuerySyntax(in []byte) bool {
+	if len(in) > 0 && in[0] == '-' {
+		in = in[1:]
+	}
+
+	for pref := range prefixes {
+		if bytes.HasPrefix(in, []byte(pref)) {
+			return true
+		}
+	}
+	return false
+}
+
 // Parse parses a string into a query.
 func Parse(qStr string) (Q, error) {
 	b := []byte(qStr)
@@ -562,6 +575,13 @@ func nextToken(in []byte) (*token, error) {
 		return &token{
 			Type:  tokNegate,
 			Text:  []byte{'-'},
+			Input: in[:1],
+		}, nil
+	}
+	if left[0] == '(' && startsQuerySyntax(left[1:]) {
+		return &token{
+			Type:  tokParenOpen,
+			Text:  []byte{'('},
 			Input: in[:1],
 		}, nil
 	}

--- a/query/parse.go
+++ b/query/parse.go
@@ -110,7 +110,8 @@ func isSpace(c byte) bool {
 }
 
 func startsQuerySyntax(in []byte) bool {
-	if len(in) > 0 && in[0] == '-' {
+	// Skip grouping and negation tokens before the first atom.
+	for len(in) > 0 && (in[0] == '(' || in[0] == '-') {
 		in = in[1:]
 	}
 

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -95,9 +95,13 @@ func TestParseQuery(t *testing.T) {
 		{"lang:c++", &Language{"C++"}},
 		{"lang:cpp", &Language{"C++"}},
 		{"sym:pqr", &Symbol{&Substring{Pattern: "pqr"}}},
+		{"(sym:pqr)", &Symbol{&Substring{Pattern: "pqr"}}},
 		{"sym:Pqr", &Symbol{&Substring{Pattern: "Pqr", CaseSensitive: true}}},
 		{"sym:.*", &Symbol{&Regexp{Regexp: mustParseRE(".*")}}},
 		{"sym:a(b|d)e", &Symbol{&Regexp{Regexp: mustParseRE("a[bd]e")}}},
+		{"(file:helpers\\.go)", &Substring{Pattern: "helpers.go", FileName: true}},
+		{"(repo:go)", &Repo{regexp.MustCompile("go")}},
+		{"-(file:helpers\\.go)", &Not{&Substring{Pattern: "helpers.go", FileName: true}}},
 
 		// case
 		{"abc case:yes", &Substring{Pattern: "abc", CaseSensitive: true}},
@@ -192,6 +196,8 @@ func TestTokenize(t *testing.T) {
 		{"file:bla", tokFile, "bla"},
 		{"file:bla ", tokFile, "bla"},
 		{"f:bla ", tokFile, "bla"},
+		{"(file:bla)", tokParenOpen, "("},
+		{"(sym:bla)", tokParenOpen, "("},
 		{"(abc def) ", tokParenOpen, "("},
 		{"(abcdef)", tokText, "(abcdef)"},
 		{"(abc)(de)", tokText, "(abc)(de)"},

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -96,6 +96,8 @@ func TestParseQuery(t *testing.T) {
 		{"lang:cpp", &Language{"C++"}},
 		{"sym:pqr", &Symbol{&Substring{Pattern: "pqr"}}},
 		{"(sym:pqr)", &Symbol{&Substring{Pattern: "pqr"}}},
+		{"((sym:pqr))", &Symbol{&Substring{Pattern: "pqr"}}},
+		{"(-sym:pqr)", &Not{&Symbol{&Substring{Pattern: "pqr"}}}},
 		{"sym:Pqr", &Symbol{&Substring{Pattern: "Pqr", CaseSensitive: true}}},
 		{"sym:.*", &Symbol{&Regexp{Regexp: mustParseRE(".*")}}},
 		{"sym:a(b|d)e", &Symbol{&Regexp{Regexp: mustParseRE("a[bd]e")}}},


### PR DESCRIPTION
Fixes #1074.

No-space parenthesized field expressions currently take the regular-expression/text path, so `(sym:foo)` searches content for the literal text `sym:foo`; adding whitespace after the opening parenthesis makes the same expression a grouped symbol query.

This updates the tokenizer heuristic so parenthesized expressions that begin with known field syntax enter the existing grouping parser. It applies consistently to nested and negated forms such as `((sym:foo))`, `(-sym:foo)`, and `-(file:test)`. Bare parenthesized regular expressions such as `(foo)`, `(foo|bar)`, and `(foo)(bar)` retain their existing behavior to avoid a broader compatibility change. The query syntax and parser design documentation now describe this distinction.