### PR TITLE
fix/index: prevent repositoryless shard artifacts

### DIFF
--- a/cmd/zoekt-merge-index/main.go
+++ b/cmd/zoekt-merge-index/main.go
@@ -26,13 +26,14 @@ import (
 )
 
 // merge merges the input shards into a compound shard in dstDir. It returns the
-// full path to the compound shard. The input shards are removed on success.
+// full path to the compound shard, or an empty path when no live repositories
+// remain. The input shards are removed on success.
 func merge(dstDir string, names []string) (string, error) {
 	var files []index.IndexFile
 	for _, fn := range names {
 		f, err := os.Open(fn)
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 		defer f.Close()
 
@@ -45,7 +46,7 @@ func merge(dstDir string, names []string) (string, error) {
 		files = append(files, indexFile)
 	}
 
-	tmpName, dstName, err := index.Merge(dstDir, files...)
+	result, err := index.Merge(dstDir, files...)
 	if err != nil {
 		return "", err
 	}
@@ -63,13 +64,15 @@ func merge(dstDir string, names []string) (string, error) {
 		}
 	}
 
-	// We only rename the compound shard if all simple shards could be deleted in the
-	// previous step. This guarantees we won't have duplicate indexes.
-	if err := os.Rename(tmpName, dstName); err != nil {
-		return "", fmt.Errorf("zoekt-merge-index: failed to rename compound shard: %w", err)
+	if result.HasOutput() {
+		// We only rename the compound shard if all simple shards could be deleted in the
+		// previous step. This guarantees we won't have duplicate indexes.
+		if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
+			return "", fmt.Errorf("zoekt-merge-index: failed to rename compound shard: %w", err)
+		}
 	}
 
-	return dstName, nil
+	return result.FinalPath, nil
 }
 
 func mergeCmd(paths []string) (string, error) {
@@ -115,7 +118,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println(compoundShardPath)
+		if compoundShardPath != "" {
+			fmt.Println(compoundShardPath)
+		}
 	case "explode":
 		if flag.NArg() != 2 {
 			log.Fatal("explode requires exactly one compound shard path")

--- a/cmd/zoekt-merge-index/main_test.go
+++ b/cmd/zoekt-merge-index/main_test.go
@@ -48,6 +48,33 @@ func TestMerge(t *testing.T) {
 	require.Len(t, result.Files, 2)
 }
 
+func TestMergeAllTombstonedDeletesInputWithoutOutput(t *testing.T) {
+	dir := t.TempDir()
+	inputPath := filepath.Join(dir, "all-tombstoned.zoekt")
+
+	sb, err := index.NewShardBuilder(&zoekt.Repository{ID: 1, Name: "deleted", Tombstone: true})
+	require.NoError(t, err)
+	require.NoError(t, sb.Add(index.Document{Name: "f", Content: []byte("content")}))
+	f, err := os.Create(inputPath)
+	require.NoError(t, err)
+	require.NoError(t, sb.Write(f))
+	require.NoError(t, f.Close())
+
+	outputPath, err := merge(dir, []string{inputPath})
+	require.NoError(t, err)
+	require.Empty(t, outputPath)
+	_, err = os.Stat(inputPath)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	matches, err := filepath.Glob(filepath.Join(dir, "*.zoekt"))
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestMergeReturnsInputOpenError(t *testing.T) {
+	_, err := merge(t.TempDir(), []string{filepath.Join(t.TempDir(), "missing.zoekt")})
+	require.Error(t, err)
+}
+
 // Merge 2 simple shards and then explode them.
 func TestExplode(t *testing.T) {
 	v16Shards, err := filepath.Glob("../../testdata/shards/repo*_v16.*.zoekt")

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,7 +27,8 @@ var metricCleanupDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 // cleanup trashes shards in indexDir that do not exist in repos. For repos
 // that do not exist in indexDir, but do in indexDir/.trash it will move them
 // back into indexDir. Additionally it uses now to remove shards that have
-// been in the trash for 24 hours. It also deletes .tmp files older than 4 hours.
+// been in the trash for 24 hours, removes legacy repositoryless shards, and
+// deletes .tmp files older than 4 hours.
 func cleanup(indexDir string, repos []uint32, now time.Time, shardMerging bool) {
 	start := time.Now()
 	trashDir := filepath.Join(indexDir, ".trash")
@@ -34,9 +36,9 @@ func cleanup(indexDir string, repos []uint32, now time.Time, shardMerging bool) 
 		errorLog.Printf("failed to create trash dir: %v", err)
 	}
 
-	trash := getShards(trashDir)
+	trash := getShards(trashDir, true)
 	tombtones := getTombstonedRepos(indexDir)
-	indexShards := getShards(indexDir)
+	indexShards := getShards(indexDir, true)
 
 	// trash: Remove old shards and conflicts with index
 	minAge := now.Add(-24 * time.Hour)
@@ -176,7 +178,7 @@ type shard struct {
 	RepoTombstone bool
 }
 
-func getShards(dir string) map[uint32][]shard {
+func getShards(dir string, removeRepositoryless bool) map[uint32][]shard {
 	d, err := os.Open(dir)
 	if err != nil {
 		debugLog.Printf("failed to getShards: %s", dir)
@@ -200,6 +202,11 @@ func getShards(dir string) map[uint32][]shard {
 
 		repos, _, err := index.ReadMetadataPathAlive(path)
 		if err != nil {
+			if removeRepositoryless && errors.Is(err, index.ErrEmptyShard) {
+				infoLog.Printf("removing repositoryless shard: %s", path)
+				removeAll(shard{Path: path})
+				continue
+			}
 			debugLog.Printf("failed to read shard: %v", err)
 			continue
 		}
@@ -471,15 +478,6 @@ func removeTombstones(fn string) ([]*zoekt.Repository, error) {
 		return nil, nil
 	}
 
-	defer func() {
-		paths, err := index.IndexFilePaths(fn)
-		if err != nil {
-			return
-		}
-		for _, path := range paths {
-			os.Remove(path)
-		}
-	}()
 	err = runMerge()
 	if err != nil {
 		return nil, fmt.Errorf("runMerge: %s", err)

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -240,6 +240,7 @@ func TestVacuum(t *testing.T) {
 	}
 
 	mockMerger = func() error { return mergeHelper(t, fn) }
+	t.Cleanup(func() { mockMerger = nil })
 	got, err := removeTombstones(fn)
 	if err != nil {
 		t.Fatal(err)
@@ -270,6 +271,51 @@ func TestVacuum(t *testing.T) {
 	for _, r := range repos {
 		if r.Tombstone {
 			t.Fatalf("found tombstone for %s", r.Name)
+		}
+	}
+}
+
+func TestVacuumDeletesAllTombstonedShard(t *testing.T) {
+	tmpDir := t.TempDir()
+	fn := createCompoundShard(t, tmpDir, []uint32{1, 2})
+	for _, repoID := range []uint32{1, 2} {
+		if err := index.SetTombstone(fn, repoID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mockMerger = func() error { return mergeHelper(t, fn) }
+	t.Cleanup(func() { mockMerger = nil })
+	removed, err := removeTombstones(fn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed %d repositories, want 2", len(removed))
+	}
+	if _, err := os.Stat(fn); !os.IsNotExist(err) {
+		t.Fatalf("all-tombstoned shard was not removed: %v", err)
+	}
+	if matches, err := filepath.Glob(filepath.Join(tmpDir, "compound-*")); err != nil {
+		t.Fatal(err)
+	} else if len(matches) != 0 {
+		t.Fatalf("vacuum left compound shards behind: %v", matches)
+	}
+}
+
+func TestCleanupRemovesRepositorylessShard(t *testing.T) {
+	dir := t.TempDir()
+	path := createCompoundShard(t, dir, []uint32{1})
+	if err := os.WriteFile(path+".meta", []byte("[]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleanup runs independently of shard merging, so legacy repositoryless
+	// shards are recovered even if vacuum is disabled.
+	cleanup(dir, []uint32{1}, time.Now(), false)
+	for _, path := range []string{path, path + ".meta"} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("repositoryless shard path %s was not removed: %v", path, err)
 		}
 	}
 }
@@ -414,8 +460,8 @@ func TestCleanupCompoundShards(t *testing.T) {
 
 	cleanup(dir, repos, now, true)
 
-	index := getShards(dir)
-	trash := getShards(filepath.Join(dir, ".trash"))
+	index := getShards(dir, false)
+	trash := getShards(filepath.Join(dir, ".trash"), false)
 
 	if len(trash) != 0 {
 		t.Fatalf("expected empty trash, got %+v", trash)
@@ -493,19 +539,22 @@ func createCompoundShard(t *testing.T, dir string, ids []uint32, optFns ...func(
 	}
 
 	// create a compound shard.
-	tmpFn, dstFn, err := merge(t, dir, repoFns)
+	result, err := merge(t, dir, repoFns)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !result.HasOutput() {
+		t.Fatal("merge produced no output")
 	}
 	for _, old := range repoFns {
 		if err := os.Remove(old); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := os.Rename(tmpFn, dstFn); err != nil {
+	if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
 		t.Fatal(err)
 	}
-	return dstFn
+	return result.FinalPath
 }
 
 func mergeHelper(t *testing.T, fn string) error {
@@ -523,6 +572,22 @@ func mergeHelper(t *testing.T, fn string) error {
 	}
 	defer indexFile.Close()
 
-	_, _, err = index.Merge(filepath.Dir(fn), indexFile)
-	return err
+	result, err := index.Merge(filepath.Dir(fn), indexFile)
+	if err != nil {
+		return err
+	}
+
+	paths, err := index.IndexFilePaths(fn)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+	if result.HasOutput() {
+		return os.Rename(result.TempPath, result.FinalPath)
+	}
+	return nil
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -1200,7 +1200,7 @@ func (s *Server) DeleteAllData(ctx context.Context, _ *indexserverv1.DeleteAllDa
 }
 
 func listIndexed(indexDir string) []uint32 {
-	index := getShards(indexDir)
+	index := getShards(indexDir, false)
 	metricNumIndexed.Set(float64(len(index)))
 	repoIDs := make([]uint32, 0, len(index))
 	for id := range index {

--- a/cmd/zoekt-sourcegraph-indexserver/meta_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/meta_test.go
@@ -63,13 +63,17 @@ func TestMergeMeta(t *testing.T) {
 	// create a compound shard. Use a new indexdir to avoid the need to cleanup
 	// old shards.
 	dir = t.TempDir()
-	tmpFn, dstFn, err := merge(t, dir, repoFns)
+	result, err := merge(t, dir, repoFns)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Rename(tmpFn, dstFn); err != nil {
+	if !result.HasOutput() {
+		t.Fatal("merge produced no output")
+	}
+	if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
 		t.Fatal(err)
 	}
+	dstFn := result.FinalPath
 
 	readPublic := func() []string {
 		var public []string
@@ -103,20 +107,20 @@ func TestMergeMeta(t *testing.T) {
 	}
 }
 
-func merge(t *testing.T, dstDir string, names []string) (string, string, error) {
+func merge(t *testing.T, dstDir string, names []string) (index.MergeResult, error) {
 	t.Helper()
 
 	var files []index.IndexFile
 	for _, fn := range names {
 		f, err := os.Open(fn)
 		if err != nil {
-			return "", "", err
+			return index.MergeResult{}, err
 		}
 		defer f.Close()
 
 		indexFile, err := index.NewIndexFile(f)
 		if err != nil {
-			return "", "", err
+			return index.MergeResult{}, err
 		}
 		defer indexFile.Close()
 

--- a/index/builder_test.go
+++ b/index/builder_test.go
@@ -966,11 +966,14 @@ func createTestCompoundShard(t testing.TB, indexDir string, repositories []zoekt
 	}
 
 	// merge all the simple shards into a compound shard
-	tmpName, dstName, err := Merge(indexDir, files...)
+	result, err := Merge(indexDir, files...)
 	if err != nil {
 		t.Fatalf("merging index files into compound shard: %s", err)
 	}
-	if err := os.Rename(tmpName, dstName); err != nil {
+	if !result.HasOutput() {
+		t.Fatal("merging index files produced no output")
+	}
+	if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/index/merge.go
+++ b/index/merge.go
@@ -14,41 +14,53 @@ import (
 	"github.com/sourcegraph/zoekt"
 )
 
-// Merge files into a compound shard in dstDir. Merge returns tmpName and a
-// dstName. It is the responsibility of the caller to delete the input shards and
-// rename the temporary compound shard from tmpName to dstName.
-func Merge(dstDir string, files ...IndexFile) (tmpName, dstName string, _ error) {
+// MergeResult describes the optional output of a successful Merge. HasOutput
+// is false when every input repository was tombstoned and the merge therefore
+// produced no replacement shard.
+type MergeResult struct {
+	TempPath  string
+	FinalPath string
+}
+
+// HasOutput reports whether the merge produced a replacement shard.
+func (r MergeResult) HasOutput() bool {
+	return r.TempPath != ""
+}
+
+// Merge files into a compound shard in dstDir. A successful merge produces no
+// output when every input repository is tombstoned. It is the responsibility
+// of the caller to delete the input shards and, when result.HasOutput(), rename
+// the temporary compound shard to its final path.
+func Merge(dstDir string, files ...IndexFile) (result MergeResult, _ error) {
 	var ds []*indexData
 	for _, f := range files {
 		searcher, err := NewSearcher(f)
 		if err != nil {
-			return "", "", err
+			return MergeResult{}, err
 		}
 		ds = append(ds, searcher.(*indexData))
 	}
 
 	ib, err := merge(ds...)
 	if err != nil {
-		return "", "", err
+		return MergeResult{}, err
+	}
+	if len(ib.repoList) == 0 {
+		return MergeResult{}, nil
 	}
 
 	hasher := sha1.New()
-	for _, d := range ds {
-		for i, md := range d.repoMetaData {
-			if d.repoMetaData[i].Tombstone {
-				continue
-			}
-			hasher.Write([]byte(md.Name))
-			hasher.Write([]byte{0})
-		}
+	for _, repo := range ib.repoList {
+		hasher.Write([]byte(repo.Name))
+		hasher.Write([]byte{0})
 	}
 
-	dstName = filepath.Join(dstDir, fmt.Sprintf("compound-%x_v%d.%05d.zoekt", hasher.Sum(nil), NextIndexFormatVersion, 0))
-	tmpName = dstName + ".tmp"
-	if err := builderWriteAll(tmpName, ib); err != nil {
-		return "", "", err
+	result.FinalPath = filepath.Join(dstDir, fmt.Sprintf("compound-%x_v%d.%05d.zoekt", hasher.Sum(nil), NextIndexFormatVersion, 0))
+	result.TempPath = result.FinalPath + ".tmp"
+	if err := builderWriteAll(result.TempPath, ib); err != nil {
+		return MergeResult{}, err
 	}
-	return tmpName, dstName, nil
+	return result, nil
 }
 
 func builderWriteAll(fn string, ib *ShardBuilder) error {
@@ -103,41 +115,46 @@ func merge(ds ...*indexData) (*ShardBuilder, error) {
 	sb.indexFormatVersion = NextIndexFormatVersion
 
 	for _, d := range ds {
-		lastRepoID := -1
-		for docID := uint32(0); int(docID) < len(d.fileBranchMasks); docID++ {
-			repoID := int(d.repos[docID])
-
-			if d.repoMetaData[repoID].Tombstone {
-				continue
+		err := forEachRepositoryDocumentRange(d, func(repoID int, start, end uint32) error {
+			repo := &d.repoMetaData[repoID]
+			if repo.Tombstone {
+				return nil
 			}
 
-			if repoID != lastRepoID {
-				if lastRepoID > repoID {
-					return nil, fmt.Errorf("non-contiguous repo ids in %s for document %d: old=%d current=%d", d.String(), docID, lastRepoID, repoID)
-				}
-				lastRepoID = repoID
-
-				// Initialize repo metadata if it does not already exist.
-				repo := d.repoMetaData[repoID]
-				if repo.Metadata == nil {
-					repo.Metadata = make(map[string]string)
-				}
-
-				// TODO we are losing empty repos on merging since we only get here if
-				// there is an associated document.
-
-				if err := sb.setRepository(&d.repoMetaData[repoID]); err != nil {
-					return nil, err
-				}
+			if err := sb.setRepository(repo); err != nil {
+				return err
 			}
 
-			if err := addDocument(d, sb, repoID, docID); err != nil {
-				return nil, err
+			for docID := start; docID < end; docID++ {
+				if err := addDocument(d, sb, repoID, docID); err != nil {
+					return err
+				}
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return sb, nil
+}
+
+func forEachRepositoryDocumentRange(d *indexData, f func(repoID int, start, end uint32) error) error {
+	var docID uint32
+	for repoID := range d.repoMetaData {
+		start := docID
+		for int(docID) < len(d.repos) && d.repos[docID] == uint16(repoID) {
+			docID++
+		}
+		if err := f(repoID, start, docID); err != nil {
+			return err
+		}
+	}
+	if int(docID) != len(d.repos) {
+		return fmt.Errorf("document %d in %s references repository %d, but the shard has %d repositories", docID, d.String(), d.repos[docID], len(d.repoMetaData))
+	}
+	return nil
 }
 
 // Explode takes an input shard and creates 1 simple shard per repository. It is
@@ -233,44 +250,26 @@ func explode(dstDir string, f IndexFile, ibFuncs ...shardBuilderFunc) (map[strin
 		return builderWriteAll(shardNameTmp, ib)
 	}
 
-	var sb *ShardBuilder
-	lastRepoID := -1
-	for docID := uint32(0); int(docID) < len(d.fileBranchMasks); docID++ {
-		repoID := int(d.repos[docID])
-
+	err = forEachRepositoryDocumentRange(d, func(repoID int, start, end uint32) error {
 		if d.repoMetaData[repoID].Tombstone {
-			continue
+			return nil
 		}
 
-		if repoID != lastRepoID {
-			if lastRepoID > repoID {
-				return shardNames, fmt.Errorf("non-contiguous repo ids in %s for document %d: old=%d current=%d", d.String(), docID, lastRepoID, repoID)
-			}
-			lastRepoID = repoID
+		sb := newShardBuilder(0)
+		sb.indexFormatVersion = IndexFormatVersion
+		if err := sb.setRepository(&d.repoMetaData[repoID]); err != nil {
+			return err
+		}
 
-			if sb != nil {
-				if err := writeShard(sb); err != nil {
-					return shardNames, err
-				}
-			}
-
-			sb = newShardBuilder(0)
-			sb.indexFormatVersion = IndexFormatVersion
-			if err := sb.setRepository(&d.repoMetaData[repoID]); err != nil {
-				return shardNames, err
+		for docID := start; docID < end; docID++ {
+			if err := addDocument(d, sb, repoID, docID); err != nil {
+				return err
 			}
 		}
-
-		err := addDocument(d, sb, repoID, docID)
-		if err != nil {
-			return shardNames, err
-		}
-	}
-
-	if sb != nil {
-		if err := writeShard(sb); err != nil {
-			return shardNames, err
-		}
+		return writeShard(sb)
+	})
+	if err != nil {
+		return shardNames, err
 	}
 
 	return shardNames, nil

--- a/index/merge_test.go
+++ b/index/merge_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -45,15 +46,18 @@ func TestMergePreservesStoredCategoryForSkippedGeneratedFile(t *testing.T) {
 	}
 	defer indexFile.Close()
 
-	tmpName, dstName, err := Merge(tmpDir, indexFile)
+	result, err := Merge(tmpDir, indexFile)
 	if err != nil {
 		t.Fatalf("Merge: %v", err)
 	}
-	if err := os.Rename(tmpName, dstName); err != nil {
+	if !result.HasOutput() {
+		t.Fatal("Merge produced no output")
+	}
+	if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
 		t.Fatalf("Rename: %v", err)
 	}
 
-	mergedFile, err := os.Open(dstName)
+	mergedFile, err := os.Open(result.FinalPath)
 	if err != nil {
 		t.Fatalf("Open merged shard: %v", err)
 	}
@@ -119,17 +123,20 @@ func TestExplode(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	tmpName, dstName, err := Merge(tmpDir, files...)
+	result, err := Merge(tmpDir, files...)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Rename(tmpName, dstName)
+	if !result.HasOutput() {
+		t.Fatal("Merge produced no output")
+	}
+	err = os.Rename(result.TempPath, result.FinalPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// explode
-	f, err := os.Open(dstName)
+	f, err := os.Open(result.FinalPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,6 +168,170 @@ func TestExplode(t *testing.T) {
 	}
 }
 
+func TestMergeAllTombstonedProducesNoShard(t *testing.T) {
+	dir := t.TempDir()
+	sb := newShardBuilder(0)
+	sb.indexFormatVersion = NextIndexFormatVersion
+	if err := sb.setRepository(&zoekt.Repository{ID: 1, Name: "deleted", Tombstone: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sb.Add(Document{Name: "f", Content: []byte("content")}); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "all-tombstoned.zoekt")
+	if err := builderWriteAll(path, sb); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexFile, err := NewIndexFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer indexFile.Close()
+
+	result, err := Merge(dir, indexFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.HasOutput() {
+		t.Fatalf("Merge produced an output for an all-tombstoned shard: %+v", result)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, "compound-*")); err != nil {
+		t.Fatal(err)
+	} else if len(matches) != 0 {
+		t.Fatalf("Merge wrote compound shards: %v", matches)
+	}
+}
+
+func TestShardBuilderRejectsRepositorylessShard(t *testing.T) {
+	sb := newShardBuilder(0)
+	sb.indexFormatVersion = NextIndexFormatVersion
+	if err := sb.Write(&bytes.Buffer{}); err == nil {
+		t.Fatal("Write succeeded without repository metadata")
+	}
+}
+
+func TestVerifyRepositoryReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      indexData
+		wantError bool
+	}{
+		{
+			name: "valid",
+			data: indexData{
+				repoMetaData:    make([]zoekt.Repository, 2),
+				fileBranchMasks: make([]uint64, 3),
+				repos:           []uint16{0, 0, 1},
+			},
+		},
+		{
+			name: "wrong reference count",
+			data: indexData{
+				repoMetaData:    make([]zoekt.Repository, 1),
+				fileBranchMasks: make([]uint64, 2),
+				repos:           []uint16{0},
+			},
+			wantError: true,
+		},
+		{
+			name: "repository out of range",
+			data: indexData{
+				repoMetaData:    make([]zoekt.Repository, 1),
+				fileBranchMasks: make([]uint64, 1),
+				repos:           []uint16{1},
+			},
+			wantError: true,
+		},
+		{
+			name: "repositories out of order",
+			data: indexData{
+				repoMetaData:    make([]zoekt.Repository, 2),
+				fileBranchMasks: make([]uint64, 2),
+				repos:           []uint16{1, 0},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.data.verifyRepositoryReferences()
+			if (err != nil) != tt.wantError {
+				t.Fatalf("verifyRepositoryReferences() error = %v, wantError %t", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestMergeAndExplodePreserveRepositoryWithoutDocuments(t *testing.T) {
+	dir := t.TempDir()
+	sb := newShardBuilder(0)
+	sb.indexFormatVersion = NextIndexFormatVersion
+	if err := sb.setRepository(&zoekt.Repository{ID: 1, Name: "deleted", Tombstone: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sb.Add(Document{Name: "f", Content: []byte("content")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sb.setRepository(&zoekt.Repository{ID: 2, Name: "empty"}); err != nil {
+		t.Fatal(err)
+	}
+
+	inputPath := filepath.Join(dir, "input.zoekt")
+	if err := builderWriteAll(inputPath, sb); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(inputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexFile, err := NewIndexFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Merge(dir, indexFile)
+	indexFile.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.HasOutput() {
+		t.Fatal("Merge produced no output for a live repository without documents")
+	}
+	if err := os.Rename(result.TempPath, result.FinalPath); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, _, err := ReadMetadataPath(result.FinalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 || repos[0].Name != "empty" {
+		t.Fatalf("merged repositories = %v, want empty", repos)
+	}
+
+	if err := Explode(dir, result.FinalPath); err != nil {
+		t.Fatal(err)
+	}
+	opts := Options{
+		IndexDir:              dir,
+		RepositoryDescription: *repos[0],
+	}
+	simplePath := opts.shardNameVersion(IndexFormatVersion, 0)
+	repos, _, err = ReadMetadataPath(simplePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 || repos[0].Name != "empty" {
+		t.Fatalf("exploded repositories = %v, want empty", repos)
+	}
+}
+
 // TestExplodeEmptyShard verifies that exploding a compound shard with zero
 // repositories removes the shard and returns success, instead of failing and
 // leaving an unusable shard on disk. A compound shard reaches this state once
@@ -170,13 +341,8 @@ func TestExplode(t *testing.T) {
 func TestExplodeEmptyShard(t *testing.T) {
 	dir := t.TempDir()
 
-	// Build a compound shard that contains no repositories.
-	sb := newShardBuilder(0)
-	sb.indexFormatVersion = NextIndexFormatVersion
 	path := filepath.Join(dir, fmt.Sprintf("compound-empty_v%d.00000.zoekt", NextIndexFormatVersion))
-	if err := builderWriteAll(path, sb); err != nil {
-		t.Fatalf("builderWriteAll: %v", err)
-	}
+	writeLegacyRepositorylessShard(t, path)
 
 	// Confirm the shard really is the empty-shard case.
 	if _, _, err := ReadMetadataPath(path); !errors.Is(err, ErrEmptyShard) {
@@ -189,6 +355,46 @@ func TestExplodeEmptyShard(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("empty shard was not removed, stat err = %v", err)
+	}
+}
+
+func writeLegacyRepositorylessShard(t *testing.T, path string) {
+	t.Helper()
+
+	sb := newShardBuilder(0)
+	sb.indexFormatVersion = NextIndexFormatVersion
+	sb.ID = "legacy-shard-id"
+	if err := sb.setRepository(&zoekt.Repository{ID: 1, Name: "legacy"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := builderWriteAll(path, sb); err != nil {
+		t.Fatalf("builderWriteAll: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexFile, err := NewIndexFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var toc indexTOC
+	if err := (&reader{r: indexFile}).readTOCSections(&toc, []string{"repoMetaData"}); err != nil {
+		indexFile.Close()
+		t.Fatal(err)
+	}
+	indexFile.Close()
+
+	emptyMetadata := bytes.Repeat([]byte(" "), int(toc.repoMetaData.sz))
+	copy(emptyMetadata, "[]")
+	f, err = os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteAt(emptyMetadata, int64(toc.repoMetaData.off)); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/index/read.go
+++ b/index/read.go
@@ -420,6 +420,10 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 		d.repos = make([]uint16, len(d.fileBranchMasks))
 	}
 
+	if err := d.verifyRepositoryReferences(); err != nil {
+		return nil, err
+	}
+
 	if err := d.calculateStats(); err != nil {
 		return nil, err
 	}
@@ -427,10 +431,11 @@ func (r *reader) readIndexData(toc *indexTOC) (*indexData, error) {
 	return &d, nil
 }
 
-// ErrEmptyShard is returned when reading the metadata of a shard that contains
-// no repositories and has no ID to backfill one from. Such a shard holds no
-// data and cannot be loaded, so callers may treat it as safe to delete.
-var ErrEmptyShard = errors.New("len(repos)=0. Cannot backfill ID")
+// ErrEmptyShard is returned when reading a shard that contains no repository
+// metadata. Persisted shards must describe at least one repository, even when
+// that repository contains no documents. Callers responsible for cleaning up
+// legacy shards may treat this error as a signal to remove the shard.
+var ErrEmptyShard = errors.New("shard contains no repository metadata")
 
 func (r *reader) parseMetadata(metaData simpleSection, repoMetaData simpleSection) ([]*zoekt.Repository, *zoekt.IndexMetadata, error) {
 	var md zoekt.IndexMetadata
@@ -465,10 +470,11 @@ func (r *reader) parseMetadata(metaData simpleSection, repoMetaData simpleSectio
 		}
 	}
 
+	if len(repos) == 0 {
+		return nil, &md, ErrEmptyShard
+	}
+
 	if md.ID == "" {
-		if len(repos) == 0 {
-			return nil, nil, ErrEmptyShard
-		}
 		md.ID = backfillID(repos[0].Name)
 	}
 
@@ -523,6 +529,24 @@ func (d *indexData) verify() error {
 		if got != n {
 			return fmt.Errorf("got %s %d, want %d", what, got, n)
 		}
+	}
+	return nil
+}
+
+func (d *indexData) verifyRepositoryReferences() error {
+	if len(d.repos) != len(d.fileBranchMasks) {
+		return fmt.Errorf("got repository references for %d documents, want %d", len(d.repos), len(d.fileBranchMasks))
+	}
+
+	var previous uint16
+	for docID, repoID := range d.repos {
+		if int(repoID) >= len(d.repoMetaData) {
+			return fmt.Errorf("document %d references repository %d, but the shard has %d repositories", docID, repoID, len(d.repoMetaData))
+		}
+		if docID > 0 && repoID < previous {
+			return fmt.Errorf("repository references are not contiguous at document %d: previous=%d current=%d", docID, previous, repoID)
+		}
+		previous = repoID
 	}
 	return nil
 }

--- a/index/write.go
+++ b/index/write.go
@@ -125,6 +125,10 @@ func writePostings(w *writer, s *postingsBuilder, ngramText *simpleSection,
 }
 
 func (b *ShardBuilder) Write(out io.Writer) error {
+	if len(b.repoList) == 0 {
+		return fmt.Errorf("cannot write shard without repository metadata")
+	}
+
 	next := b.indexFormatVersion == NextIndexFormatVersion
 
 	buffered := bufio.NewWriterSize(out, 1<<20)


### PR DESCRIPTION
The recovery added in #1088 removes repositoryless compound shards once vacuum tries to explode them, but compaction can still create a fresh invalid shard whenever every repository has been tombstoned. That leaves another window where zoekt-webserver cannot load the artifact, and it also exposes a broader mismatch: a live repository with zero documents is valid, while a persisted shard with zero repositories is not.

This changes merge into an explicit zero-or-one-output operation. Merge and explode now iterate repository metadata first, preserving live repositories even when they contain no documents. When no live repositories remain, the merge command deletes its inputs without writing a replacement. Writers reject repositoryless shards, readers validate document-to-repository references, and cleanup removes legacy repositoryless artifacts even when shard merging and vacuum are disabled. The existing Explode recovery remains as a defensive path for artifacts already on disk.

The filesystem lifecycle is now owned by the merge command rather than split with vacuum cleanup, which also avoids deleting an input shard after a failed merge subprocess. The full short test suite and all command builds pass.