### PR TITLE
gitindex: avoid logging the default cat-file mode

### DIFF
--- a/gitindex/index.go
+++ b/gitindex/index.go
@@ -639,7 +639,8 @@ func indexGitRepo(opts Options, config gitIndexConfig) (bool, error) {
 	useCatfileBatch := true
 	if disabled, _ := strconv.ParseBool(catfileBatchDisabled); disabled {
 		useCatfileBatch = false
-		log.Printf("cat-file batch disabled via ZOEKT_DISABLE_CATFILE_BATCH, using go-git")
+	} else {
+		log.Printf("cat-file batch enabled via ZOEKT_DISABLE_CATFILE_BATCH=false")
 	}
 	filterSpec := catfileFilterSpec(opts)
 	if useCatfileBatch && filterSpec != "" {


### PR DESCRIPTION
Cat-file batching is currently disabled by default while its memory behavior is investigated, so logging that state on every indexing run creates noise rather than surfacing useful configuration. This keeps the default path quiet and logs only when `ZOEKT_DISABLE_CATFILE_BATCH=false` opts into the non-default batch path