### PR TITLE
indexserver: do not copy struct with mutex

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -213,7 +213,7 @@ type Server struct {
 	// CPUCount is the number of CPUs to use for indexing shards.
 	CPUCount int
 
-	queue Queue
+	queue *Queue
 
 	// muIndexDir protects the index directory from concurrent access.
 	muIndexDir indexMutex
@@ -1652,7 +1652,7 @@ func newServer(conf rootConfig) (*Server, error) {
 		IndexConcurrency:                  int(conf.indexConcurrency),
 		Interval:                          conf.interval,
 		CPUCount:                          cpuCount,
-		queue:                             *q,
+		queue:                             q,
 		shardMerging:                      !conf.disableShardMerging,
 		deltaBuildRepositoriesAllowList:   deltaBuildRepositoriesAllowList,
 		deltaShardNumberFallbackThreshold: deltaShardNumberFallbackThreshold,


### PR DESCRIPTION
Resolves this warning from go vet:

```
  cmd/zoekt-sourcegraph-indexserver/main.go:1655:38: literal copies lock value from *q:
  github.com/sourcegraph/zoekt/cmd/zoekt-sourcegraph-indexserver.Queue contains sync.Mutex
```

In practice this wasn't an issue since we only copied the queue once at startup.