### PR TITLE
index: guard posting iterator against overflowing varints

### DIFF
--- a/index/hititer.go
+++ b/index/hititer.go
@@ -187,6 +187,15 @@ type compressedPostingIterator struct {
 
 func newCompressedPostingIterator(b []byte, w ngram) *compressedPostingIterator {
 	d, sz := binary.Uvarint(b)
+	if sz <= 0 {
+		// binary.Uvarint returns a non-positive length when b is empty or the
+		// varint overflows 64 bits; slicing b[sz:] would panic, so yield an
+		// exhausted iterator (issue #1106).
+		return &compressedPostingIterator{
+			_first: math.MaxUint32,
+			what:   w,
+		}
+	}
 	return &compressedPostingIterator{
 		_first:           uint32(d),
 		blob:             b[sz:],
@@ -212,6 +221,12 @@ func (i *compressedPostingIterator) next(limit uint32) {
 
 	for i._first <= limit && len(i.blob) > 0 {
 		delta, sz := binary.Uvarint(i.blob)
+		if sz <= 0 {
+			// Corrupt or overflowing varint; stop advancing rather than panic
+			// on i.blob[sz:] (issue #1106).
+			i.blob = nil
+			break
+		}
 		i._first += uint32(delta)
 		i.indexBytesLoaded += sz
 		i.blob = i.blob[sz:]

--- a/index/hititer_test.go
+++ b/index/hititer_test.go
@@ -16,6 +16,7 @@ package index
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -111,4 +112,25 @@ func genUints32(size int) []uint32 {
 		nums[i] = r.Uint32()
 	}
 	return nums
+}
+
+func TestCompressedPostingIterator_overflowVarint(t *testing.T) {
+	// A varint that overflows 64 bits makes binary.Uvarint return a negative
+	// length, so slicing blob[sz:] used to panic (issue #1106). The iterator
+	// must instead treat the posting list as exhausted.
+	overflow := []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}
+
+	// Construction from an overflowing first varint.
+	it := newCompressedPostingIterator(overflow, stringToNGram("abc"))
+	if got := it.first(); got != math.MaxUint32 {
+		t.Fatalf("first() after overflow varint = %d, want exhausted (%d)", got, uint32(math.MaxUint32))
+	}
+
+	// A valid first entry followed by an overflowing delta, hit while advancing.
+	blob := append([]byte{0x01}, overflow...)
+	it = newCompressedPostingIterator(blob, stringToNGram("abc"))
+	it.next(100)
+	if got := it.first(); got != math.MaxUint32 {
+		t.Fatalf("first() after overflow delta = %d, want exhausted (%d)", got, uint32(math.MaxUint32))
+	}
 }


### PR DESCRIPTION
Addresses finding #2 of #1106 (the compressed posting-iterator panic).

## Problem

`newCompressedPostingIterator` and `(*compressedPostingIterator).next` in `index/hititer.go` slice `blob[sz:]` using the length returned by `binary.Uvarint` without checking it. `binary.Uvarint` returns a non-positive length when the varint is empty or overflows 64 bits (per its contract), so a malformed posting list makes the slice bound go negative and panics:

```
panic: runtime error: slice bounds out of range [-11:]
  index/hititer.go:192
```

Repro from the issue:

```go
blob := []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}
newCompressedPostingIterator(blob, ...) // panics
```

## Fix

Guard both `binary.Uvarint` call sites: on a non-positive length, treat the posting list as exhausted (construction) / stop advancing (`next`) instead of slicing with a bad length.

## Test

Added `TestCompressedPostingIterator_overflowVarint`, covering both the constructor and the `next` paths with the overflowing-varint input. Verified red before the fix (it panics with `slice bounds out of range [-11:]`) and green after. `go test ./index/`, `gofmt`, and `go vet` all pass locally.

## Scope

Scoped to finding #2 only (the posting-iterator negative-length guard). The other two findings in #1106 (re-opening a panicked shard, and the corrupt-shard hang) are larger and left for separate changes.

---

Disclosure: developed with the assistance of Claude Code (AI); reviewed and verified by me.
