### PR TITLE
fix(query): parse field filters inside parentheses

### DIFF
--- a/query/parse.go
+++ b/query/parse.go
@@ -520,6 +520,17 @@ var reservedWords = map[string]int{
 	"or": tokOr,
 }
 
+// hasFieldPrefix reports whether b starts with any of the field prefixes
+// recognized by the tokenizer (e.g. `sym:`, `file:`, `meta.`).
+func hasFieldPrefix(b []byte) bool {
+	for pref := range prefixes {
+		if bytes.HasPrefix(b, []byte(pref)) {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *token) setType() {
 	// After we consumed the input, we have to interpret some of the text,
 	// eg. to distinguish between ")" the text and ) the query grouping
@@ -564,6 +575,24 @@ func nextToken(in []byte) (*token, error) {
 			Text:  []byte{'-'},
 			Input: in[:1],
 		}, nil
+	}
+
+	// If the input opens with one or more `(` and is immediately followed by
+	// a known field prefix (e.g. `sym:`, `file:`, `repo:`), emit the `(` as
+	// a paren-open token. Otherwise the main loop would consume the whole
+	// `(sym:foo)` as a single literal text token (issue #1074).
+	if left[0] == '(' {
+		i := 0
+		for i < len(left) && left[i] == '(' {
+			i++
+		}
+		if i < len(left) && hasFieldPrefix(left[i:]) {
+			return &token{
+				Type:  tokParenOpen,
+				Text:  []byte{'('},
+				Input: in[:1],
+			}, nil
+		}
 	}
 
 	foundSpace := false

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -98,6 +98,11 @@ func TestParseQuery(t *testing.T) {
 		{"sym:Pqr", &Symbol{&Substring{Pattern: "Pqr", CaseSensitive: true}}},
 		{"sym:.*", &Symbol{&Regexp{Regexp: mustParseRE(".*")}}},
 		{"sym:a(b|d)e", &Symbol{&Regexp{Regexp: mustParseRE("a[bd]e")}}},
+		// Field keywords directly after an opening paren must be tokenized
+		// as fields, not folded into a literal text token. Regression test
+		// for https://github.com/sourcegraph/zoekt/issues/1074.
+		{"(sym:foo)", &Symbol{&Substring{Pattern: "foo"}}},
+		{"(f:bar)", &Substring{Pattern: "bar", FileName: true}},
 
 		// case
 		{"abc case:yes", &Substring{Pattern: "abc", CaseSensitive: true}},


### PR DESCRIPTION
Fixes #1074

## Reproduction
`(sym:foo)` was parsed as a literal substring query for `sym:foo` instead of a grouped symbol filter. `( sym:foo)` already parsed as a symbol filter.

## Fix summary
- Preserve opening parentheses as parser tokens when the grouped expression starts with a known field prefix.
- Add regression coverage for grouped `sym:` and `f:` field filters.

## Tests run
- `git diff --check` → pass
- `go test ./query/ -run TestParseQuery -count=1` → pass
- `go test ./query -count=1` → pass
- `go test ./... -short` → fails locally on Windows/environment issues unrelated to `query` (`unix.Umask`/platform build errors, missing `false`, Windows path expectations, struct-size assumptions, allocator memory reserve). The changed `query` package stayed green.

## Risk
Low. The change is limited to tokenization before known field prefixes inside parentheses; non-field parenthesized text keeps the existing literal behavior.

## Non-goals
- No broad parser rewrite.
- No changes to non-field parenthesized text behavior.