### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.4
+golang 1.26.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 RUN apk add --no-cache ca-certificates
 

--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -101,7 +101,7 @@ func run() int {
 	}
 
 	opts.LanguageMap = make(ctags.LanguageMap)
-	for _, mapping := range strings.Split(*languageMap, ",") {
+	for mapping := range strings.SplitSeq(*languageMap, ",") {
 		m := strings.Split(mapping, ":")
 		if len(m) != 2 {
 			continue

--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -90,8 +90,8 @@ func main() {
 
 	ignoreDirMap := map[string]struct{}{}
 	if *ignoreDirs != "" {
-		dirs := strings.Split(*ignoreDirs, ",")
-		for _, d := range dirs {
+		dirs := strings.SplitSeq(*ignoreDirs, ",")
+		for d := range dirs {
 			d = strings.TrimSpace(d)
 			if d != "" {
 				ignoreDirMap[d] = struct{}{}

--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -340,7 +340,7 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 
 		stdout, _ := loggedRun(cmd)
 
-		for _, fn := range bytes.Split(stdout, []byte{'\n'}) {
+		for fn := range bytes.SplitSeq(stdout, []byte{'\n'}) {
 			if len(fn) == 0 {
 				continue
 			}

--- a/cmd/zoekt-mirror-gitlab/main.go
+++ b/cmd/zoekt-mirror-gitlab/main.go
@@ -87,8 +87,8 @@ func main() {
 		ListOptions: gitlab.ListOptions{
 			PerPage: 100,
 		},
-		Sort:       gitlab.Ptr("asc"),
-		OrderBy:    gitlab.Ptr("id"),
+		Sort:       new("asc"),
+		OrderBy:    new("id"),
 		Membership: isMember,
 	}
 	if *isPublic {
@@ -100,11 +100,11 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		opt.LastActivityAfter = gitlab.Ptr(targetDate)
+		opt.LastActivityAfter = new(targetDate)
 	}
 
 	if *noArchived {
-		opt.Archived = gitlab.Ptr(false)
+		opt.Archived = new(false)
 	}
 
 	var gitlabProjects []*gitlab.Project

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1360,7 +1360,7 @@ func getEnvWithDefaultDuration(k string, defaultVal time.Duration) time.Duration
 
 func getEnvWithDefaultEmptySet(k string) map[string]struct{} {
 	set := map[string]struct{}{}
-	for _, v := range strings.Split(os.Getenv(k), ",") {
+	for v := range strings.SplitSeq(os.Getenv(k), ",") {
 		v = strings.TrimSpace(v)
 		if v != "" {
 			set[v] = struct{}{}

--- a/gitindex/catfile_hardening_test.go
+++ b/gitindex/catfile_hardening_test.go
@@ -80,7 +80,7 @@ func TestCatfileReader_ConcurrentClose(t *testing.T) {
 	wg.Add(goroutines)
 	barrier := make(chan struct{})
 
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			<-barrier // all start at once
@@ -186,7 +186,7 @@ func createManyBlobRepo(t *testing.T, fileCount, fileSize int) (string, []plumbi
 
 	runGit(t, dir, "init", "-b", "main", "repo")
 
-	for i := 0; i < fileCount; i++ {
+	for i := range fileCount {
 		content := bytes.Repeat([]byte{byte(i)}, fileSize)
 		name := filepath.Join(repoDir, fmt.Sprintf("file_%03d.bin", i))
 		if err := os.WriteFile(name, content, 0o644); err != nil {
@@ -203,7 +203,7 @@ func createManyBlobRepo(t *testing.T, fileCount, fileSize int) (string, []plumbi
 	}
 
 	ids := make([]plumbing.Hash, 0, fileCount)
-	for _, entry := range bytes.Split(out, []byte{0}) {
+	for entry := range bytes.SplitSeq(out, []byte{0}) {
 		if len(entry) == 0 {
 			continue
 		}
@@ -268,7 +268,7 @@ func TestCatfileReader_ReadAfterFullConsumption(t *testing.T) {
 	}
 
 	// Blob is fully read — additional Reads must return EOF.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		buf := make([]byte, 10)
 		n, err := cr.Read(buf)
 		if n != 0 || err != io.EOF {
@@ -718,7 +718,7 @@ func TestCatfileReader_RepeatedNextAfterEOF(t *testing.T) {
 	}
 
 	// Second and third EOF — must be stable.
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		_, _, _, err = cr.Next()
 		if err != io.EOF {
 			t.Fatalf("Next #%d after EOF: %v, want io.EOF", i+2, err)
@@ -843,7 +843,7 @@ func TestCatfileReader_DuplicateSHAs(t *testing.T) {
 	}
 	defer cr.Close()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		size, missing, excluded, err := cr.Next()
 		if err != nil {
 			t.Fatalf("Next #%d: %v", i, err)

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -825,7 +825,6 @@ func TestIndexDeltaBasic(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -148,4 +148,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.9
+go 1.26.4

--- a/grpc/grpcutil/util.go
+++ b/grpc/grpcutil/util.go
@@ -14,8 +14,8 @@ import (
 // Copied from github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/reporter.go
 func SplitMethodName(fullMethod string) (string, string) {
 	fullMethod = strings.TrimPrefix(fullMethod, "/") // remove leading slash
-	if i := strings.Index(fullMethod, "/"); i >= 0 {
-		return fullMethod[:i], fullMethod[i+1:]
+	if before, after, ok := strings.Cut(fullMethod, "/"); ok {
+		return before, after
 	}
 	return "unknown", "unknown"
 }

--- a/index/builder_test.go
+++ b/index/builder_test.go
@@ -614,7 +614,6 @@ func TestBuilder_DeltaShardsBuildsShouldErrorOnIndexOptionsMismatch(t *testing.T
 			options: func(options *Options) { options.LargeFiles = []string{"-large_file", "*.md", "-large_file", "*.yaml"} },
 		},
 	} {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			indexDir := t.TempDir()
@@ -714,7 +713,6 @@ func TestBuilder_DeltaShardsMetadataInOlderShards(t *testing.T) {
 			},
 		},
 	} {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			indexDir := t.TempDir()
@@ -1090,11 +1088,11 @@ func testFileRankAspect(t *testing.T, c filerankCase) {
 	sortDocuments(got)
 
 	print := func(ds []*Document) string {
-		r := ""
+		var r strings.Builder
 		for _, d := range ds {
-			r += fmt.Sprintf("%v, ", d)
+			r.WriteString(fmt.Sprintf("%v, ", d))
 		}
-		return r
+		return r.String()
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got docs [%v], want [%v]", print(got), print(want))

--- a/index/docmatchtreecache_test.go
+++ b/index/docmatchtreecache_test.go
@@ -69,9 +69,9 @@ func TestDocMatchTreeCache_Concurrent(t *testing.T) {
 	done := make(chan bool, numGoroutines)
 
 	// Reader goroutines (should be majority of operations)
-	for i := 0; i < numGoroutines-1; i++ {
+	for i := range numGoroutines - 1 {
 		go func(id int) {
-			for j := 0; j < numOperations; j++ {
+			for j := range numOperations {
 				field := "field" + strconv.Itoa(j%10)
 				value := "value" + strconv.Itoa(j%20)
 				cache.Get(field, value)
@@ -82,7 +82,7 @@ func TestDocMatchTreeCache_Concurrent(t *testing.T) {
 
 	// Writer goroutine (fewer write operations)
 	go func() {
-		for j := 0; j < numOperations/10; j++ {
+		for j := range numOperations / 10 {
 			field := "field" + strconv.Itoa(j%10)
 			value := "value" + strconv.Itoa(j%20)
 			tree := trees[j%len(trees)]
@@ -92,7 +92,7 @@ func TestDocMatchTreeCache_Concurrent(t *testing.T) {
 	}()
 
 	// Wait for all goroutines to complete
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		<-done
 	}
 }

--- a/index/shard_builder.go
+++ b/index/shard_builder.go
@@ -121,10 +121,7 @@ const initialPostingCap = 64
 // derived from the maximum shard content size. Intentionally over-estimates
 // (the map only holds non-ASCII trigrams) to avoid rehashing.
 func estimateNgrams(shardMaxBytes int) int {
-	n := shardMaxBytes / 600
-	if n < 1024 {
-		n = 1024
-	}
+	n := max(shardMaxBytes/600, 1024)
 	return n
 }
 

--- a/search/sched.go
+++ b/search/sched.go
@@ -299,7 +299,7 @@ func (t *deadlineTimer) Stop() {
 func parseTuneables(v string) map[string]int {
 	m := map[string]int{}
 
-	for _, kv := range strings.Split(v, ",") {
+	for kv := range strings.SplitSeq(v, ",") {
 		if kv == "" {
 			continue
 		}

--- a/search/shards_test.go
+++ b/search/shards_test.go
@@ -760,7 +760,6 @@ func TestShardedSearcher_List(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ pkgs.mkShell {
   name = "zoekt";
 
   nativeBuildInputs = [
-    pkgs.go_1_23
+    pkgs.go_1_26
 
     # zoekt-git-index
     pkgs.git


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)