### PR TITLE
index: skip files when ctags times out

### DIFF
--- a/index/builder.go
+++ b/index/builder.go
@@ -91,7 +91,8 @@ type Options struct {
 	// Same as CTagsPath but for scip-ctags
 	ScipCTagsPath string
 
-	// If set, ctags must succeed.
+	// If set, ctags binaries must be available and non-timeout parser errors
+	// fail indexing. Per-file parsing timeouts are skipped.
 	CTagsMustSucceed bool
 
 	// LargeFiles is a slice of glob patterns, including ** for any number

--- a/index/ctags.go
+++ b/index/ctags.go
@@ -16,6 +16,7 @@ package index
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"slices"
@@ -67,9 +68,15 @@ func parseSymbols(todo []*Document, languageMap ctags.LanguageMap, parserBins ct
 
 		monitor.BeginParsing(doc)
 		es, err := parser.Parse(doc.Name, doc.Content, parserType)
-		monitor.EndParsing(es)
+		monitor.EndParsing(es, parserType, err)
 
 		if err != nil {
+			var timeoutErr *ctags.ParseTimeoutError
+			if errors.As(err, &timeoutErr) {
+				// Symbol extraction is best effort. A timeout only means this file
+				// has no symbol metadata, so continue indexing the remaining files.
+				continue
+			}
 			return err
 		}
 		if len(es) == 0 {
@@ -224,6 +231,7 @@ type monitor struct {
 
 	currentDocName       string
 	currentDocSize       int
+	currentDocStart      time.Time
 	currentDocStuckCount int
 
 	done chan struct{}
@@ -248,11 +256,12 @@ func (m *monitor) BeginParsing(doc *Document) {
 	// set current doc
 	m.currentDocName = doc.Name
 	m.currentDocSize = len(doc.Content)
+	m.currentDocStart = now
 
 	m.mu.Unlock()
 }
 
-func (m *monitor) EndParsing(entries []*ctags.Entry) {
+func (m *monitor) EndParsing(entries []*ctags.Entry, parserType ctags.CTagsParserType, err error) {
 	now := time.Now()
 	m.mu.Lock()
 	m.lastUpdate = now
@@ -261,15 +270,19 @@ func (m *monitor) EndParsing(entries []*ctags.Entry) {
 	m.totalSize += m.currentDocSize
 	m.totalSymbols += len(entries)
 
-	// inform done if we warned about current document
-	if m.currentDocStuckCount > 0 {
+	var timeoutErr *ctags.ParseTimeoutError
+	if errors.As(err, &timeoutErr) {
+		log.Printf("WARN: skipping symbol analysis after timeout: file=%q parser=%s duration=%v timeout=%v size_bytes=%d", m.currentDocName, ctags.ParserToString(parserType), now.Sub(m.currentDocStart).Truncate(time.Second), timeoutErr.Timeout, m.currentDocSize)
+	} else if m.currentDocStuckCount > 0 {
+		// Inform done if we warned about the current document.
 		log.Printf("symbol analysis for %s (size %d bytes) is done and found %d symbols", m.currentDocName, m.currentDocSize, len(entries))
-		m.currentDocStuckCount = 0
 	}
+	m.currentDocStuckCount = 0
 
 	// unset current document
 	m.currentDocName = ""
 	m.currentDocSize = 0
+	m.currentDocStart = time.Time{}
 
 	m.mu.Unlock()
 }

--- a/internal/ctags/parser.go
+++ b/internal/ctags/parser.go
@@ -48,6 +48,16 @@ type parseResult struct {
 	err     error
 }
 
+// ParseTimeoutError reports that ctags exceeded the per-file parsing timeout.
+type ParseTimeoutError struct {
+	Name    string
+	Timeout time.Duration
+}
+
+func (e *ParseTimeoutError) Error() string {
+	return fmt.Sprintf("ctags timed out after %s parsing %s", e.Timeout, e.Name)
+}
+
 func (lp *CTagsParser) Parse(name string, content []byte, typ CTagsParserType) ([]*Entry, error) {
 	if lp.parsers[typ] == nil {
 		parser, err := lp.newParserProcess(typ)
@@ -71,8 +81,11 @@ func (lp *CTagsParser) Parse(name string, content []byte, typ CTagsParserType) (
 	case resp := <-recv:
 		return resp.entries, resp.err
 	case <-deadline.C:
-		// Error out since ctags hanging is a sign something bad is happening.
-		return nil, fmt.Errorf("ctags timedout after %s parsing %s", parseTimeout, name)
+		// The parser is still processing this request and cannot safely be reused.
+		// Discard it so a later file gets a fresh process.
+		delete(lp.parsers, typ)
+		go parser.Close()
+		return nil, &ParseTimeoutError{Name: name, Timeout: parseTimeout}
 	}
 }
 


### PR DESCRIPTION
In our OSS corpus we seem to only run into time outs now not due to hangs, but due to a mix of large files and constrained indexing systems. Rather than increasing the timeout, the symbols in these files are usually not that interesting so lets rather just skip them.