### PR TITLE
doc: update all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ For more details on Zoekt's design, see the [docs directory](doc/).
 
 ### Installation
 
-    go get github.com/sourcegraph/zoekt/
+Install the commands you need with `go install`, as shown below. The examples
+use the latest released version and assume that Go's binary installation
+directory is on your `PATH`.
 
 **Note**: It is also recommended to install [Universal ctags](https://github.com/universal-ctags/ctags), as symbol
 information is a key signal in ranking search results. See [ctags.md](doc/ctags.md) for more information.
@@ -40,19 +42,19 @@ for simple local usage, or for testing and development.
 
 #### Indexing a local git repo
 
-    go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index
-    $GOPATH/bin/zoekt-git-index -index ~/.zoekt /path/to/repo
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@latest
+    zoekt-git-index -index ~/.zoekt /path/to/repo
 
 #### Indexing a local directory (not git-specific)
 
-    go install github.com/sourcegraph/zoekt/cmd/zoekt-index
-    $GOPATH/bin/zoekt-index -index ~/.zoekt /path/to/repo
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-index@latest
+    zoekt-index -index ~/.zoekt /path/to/repo
 
 #### Searching an index
 
-    go install github.com/sourcegraph/zoekt/cmd/zoekt
-    $GOPATH/bin/zoekt 'hello'
-    $GOPATH/bin/zoekt 'hello file:README'
+    go install github.com/sourcegraph/zoekt/cmd/zoekt@latest
+    zoekt 'hello'
+    zoekt 'hello file:README'
 
 ### Zoekt services
 
@@ -61,13 +63,15 @@ of remote repositories. The index server can be configured to periodically fetch
 from a code host. The webserver can be configured to serve search results through a web UI or API.
 
 #### Indexing a GitHub organization
-    
-    go install github.com/sourcegraph/zoekt/cmd/zoekt-indexserver
+
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-indexserver@latest
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-mirror-github@latest
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-git-index@latest
 
     echo YOUR_GITHUB_TOKEN_HERE > token.txt
     echo '[{"GitHubOrg": "apache", "CredentialPath": "token.txt"}]' > config.json
 
-    $GOPATH/bin/zoekt-indexserver -mirror_config config.json -data_dir ~/.zoekt/ 
+    zoekt-indexserver -mirror_config config.json -data_dir ~/.zoekt/
 
 This will fetch all repos under 'github.com/apache', then index the repositories. The indexserver takes care of
 periodically fetching and indexing new data, and cleaning up logfiles. See [config.go](cmd/zoekt-indexserver/config.go)
@@ -75,8 +79,8 @@ for more details on this configuration.
 
 #### Starting the web server
 
-    go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver
-    $GOPATH/bin/zoekt-webserver -index ~/.zoekt/
+    go install github.com/sourcegraph/zoekt/cmd/zoekt-webserver@latest
+    zoekt-webserver -index ~/.zoekt/
 
 This will start a web server with a simple search UI at http://localhost:6070.
 See the [query syntax docs](doc/query_syntax.md) for more details on the query
@@ -91,13 +95,13 @@ includes the Zoekt binaries, `git`, and `universal-ctags`. By default it runs
     docker run --rm -p 6070:6070 -v "$PWD/index:/data/index" ghcr.io/sourcegraph/zoekt
 
 You can override the default command to run `zoekt-indexserver` instead. This
-example stores cloned repositories, logs, and indexes under `/data` and reads a
-mounted mirror config file:
+example stores cloned repositories, logs, and indexes in the named Docker
+volume `zoekt-data` and reads a mounted mirror config file:
 
     docker run --rm \
       -v "$PWD/config.json:/config.json:ro" \
       -v "$PWD/token.txt:/home/zoekt/token.txt:ro" \
-      -v "$PWD/zoekt-data:/data" \
+      -v zoekt-data:/data \
       ghcr.io/sourcegraph/zoekt \
       zoekt-indexserver -mirror_config /config.json -data_dir /data
 
@@ -105,11 +109,12 @@ If you start the web server with `-rpc`, it exposes a [simple JSON search
 API](doc/json-api.md) at `http://localhost:6070/api/search`.
 
 The JSON API supports advanced features including:
-- Streaming search results (using the `FlushWallTime` option)
 - Alternative BM25 scoring (using the `UseBM25Scoring` option)
 - Context lines around matches (using the `NumContextLines` option)
 
-Finally, the web server exposes a gRPC API that supports [structured query objects](query/query.go) and advanced search options.
+Finally, the web server exposes a [gRPC API](grpc/protos/zoekt/webserver/v1/webserver.proto)
+that supports structured query objects, streaming search results, and advanced
+search options.
 
 ## Acknowledgements
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -132,8 +132,9 @@ Index format
 The index is organized in shards, where each shard is a file, laid out
 such that it can be mmap'd efficiently.
 
-Each shard contains data for one code repository. The basic data in an
-index shard are the following
+A shard can contain one repository or, after shard merging, multiple
+repositories in a compound shard. The basic data in an index shard are the
+following
 
    * file contents
    * filenames
@@ -307,9 +308,9 @@ Since the UI is unauthenticated, there are no authentication secrets to steal.
 
 Since the code is public, there is no sensitive code to steal.
 
-This leaves us with the following senstive data:
+This leaves us with the following sensitive data:
 
-   * Credentials for accesssing git repostitories (eg. github access token)
+   * Credentials for accessing git repositories (eg. github access token)
    * TLS server certificates
    * Query logs
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -15,13 +15,16 @@ on the internet.
 
 I had to implement SSH hashed hostkey checking on a whim recently, and
 here is how I quickly zoomed into the relevant code using
-[our public zoekt instance](http://cs.bazel.build):
+[our public zoekt instance](https://cs.bazel.build):
 
-* [hash host ssh](http://cs.bazel.build/search?q=hash+host+ssh&num=50): more than 20k results in 750 files, in 3 seconds
+The result counts and timings below are a historical snapshot; they vary with
+the indexed corpus, server configuration, and cache state.
 
-* [hash host r:openssh](http://cs.bazel.build/search?q=hash+host+r%3Aopenssh&num=50): 6k results in 114 files, in 20ms
+* [hash host ssh](https://cs.bazel.build/search?q=hash+host+ssh&num=50): more than 20k results in 750 files, in 3 seconds
 
-* [hash host r:openssh known_host](http://cs.bazel.build/search?q=hash+host+r%3Aopenssh+known_host&num=50): 4k result in 42 files, in 13ms
+* [hash host r:openssh](https://cs.bazel.build/search?q=hash+host+r%3Aopenssh&num=50): 6k results in 114 files, in 20ms
+
+* [hash host r:openssh known_host](https://cs.bazel.build/search?q=hash+host+r%3Aopenssh+known_host&num=50): 4k result in 42 files, in 13ms
 
 the last query still yielded a substantial number of results, but the
 function `hash_host` that I was looking for was the 3rd result from
@@ -56,8 +59,8 @@ this to work, you need the following features:
   googlesource.com.
 
 * Speed: `zoekt` uses an index based on positional trigrams. For rare
-  strings, eg. `nienhuys`, this typically yields results in ~10ms if
-  the operating system caches are warm.
+  strings, eg. `nienhuys`, this can yield results in milliseconds when the
+  operating system caches are warm.
 
 * Approximate queries: `zoekt` supports substring patterns and regular
   expressions, and can do case-insensitive matching on UTF-8 text.
@@ -84,14 +87,10 @@ supported by all projects.
 
 ## What about the search on `github.com`?
 
-GitHub's search has great coverage, but unfortunately, its search
-functionality doesn't support arbitrary substrings. For example, a
-query [for part of my
-surname](https://github.com/search?utf8=%E2%9C%93&q=nienhuy&type=Code)
-does not turn up anything (except this document), while
-[my complete
-name](https://github.com/search?utf8=%E2%9C%93&q=nienhuys&type=Code)
-does.
+GitHub provides hosted code search across repositories on GitHub. Zoekt is
+intended for deployments that need to self-host search, index repositories
+from multiple code hosts, choose which branches to index, or integrate search
+through their own web service or API.
 
 ## What about Etsy/Hound?
 
@@ -117,34 +116,30 @@ parallelized across shards.
 
 ## Can I index multiple branches?
 
-Yes. You can index 64 branches (see also
-https://github.com/google/zoekt/issues/32). Files that are identical
-across branches take up space just once in the index.
+Yes. Pass a comma-separated list to `zoekt-git-index -branches`. Zoekt can
+index up to 64 branches per repository, and files that are identical across
+branches take up space just once in the index.
 
 ## How fast is the search?
 
-Rare strings, are extremely fast to retrieve, for example `r:torvalds
+Search latency depends on the corpus, query, result limit, hardware, and cache
+state. As a historical example, `r:torvalds
 crazy` (search "crazy" in the linux kernel) typically takes [about
 7-10ms on
-cs.bazel.build](http://cs.bazel.build/search?q=r%3Atorvalds+crazy&num=70).
+cs.bazel.build](https://cs.bazel.build/search?q=r%3Atorvalds+crazy&num=70).
 
 The speed for common strings is dominated by how many results you want
 to see. For example [r:torvalds license] can give some results
 quickly, but producing [all 86k
-results](http://cs.bazel.build/search?q=r%3Atorvalds+license&num=50000)
+results](https://cs.bazel.build/search?q=r%3Atorvalds+license&num=50000)
 takes between 100ms and 1 second. Then, streaming the results to your
 browser, and rendering the HTML takes several seconds.
 
 ## How fast is the indexer?
 
-The Linux kernel (55K files, 545M data) takes about 160s to index on
-my x250 laptop using a single thread.  The process can be parallelized
-for speedup.
-
-## What does [cs.bazel.build](https://cs.bazel.build/) run on?
-
-Currently, it runs on a single Google Cloud VM with 16 vCPUs, 60G RAM and an
-attached physical SSD.
+In one historical benchmark, the Linux kernel (55K files, 545M data) took
+about 160 seconds to index on an X250 laptop using a single thread. The process
+can be parallelized for speedup.
 
 ## How does `zoekt` work?
 
@@ -158,6 +153,6 @@ distance apart.
 Some further background documentation
 
  * [Designdoc](design.md) for technical details
- * [Godoc](https://godoc.org/github.com/google/zoekt)
+ * [Godoc](https://pkg.go.dev/github.com/sourcegraph/zoekt)
  * Gerrit 2016 user summit: [slides](https://storage.googleapis.com/gerrit-talks/summit/2016/zoekt.pdf)
  * Gerrit 2017 user summit: [transcript](https://gitenterprise.me/2017/11/01/gerrit-user-summit-zoekt-code-search-engine/),  [slides](https://storage.googleapis.com/gerrit-talks/summit/2017/Zoekt%20-%20improved%20codesearch.pdf), [video](https://www.youtube.com/watch?v=_-KTAvgJYdI)

--- a/doc/indexing.md
+++ b/doc/indexing.md
@@ -8,8 +8,9 @@ Parameters are in the `zoekt` section of the git-config.
 * `web-url`: base URL for linking to files, commits, and the repository, eg.
 `https://github.com/hanwen/usb`
 
-* `web-url-type`: type of URL, eg. github. Supported are cgit,
-  gitiles, gitweb, cgit and gitea.
+* `web-url-type`: code host used to generate links. Supported values are
+  `azuredevops`, `bitbucket-cloud`, `bitbucket-server`, `cgit`, `gitea`,
+  `github`, `gitiles`, `gitlab`, `gitweb`, and `source.bazel.build`.
 
 * `github-stars`, `github-forks`, `github-watchers`,
   `github-subscribers`: counters for github interactions
@@ -21,11 +22,11 @@ Parameters are in the `zoekt` section of the git-config.
 Clone a remote repository and add the indexer configuration.
 
 ```sh
-git clone --bare https://codeberg.org/Codeberg/gitea
-cd gitea.git
+git clone --bare https://codeberg.org/Codeberg/Community
+cd Community.git
 git config zoekt.web-url-type gitea
-git config zoekt.web-url https://codeberg.org/Codeberg/gitea
-git config zoekt.name codeberg.org/Codeberg/gitea
+git config zoekt.web-url https://codeberg.org/Codeberg/Community
+git config zoekt.name codeberg.org/Codeberg/Community
 ```
 
 The tail of the git *config* should then contain:
@@ -33,12 +34,12 @@ The tail of the git *config* should then contain:
 ```ini
 [zoekt]
 	web-url-type = gitea
-	web-url = https://codeberg.org/Codeberg/gitea
-	name = codeberg.org/Codeberg/gitea
+	web-url = https://codeberg.org/Codeberg/Community
+	name = codeberg.org/Codeberg/Community
 ```
 
-The *gitea.git* repository can then be indexed with `zoekt-git-index`
+The *Community.git* repository can then be indexed with `zoekt-git-index`
 
 ```sh
-zoekt-git-index  --branches main  -index /data/index -repo_cache /data/repos gitea.git
+zoekt-git-index -branches main -index /data/index -repo_cache /data/repos Community.git
 ```

--- a/doc/json-api.md
+++ b/doc/json-api.md
@@ -2,8 +2,10 @@
 
 When running `zoekt-webserver` with the `-rpc` option there will be a JSON HTTP API available for searches at `/api/search`:
 
-```
-curl -XPOST -d '{"Q":"needle"}' 'http://127.0.0.1:6070/api/search'
+```sh
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"Q":"needle"}' \
+  http://127.0.0.1:6070/api/search
 ```
 
 ## Filtering by repository IDs
@@ -12,16 +14,29 @@ If your projects are indexed with a `repoid` (added automatically by some
 indexers) then you can filter your searches to a subset of repositories
 efficiently using the `RepoIDs` filter:
 
+```sh
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"Q":"needle","RepoIDs":[1234,4567]}' \
+  http://127.0.0.1:6070/api/search
 ```
-curl -XPOST -d '{"Q":"needle","RepoIDs":[1234,4567]}' 'http://34.120.239.98/api/search'
+
+## Listing repositories
+
+Use `/api/list` to return metadata for repositories that match a query:
+
+```sh
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"Q":"repo:sourcegraph"}' \
+  http://127.0.0.1:6070/api/list
 ```
 
 ## Options
 
-There are multiple options that can be passed under `Opts` which can also be
-found at
-[SearchOptions](https://github.com/sourcegraph/zoekt/blob/58cf4748830ac0eded1517cc8c2454694c531fbd/api.go#L470).
+There are multiple options that can be passed under `Opts`; see the
+[SearchOptions](../api.go) type for the current fields.
 
-```
-curl -XPOST -d '{"Q":"needle","Opts":{"EstimateDocCount":true,"NumContextLines":10}}' 'http://34.120.239.98/api/search'
+```sh
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"Q":"needle","Opts":{"EstimateDocCount":true,"NumContextLines":10}}' \
+  http://127.0.0.1:6070/api/search
 ```

--- a/doc/query_syntax.md
+++ b/doc/query_syntax.md
@@ -9,11 +9,13 @@ For a brief overview of Zoekt's query syntax, see [these great docs from neogrok
 ## Syntax Overview
 
 A query is made up of expressions. An **expression** can be:
-- A negation (e.g., `-`),
+- A search pattern (e.g., `error.*handler`),
 - A field (e.g., `repo:`),
 - A grouping (e.g., parentheses `()`),
+- A negated expression (e.g., `-repo:archived-project`).
 
-Logical `OR` operations combine multiple expressions. The **`AND` operator is implicit**, meaning multiple expressions written together will be automatically treated as `AND`.
+The lowercase `or` operator combines alternatives. Conjunction is implicit,
+so multiple expressions written together are treated as AND conditions.
 
 ---
 
@@ -25,17 +27,18 @@ Fields restrict your query to specific criteria. Here's a list of fields and the
 
 | Field        | Aliases | Values                 | Description                                                | Examples                               |
 |--------------|---------|------------------------|------------------------------------------------------------|----------------------------------------|
-| `archived:`  | `a:`    | `yes` or `no`          | Filters archived repositories.                             | `archived:yes`                         |
-| `case:`      | `c:`    | `yes`, `no`, or `auto` | Matches case-sensitive or insensitive text.                | `case:yes content:"Foo"`               |
-| `content:`   | `c:`    | Text (string or regex) | Searches content of files.                                 | `content:"search term"`                |
-| `file:`      | `f:`    | Text (string or regex) | Searches file names.                                       | `file:"main.go"`                       |
-| `fork:`      | `f:`    | `yes` or `no`          | Filters forked repositories.                               | `fork:no`                              |
-| `lang:`      | `l:`    | Text                   | Filters by programming language.                           | `lang:python`                          |
+| `archived:`  |         | `yes` or `no`          | Filters archived repositories.                             | `archived:yes`                         |
+| `case:`      |         | `yes`, `no`, or `auto` | Matches case-sensitive or insensitive text.                | `case:yes content:"Foo"`               |
+| `content:`   | `c:`    | Regex pattern          | Searches content of files.                                 | `content:"search term"`                |
+| `file:`      | `f:`    | Regex pattern          | Searches file names.                                       | `file:main\.go$`                       |
+| `fork:`      |         | `yes` or `no`          | Filters forked repositories.                               | `fork:no`                              |
+| `lang:`      |         | Text                   | Filters by programming language.                           | `lang:python`                          |
+| `meta.<field>:` |      | Regex pattern          | Filters repository metadata values.                        | `meta.license:Apache-.*`               |
 | `public:`    |         | `yes` or `no`          | Filters public repositories.                               | `public:yes`                           |
-| `regex:`     |         | Regex pattern          | Matches content using a regular expression.                | `regex:/foo.*bar/`                     |
-| `repo:`      | `r:`    | Text (string or regex) | Filters repositories by name.                              | `repo:"github.com/user/project"`       |
-| `sym:`       |         | Text                   | Searches for symbol names.                                 | `sym:"MyFunction"`                     |
-| `branch:`    | `b:`    | Text                   | Searches within a specific branch.                         | `branch:main`                          |
+| `regex:`     |         | Regex pattern          | Matches content using a regular expression.                | `regex:foo.*bar`                       |
+| `repo:`      | `r:`    | Regex pattern          | Filters repositories by name.                              | `repo:github\.com/user/project$`       |
+| `sym:`       |         | Regex pattern          | Searches for symbol names.                                 | `sym:"MyFunction"`                     |
+| `branch:`    | `b:`    | Text                   | Matches branch names containing the value; `HEAD` selects the default branch. | `branch:main` |
 | `type:`      | `t:`    | `filematch`, `filename`, `file`, or `repo` | Limits result types.                   | `type:filematch`                       |
 
 ---
@@ -47,7 +50,7 @@ Negate an expression using the `-` symbol.
 #### Examples:
 - Exclude a repository:
   ```plaintext
-  -repo:"github.com/example/repo"
+  -repo:github\.com/example/repo$
   ```
 - Exclude a language:
   ```plaintext
@@ -82,7 +85,8 @@ Use `or` to combine multiple expressions.
   lang:go or lang:java
   ```
 
-`and` boolean operator is applied automatically when expressions are separated by a space.
+Conjunction is applied automatically when expressions are separated by a
+space. The word `and` is not an operator; it is interpreted as a search term.
 
 ---
 
@@ -98,6 +102,17 @@ public:yes archived:no fork:no
 
 This finds repositories that are public, not archived, and not forks.
 
+### Filtering by Repository Metadata
+
+When an indexer stores custom key-value metadata for a repository, use
+`meta.<field>:` to match the value with a regular expression. For example:
+
+```plaintext
+meta.license:Apache-.*
+```
+
+Repositories without that metadata field do not match.
+
 ### Result Type Control
 
 The `type:` operator controls what kind of results are returned:
@@ -108,7 +123,7 @@ type:repo content:config
 
 This returns repository names instead of file matches. Valid values include:
 - `filematch` - Returns file content matches (default)
-- `filename` - Returns only matching filenames
+- `filename` (or `file`) - Returns only matching filenames
 - `repo` - Returns only repository names
 
 `type:` applies to the whole expression in its current scope, including `or`
@@ -124,9 +139,16 @@ for example `(type:repo foo) or bar`.
   Use `yes` or `no` for fields like `archived:` or `fork:`.
 
 - **Text Fields**:
-  Text fields (`content:`, `repo:`, etc.) accept:
-  - Strings: `"my text"`
-  - Regular expressions: `/my.*regex/`
+  Search terms and text fields (`content:`, `repo:`, etc.) are parsed as
+  [Go regular expressions](https://pkg.go.dev/regexp/syntax). Patterns that
+  contain no regular expression operations are optimized as substring
+  searches. Write patterns directly without surrounding `/` delimiters;
+  slashes in a pattern are matched literally.
+
+- **Quoted Values**:
+  Double quotes group values containing spaces, as in `"my text"`. Inside a
+  quoted value, a backslash escapes the next character. Use two backslashes
+  when the regular expression itself needs a backslash.
 
 - **Escape Characters**:
   To include special characters, use backslashes (`\`).
@@ -138,7 +160,7 @@ for example `(type:repo foo) or bar`.
   ```
 - Match the regex `foo.*bar`:
   ```plaintext
-  content:/foo.*bar/
+  content:foo.*bar
   ```
 
 ---
@@ -165,12 +187,12 @@ case-sensitive; otherwise, it will be case-insensitive.
 
 2. **Exclude archived repositories and match a regex**:
    ```plaintext
-   archived:no regex:/error.*handler/
+   archived:no regex:error.*handler
    ```
 
 3. **Find files named `README.md` in forks**:
    ```plaintext
-   file:"README.md" fork:yes
+   file:README\.md$ fork:yes
    ```
 
 4. **Search for a specific branch**:
@@ -180,7 +202,7 @@ case-sensitive; otherwise, it will be case-insensitive.
 
 5. **Combine multiple fields**:
    ```plaintext
-   (repo:"github.com/example" or repo:"github.com/test") and lang:go
+   (repo:github\.com/example$ or repo:github\.com/test$) lang:go
    ```
 
 ---
@@ -189,12 +211,12 @@ case-sensitive; otherwise, it will be case-insensitive.
 
 1. **Combine Filters**: You can combine as many fields as needed. For instance:
    ```plaintext
-   repo:"github.com/example" lang:go content:"init"
+   repo:github\.com/example$ lang:go content:"init"
    ```
 
 2. **Use Regular Expressions**: Make complex content searches more powerful:
    ```plaintext
-   content:/func\s+\w+\s*\(/
+   content:func\s+\w+\s*\(
    ```
 
 3. **Case Sensitivity**: Use `case:yes` for exact matches:
@@ -204,39 +226,38 @@ case-sensitive; otherwise, it will be case-insensitive.
 
 4. **Match Specific File Types**:
    ```plaintext
-   file:".*\.go" content:"package main"
+   file:.*\.go$ content:"package main"
    ```
 
 ### EBNF Summary
 
 ```ebnf
-query       = expression , { "or" , expression } ;
+query       = conjunction , { "or" , conjunction } ;
 
-expression  = negation
-            | grouping
-            | field ;
+conjunction = expression , { expression } ;
 
-negation    = "-" , expression ;
+expression  = [ "-" ] , ( grouping | text | field ) ;
 
 grouping    = "(" , query , ")" ;
 
-field       = ( ( "archived:" | "a:" ) , boolean )
-            | ( ( "case:" | "c:" ) , ("yes" | "no" | "auto") )
+field       = ( "archived:" , boolean )
+            | ( "case:" , ("yes" | "no" | "auto") )
             | ( ( "content:" | "c:" ) , text )
             | ( ( "file:" | "f:" ) , text )
-            | ( ( "fork:" | "f:" ) , boolean )
-            | ( ( "lang:" | "l:" ) , text )
-            | ( ( "public:" ) , boolean )
-            | ( ( "regex:" ) , text )
+            | ( "fork:" , boolean )
+            | ( "lang:" , text )
+            | ( "public:" , boolean )
+            | ( "regex:" , text )
             | ( ( "repo:" | "r:" ) , text )
-            | ( ( "sym:" ) , text )
+            | ( "sym:" , text )
             | ( ( "branch:" | "b:" ) , text )
-            | ( ( "type:" | "t:" ) , type );
+            | ( ( "type:" | "t:" ) , type )
+            | ( "meta." , metadata-name , ":" , text );
 
 boolean     = "yes" | "no" ;
-text        = string | regex ;
-string      = '"' , { character | escape } , '"' ;
-regex       = '/' , { character | escape } , '/' ;
+text        = quoted | unquoted ;
+quoted      = '"' , { character | escape } , '"' ;
+unquoted    = character , { character | escape } ;
 
 type        = "filematch" | "filename" | "file" | "repo" ;
 ```


### PR DESCRIPTION
Noticed the installation instructions were referencing old ways of fetching go code. So got an agent to audit the docs and cherry-picked some of its suggestions in.