### PR TITLE
languages: update enry and preserve Mathematica

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/felixge/fgprof v0.9.5
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68
-	github.com/go-enry/go-enry/v2 v2.9.1
+	github.com/go-enry/go-enry/v2 v2.9.6
 	github.com/go-git/go-git/v5 v5.19.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/gfleury/go-bitbucket-v1/test/bb-mock-server v0.0.0-20230825095122-9bc
 github.com/gfleury/go-bitbucket-v1/test/bb-mock-server v0.0.0-20230825095122-9bc1711434ab/go.mod h1:VssB0kb1cETNaFFC/0mHVCj+7i5TS2xraYq+tl9JLwE=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-enry/go-enry/v2 v2.9.1 h1:G9iDteJ/Mc0F4Di5NeQknf83R2OkRbwY9cAYmcqVG6U=
-github.com/go-enry/go-enry/v2 v2.9.1/go.mod h1:9yrj4ES1YrbNb1Wb7/PWYr2bpaCXUGRt0uafN0ISyG8=
+github.com/go-enry/go-enry/v2 v2.9.6 h1:np63eOtMV56zfYDHnFVgpEVOk8fr2kmylcMnAZUDbSs=
+github.com/go-enry/go-enry/v2 v2.9.6/go.mod h1:9yrj4ES1YrbNb1Wb7/PWYr2bpaCXUGRt0uafN0ISyG8=
 github.com/go-enry/go-oniguruma v1.2.1 h1:k8aAMuJfMrqm/56SG2lV9Cfti6tC4x8673aHCcBk+eo=
 github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6ilRZbCAD5Hf4=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/index/eval.go
+++ b/index/eval.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"time"
 
-	enry_data "github.com/go-enry/go-enry/v2/data"
 	"github.com/grafana/regexp"
 
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/internal/tenant"
+	"github.com/sourcegraph/zoekt/languages"
 	"github.com/sourcegraph/zoekt/query"
 )
 
@@ -89,7 +89,7 @@ func (d *indexData) simplify(in query.Q) query.Q {
 				// For index files that haven't been re-indexed by go-enry,
 				// fall back to file-based matching and continue even if this
 				// repo doesn't have the specific language present.
-				extsForLang := enry_data.ExtensionsByLanguage[r.Language]
+				extsForLang := languages.GetLanguageExtensions(r.Language)
 				if extsForLang != nil {
 					extFrags := make([]string, 0, len(extsForLang))
 					for _, ext := range extsForLang {

--- a/languages/extensions.go
+++ b/languages/extensions.go
@@ -30,7 +30,11 @@ func GetLanguageByNameOrAlias(nameOrAlias string) (lang string, ok bool) {
 		return lang, true
 	}
 
-	return enry.GetLanguageByAlias(alias)
+	lang, ok = enry.GetLanguageByAlias(alias)
+	if !ok {
+		return "", false
+	}
+	return legacyLanguageName(lang), true
 }
 
 // GetLanguageExtensions returns the list of file extensions for a given
@@ -47,6 +51,7 @@ func GetLanguageExtensions(language string) []string {
 		return langs
 	}
 
+	language = enryLanguageName(language)
 	ignoreExts, isNiche := nicheExtensionUsages[language]
 	// Force a copy to avoid accidentally modifying the global variable
 	exts := slices.Clone(enry.GetLanguageExtensions(language))

--- a/languages/extensions_test.go
+++ b/languages/extensions_test.go
@@ -85,6 +85,12 @@ func TestGetLanguageExtensions_NonAmbiguousExtensions(t *testing.T) {
 	}
 }
 
+func TestGetLanguageExtensions_LegacyLanguageName(t *testing.T) {
+	extensions := GetLanguageExtensions("Mathematica")
+	require.Contains(t, extensions, ".wl")
+	require.Contains(t, extensions, ".mathematica")
+}
+
 func TestGetLanguagesByExtension_UnsupportedExtensions(t *testing.T) {
 	for ext, language := range unsupportedByEnryExtensionToNameMap {
 		filename := "foo" + ext

--- a/languages/languages.go
+++ b/languages/languages.go
@@ -16,6 +16,19 @@ var enryLanguageMappings = map[string]string{
 	"c#":  "c_sharp",
 }
 
+// go-enry follows Linguist's rename from "Mathematica" to "Wolfram Language".
+// Keep exposing "Mathematica" from Zoekt so new indexes continue to match the
+// language name stored in existing shards and used by Zoekt clients.
+// Without this compatibility mapping, mixed old/new indexes would split
+// lang:mathematica results until every repository had been reindexed.
+var legacyLanguageNames = map[string]string{
+	"Wolfram Language": "Mathematica",
+}
+
+var enryLanguageNames = map[string]string{
+	"Mathematica": "Wolfram Language",
+}
+
 // NormalizeLanguage converts the language name to lowercase and maps known
 // aliases to their canonical names.
 func NormalizeLanguage(filetype string) string {
@@ -99,7 +112,29 @@ func GetLanguages(path string, getContent func() ([]byte, error)) ([]string, err
 	}
 
 	langs, err := impl()
-	return slices.Clone(langs), err
+	return applyLegacyLanguageNames(langs), err
+}
+
+func applyLegacyLanguageNames(langs []string) []string {
+	out := slices.Clone(langs)
+	for i, lang := range out {
+		out[i] = legacyLanguageName(lang)
+	}
+	return out
+}
+
+func legacyLanguageName(lang string) string {
+	if legacy, ok := legacyLanguageNames[lang]; ok {
+		return legacy
+	}
+	return lang
+}
+
+func enryLanguageName(lang string) string {
+	if enryName, ok := enryLanguageNames[lang]; ok {
+		return enryName
+	}
+	return lang
 }
 
 // GetLanguagesFromContent is a convenience wrapper around GetLanguages that

--- a/languages/languages_test.go
+++ b/languages/languages_test.go
@@ -72,8 +72,8 @@ fourthpower[x_] := square[square[x]]
 		{path: "file.magik", content: emptyContent, expectedLanguages: []string{"Magik"}},
 		{path: "file.apxc", content: emptyContent, expectedLanguages: []string{"Apex"}},
 		// Check that we classify cls files by content and not just by extension
-		{path: "tex.cls", content: `\DeclareOption*{}`, expectedLanguages: []string{"TeX", "Apex", "ObjectScript", "Visual Basic 6.0", "OpenEdge ABL", "VBA"}},
-		{path: "tex.cls", content: `public class HelloWorld {`, expectedLanguages: []string{"Apex", "Visual Basic 6.0", "TeX", "OpenEdge ABL", "ObjectScript", "VBA"}},
+		{path: "tex.cls", content: `\DeclareOption*{}`, expectedLanguages: []string{"TeX", "Apex", "ObjectScript", "Visual Basic 6.0", "VBA", "OpenEdge ABL"}},
+		{path: "tex.cls", content: `public class HelloWorld {`, expectedLanguages: []string{"Apex", "Visual Basic 6.0", "VBA", "TeX", "OpenEdge ABL", "ObjectScript"}},
 	}
 
 	for _, testCase := range testCases {
@@ -169,6 +169,18 @@ func TestGetLanguageByNameOrAlias(t *testing.T) {
 			name:   "apex example unsupported by linguist alias",
 			alias:  "apex",
 			want:   "Apex",
+			wantOk: true,
+		},
+		{
+			name:   "mathematica legacy name",
+			alias:  "mathematica",
+			want:   "Mathematica",
+			wantOk: true,
+		},
+		{
+			name:   "wolfram language alias",
+			alias:  "Wolfram Language",
+			want:   "Mathematica",
 			wantOk: true,
 		},
 	}

--- a/query/parse_test.go
+++ b/query/parse_test.go
@@ -94,6 +94,8 @@ func TestParseQuery(t *testing.T) {
 
 		{"lang:c++", &Language{"C++"}},
 		{"lang:cpp", &Language{"C++"}},
+		{"lang:mathematica", &Language{"Mathematica"}},
+		{"lang:\"Wolfram Language\"", &Language{"Mathematica"}},
 		{"sym:pqr", &Symbol{&Substring{Pattern: "pqr"}}},
 		{"sym:Pqr", &Symbol{&Substring{Pattern: "Pqr", CaseSensitive: true}}},
 		{"sym:.*", &Symbol{&Regexp{Regexp: mustParseRE(".*")}}},


### PR DESCRIPTION
The enry update follows Linguist in renaming Mathematica to Wolfram Language. Zoekt indexes and clients already use Mathematica, so adopting the new name directly would split language searches across old and new shards until every repository had been reindexed.

We likely need some sort of lightweight way to make changes like this which doesn't force reindexing, but allows us to start encoding things differently for new indexes + make decisions at search time based on the version. We kinda have stuff like that, but it isn't lightweight. So we keep Zoekt's public language name stable while accepting the new Wolfram aliases from enry.