### PR TITLE
index: gracefully delete empty compound shards on explode

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -428,8 +428,9 @@ func (s *Server) vacuum() {
 
 			if err != nil {
 				errorLog.Printf("failed to explode compound shard: shard=%s out=%s err=%s", path, string(b), err)
+			} else {
+				infoLog.Printf("exploded compound shard: shard=%s", path)
 			}
-			infoLog.Printf("exploded compound shard: shard=%s", path)
 			continue
 		}
 

--- a/index/merge.go
+++ b/index/merge.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -164,7 +165,14 @@ func Explode(dstDir string, inputShard string) error {
 		}
 	}()
 	if err != nil {
-		return fmt.Errorf("zoekt.Explode: %w", err)
+		// A compound shard with no repositories (for example after all of its
+		// repos have been tombstoned and merged out) has nothing to explode into
+		// simple shards. It holds no data and cannot be loaded by zoekt-webserver,
+		// so treat it as empty and fall through to remove the input shard below
+		// rather than leaving it on disk to fail on every reload.
+		if !errors.Is(err, ErrEmptyShard) {
+			return fmt.Errorf("zoekt.Explode: %w", err)
+		}
 	}
 
 	// remove the input shard first to avoid duplicate indexes. In the worst case,

--- a/index/merge_test.go
+++ b/index/merge_test.go
@@ -1,6 +1,8 @@
 package index
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,6 +158,37 @@ func TestExplode(t *testing.T) {
 
 	for _, s := range simpleShards {
 		checkSameShards(t, s, filepath.Join(tmpDir, filepath.Base(s)))
+	}
+}
+
+// TestExplodeEmptyShard verifies that exploding a compound shard with zero
+// repositories removes the shard and returns success, instead of failing and
+// leaving an unusable shard on disk. A compound shard reaches this state once
+// all of its repos have been tombstoned and merged out. Such a shard cannot be
+// loaded by zoekt-webserver, so leaving it in place drives up the indexed
+// search error rate until it is removed.
+func TestExplodeEmptyShard(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build a compound shard that contains no repositories.
+	sb := newShardBuilder(0)
+	sb.indexFormatVersion = NextIndexFormatVersion
+	path := filepath.Join(dir, fmt.Sprintf("compound-empty_v%d.00000.zoekt", NextIndexFormatVersion))
+	if err := builderWriteAll(path, sb); err != nil {
+		t.Fatalf("builderWriteAll: %v", err)
+	}
+
+	// Confirm the shard really is the empty-shard case.
+	if _, _, err := ReadMetadataPath(path); !errors.Is(err, ErrEmptyShard) {
+		t.Fatalf("ReadMetadataPath: got %v, want ErrEmptyShard", err)
+	}
+
+	// Explode should remove the empty shard and return nil.
+	if err := Explode(dir, path); err != nil {
+		t.Fatalf("Explode: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("empty shard was not removed, stat err = %v", err)
 	}
 }
 

--- a/index/read.go
+++ b/index/read.go
@@ -17,6 +17,7 @@ package index
 import (
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"log"
@@ -426,6 +427,11 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	return &d, nil
 }
 
+// ErrEmptyShard is returned when reading the metadata of a shard that contains
+// no repositories and has no ID to backfill one from. Such a shard holds no
+// data and cannot be loaded, so callers may treat it as safe to delete.
+var ErrEmptyShard = errors.New("len(repos)=0. Cannot backfill ID")
+
 func (r *reader) parseMetadata(metaData simpleSection, repoMetaData simpleSection) ([]*zoekt.Repository, *zoekt.IndexMetadata, error) {
 	var md zoekt.IndexMetadata
 	if err := r.readJSON(&md, metaData); err != nil {
@@ -461,7 +467,7 @@ func (r *reader) parseMetadata(metaData simpleSection, repoMetaData simpleSectio
 
 	if md.ID == "" {
 		if len(repos) == 0 {
-			return nil, nil, fmt.Errorf("len(repos)=0. Cannot backfill ID")
+			return nil, nil, ErrEmptyShard
 		}
 		md.ID = backfillID(repos[0].Name)
 	}


### PR DESCRIPTION
## Problem

An empty compound shard — one whose repositories have all been tombstoned and merged out — has `len(repos)==0` and no ID to backfill from. Reading its metadata fails with `len(repos)=0. Cannot backfill ID`.

That error surfaced two ways for a customer, firing the `indexed_search_request_errors` alert:

- The indexserver `vacuum()` loop shells out to `zoekt-merge-index explode` to shrink small compound shards. On an empty shard `Explode` returned the error, so vacuum **left the shard on disk** (and logged `exploded compound shard` anyway).
- `zoekt-webserver` then failed to load that shard on **every reload cycle**, continuously driving up the indexed search error rate.

There was no path to recovery short of a manual `rm` of the shard.

## Fix

- `index/read.go`: expose the condition as a sentinel `ErrEmptyShard` (error string unchanged) so callers can detect it with `errors.Is`.
- `index/merge.go`: `Explode` now recognizes `ErrEmptyShard` and falls through to the existing input-shard removal instead of erroring. The empty compound shard is **deleted** and `Explode` returns success — so the vacuum loop and the `zoekt-merge-index explode` CLI both recover on their own.
- `cmd/zoekt-sourcegraph-indexserver/cleanup.go`: only log `exploded compound shard` on actual success.

## Test
1. Unit test
go test ./index/ -run TestExplodeEmptyShard -v -count=1
→ expect --- PASS: TestExplodeEmptyShard / ok.

2. Build both binaries — fixed (this branch) + old (main, via a throwaway worktree)
go build -o /tmp/zmi-fixed ./cmd/zoekt-merge-index
git worktree add /tmp/zoekt-main main
(cd /tmp/zoekt-main && go build -o /tmp/zmi-old ./cmd/zoekt-merge-index)

3. Create the empty compound shard
go run ./scratch_repro
→ ignore the finished shard … log noise; expect these lines:
empty shard:    compound-da39a3ee5e6b…709_v17.00000.zoekt
ReadMetadataPath err: len(repos)=0. Cannot backfill ID

4. Save the shard path
S=/tmp/zoekt-empty-shard-repro/compound-da39a3ee5e6b4b0d3255bfef95601890afd80709_v17.00000.zoekt

5. OLD binary → reproduce the bug (shard survives)
/tmp/zmi-old explode "$S"; echo "exit=$?"; ls -A /tmp/zoekt-empty-shard-repro
→ expect: zoekt.Explode: len(repos)=0. Cannot backfill ID, exit=1, and the shard still listed.

6. FIXED binary → same shard, now deleted
/tmp/zmi-fixed explode "$S"; echo "exit=$?"; ls -A /tmp/zoekt-empty-shard-repro
→ expect: exit=0 and the dir empty (shard removed).