### PR TITLE
gitindex: fallback when cat-file filters are unsupported

### DIFF
--- a/gitindex/catfile.go
+++ b/gitindex/catfile.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -30,6 +31,25 @@ import (
 
 type catfileReaderOptions struct {
 	filterSpec string
+}
+
+// checkCatfileFilterSupport checks whether git supports filtering cat-file
+// batch output. The feature was added in Git 2.50, but probing the command also
+// supports vendor backports without relying on version-string parsing.
+func checkCatfileFilterSupport(repoDir, filterSpec string) error {
+	cmd := exec.Command("git", "cat-file", "--batch-check", "--filter="+filterSpec)
+	cmd.Dir = repoDir
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		detail, _, _ := strings.Cut(strings.TrimSpace(stderr.String()), "\n")
+		if detail != "" {
+			return fmt.Errorf("%w: %s", err, detail)
+		}
+		return err
+	}
+	return nil
 }
 
 // catfileReader provides streaming access to git blob objects via a pipelined

--- a/gitindex/catfile_test.go
+++ b/gitindex/catfile_test.go
@@ -246,6 +246,9 @@ func TestCatfileReader_Excluded(t *testing.T) {
 	t.Parallel()
 
 	repoDir, blobs := createTestRepo(t)
+	if err := checkCatfileFilterSupport(repoDir, "blob:limit=1k"); err != nil {
+		t.Skipf("installed git does not support cat-file --filter (available in Git 2.50+): %v", err)
+	}
 
 	ids := []plumbing.Hash{
 		blobs["large.bin"],

--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -641,6 +641,13 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 		useCatfileBatch = false
 		log.Printf("cat-file batch disabled via ZOEKT_DISABLE_CATFILE_BATCH, using go-git")
 	}
+	filterSpec := catfileFilterSpec(opts)
+	if useCatfileBatch && filterSpec != "" {
+		if err := checkCatfileFilterSupport(opts.RepoDir, filterSpec); err != nil {
+			useCatfileBatch = false
+			log.Printf("git cat-file does not support --filter (%v), using go-git", err)
+		}
+	}
 
 	mainRepoKeys := make([]fileKey, 0, totalFiles)
 	mainRepoIDs := make([]plumbing.Hash, 0, totalFiles)
@@ -663,7 +670,7 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 	// Large blobs are skipped without reading content into memory.
 	if len(mainRepoIDs) > 0 {
 		crOpts := catfileReaderOptions{
-			filterSpec: catfileFilterSpec(opts),
+			filterSpec: filterSpec,
 		}
 		cr, err := newCatfileReader(opts.RepoDir, mainRepoIDs, crOpts)
 		if err != nil {

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -313,6 +313,47 @@ func TestCatfileFilterSpec(t *testing.T) {
 	}
 }
 
+func TestIndexGitRepo_CatfileFilterUnsupportedFallsBack(t *testing.T) {
+	repoDir, _ := initGitWorktree(t, "hello.txt", "hello world\n")
+	indexDir := t.TempDir()
+
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\necho 'cat-file --filter unsupported' >&2\nexit 129\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%q): %v", fakeGit, err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("ZOEKT_DISABLE_CATFILE_BATCH", "false")
+
+	opts := Options{
+		RepoDir:  repoDir,
+		Branches: []string{"main"},
+		BuildOptions: index.Options{
+			DisableCTags:          true,
+			RepositoryDescription: zoekt.Repository{Name: "repo"},
+			IndexDir:              indexDir,
+			SizeMax:               1 << 20,
+		},
+	}
+	if _, err := IndexGitRepo(opts); err != nil {
+		t.Fatalf("IndexGitRepo: %v", err)
+	}
+
+	searcher, err := search.NewDirectorySearcher(indexDir)
+	if err != nil {
+		t.Fatal("NewDirectorySearcher", err)
+	}
+	defer searcher.Close()
+
+	results, err := searcher.Search(context.Background(), &query.Const{Value: true}, &zoekt.SearchOptions{})
+	if err != nil {
+		t.Fatal("search failed", err)
+	}
+	if len(results.Files) != 1 || results.Files[0].FileName != "hello.txt" {
+		t.Fatalf("got search result %v, want hello.txt", results.Files)
+	}
+}
+
 func initGitWorktree(t *testing.T, fileName, content string) (string, string) {
 	t.Helper()
 


### PR DESCRIPTION
`git cat-file --filter` was introduced in Git 2.50. On older Git versions the command exits immediately, while the reader only observes EOF and indexing fails instead of using the existing fallback.

Probe the actual `cat-file --filter` capability before selecting the batch reader, which also accommodates vendor backports, and fall back to go-git when unsupported. The feature-specific reader test now skips when the installed Git lacks this capability.

The source change was verified with a full `go test -short ./...` run under Git config isolation. The fallback and skip paths passed on Git 2.39.5, and the supported path passed against real Git 2.53.0.