### PR TITLE
Defer file sorting for unlimited sharded searches

### DIFF
--- a/search/aggregate.go
+++ b/search/aggregate.go
@@ -33,8 +33,9 @@ func newCollectSender(opts *zoekt.SearchOptions) *collectSender {
 	return &collectSender{opts: opts}
 }
 
-// Send aggregates the new search result by adding it stats and ranking
-// and truncating its files according to the input SearchOptions.
+// Send aggregates the new search result by adding its stats. Display-limited
+// results are ranked and truncated as chunks arrive to keep the aggregate
+// bounded.
 func (c *collectSender) Send(r *zoekt.SearchResult) {
 	if c.aggregate == nil {
 		c.aggregate = &zoekt.SearchResult{
@@ -48,7 +49,9 @@ func (c *collectSender) Send(r *zoekt.SearchResult) {
 	if len(r.Files) > 0 {
 		c.aggregate.Files = append(c.aggregate.Files, r.Files...)
 
-		c.aggregate.Files = index.SortAndTruncateFiles(c.aggregate.Files, c.opts)
+		if c.hasDisplayLimit() {
+			c.aggregate.Files = index.SortAndTruncateFiles(c.aggregate.Files, c.opts)
+		}
 
 		maps.Copy(c.aggregate.RepoURLs, r.RepoURLs)
 		maps.Copy(c.aggregate.LineFragments, r.LineFragments)
@@ -73,7 +76,14 @@ func (c *collectSender) Done() (_ *zoekt.SearchResult, ok bool) {
 
 	agg := c.aggregate
 	c.aggregate = nil
+	if !c.hasDisplayLimit() {
+		agg.Files = index.SortAndTruncateFiles(agg.Files, c.opts)
+	}
 	return agg, true
+}
+
+func (c *collectSender) hasDisplayLimit() bool {
+	return c.opts.MaxDocDisplayCount > 0 || c.opts.MaxMatchDisplayCount > 0
 }
 
 // newFlushCollectSender creates a sender which will collect and rank results

--- a/search/aggregate_bench_test.go
+++ b/search/aggregate_bench_test.go
@@ -1,0 +1,108 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/query"
+)
+
+const (
+	benchmarkChunkRepositories = 128
+	benchmarkChunkFiles        = 64
+	benchmarkMatchesPerFile    = 4
+)
+
+// benchmarkResultSearcher returns one prebuilt result per repository. Each
+// benchmark repository has its own result, so the search path can sort it
+// without sharing mutable state between shards.
+type benchmarkResultSearcher struct {
+	repo   zoekt.Repository
+	result *zoekt.SearchResult
+}
+
+func (s *benchmarkResultSearcher) Search(context.Context, query.Q, *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+	return s.result, nil
+}
+
+func (s *benchmarkResultSearcher) List(context.Context, query.Q, *zoekt.ListOptions) (*zoekt.RepoList, error) {
+	return &zoekt.RepoList{Repos: []*zoekt.RepoListEntry{{Repository: s.repo}}}, nil
+}
+
+func (s *benchmarkResultSearcher) Close() {}
+
+func (s *benchmarkResultSearcher) String() string { return s.repo.Name }
+
+func BenchmarkShardedSearchManyChunks(b *testing.B) {
+	ss := newShardedSearcher(1)
+	shards := make(map[string]zoekt.Searcher, benchmarkChunkRepositories)
+
+	for repository := range benchmarkChunkRepositories {
+		repo := zoekt.Repository{
+			ID:   uint32(repository + 1),
+			Name: fmt.Sprintf("benchmark-repository-%03d", repository),
+		}
+		files := make([]zoekt.FileMatch, benchmarkChunkFiles)
+		for file := range files {
+			// Each result chunk is sorted by score, but chunks interleave in the
+			// final ordering. This makes the collector merge work representative
+			// of results from many repositories.
+			files[file] = zoekt.FileMatch{
+				FileName:     fmt.Sprintf("%s/file-%03d.go", repo.Name, file),
+				Repository:   repo.Name,
+				RepositoryID: repo.ID,
+				Score: float64((benchmarkChunkFiles-file)*benchmarkChunkRepositories +
+					benchmarkChunkRepositories - repository),
+				LineMatches: []zoekt.LineMatch{{
+					LineFragments: make([]zoekt.LineFragmentMatch, benchmarkMatchesPerFile),
+				}},
+			}
+		}
+
+		shards[repo.Name] = &benchmarkResultSearcher{
+			repo: repo,
+			result: &zoekt.SearchResult{
+				Files:         files,
+				RepoURLs:      map[string]string{repo.Name: ""},
+				LineFragments: map[string]string{},
+				Stats: zoekt.Stats{
+					MatchCount: benchmarkChunkFiles * benchmarkMatchesPerFile,
+				},
+			},
+		}
+	}
+	ss.replace(shards)
+	ss.markReady()
+
+	benchmarks := []struct {
+		name      string
+		opts      zoekt.SearchOptions
+		wantFiles int
+	}{
+		{name: "unlimited", wantFiles: benchmarkChunkRepositories * benchmarkChunkFiles},
+		{name: "max-docs-8", opts: zoekt.SearchOptions{MaxDocDisplayCount: 8}, wantFiles: 8},
+		{name: "max-docs-512", opts: zoekt.SearchOptions{MaxDocDisplayCount: 512}, wantFiles: 512},
+		{name: "max-matches-1000", opts: zoekt.SearchOptions{MaxMatchDisplayCount: 1000}, wantFiles: 250},
+	}
+
+	ctx := context.Background()
+	q := &query.Const{Value: true}
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			var fileSlots int
+			for b.Loop() {
+				result, err := ss.Search(ctx, q, &benchmark.opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if got := len(result.Files); got != benchmark.wantFiles {
+					b.Fatalf("got %d files, want %d", got, benchmark.wantFiles)
+				}
+				fileSlots = cap(result.Files)
+			}
+			b.ReportMetric(float64(fileSlots), "file-slots/op")
+		})
+	}
+}

--- a/search/aggregate_test.go
+++ b/search/aggregate_test.go
@@ -1,0 +1,138 @@
+package search
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sourcegraph/zoekt"
+)
+
+func TestCollectSenderUnlimitedSortsOnDone(t *testing.T) {
+	collector := newCollectSender(&zoekt.SearchOptions{})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("lower.go", 1, 1),
+	}})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("higher.go", 2, 1),
+	}})
+
+	if got, want := collectTestFileNames(collector.aggregate.Files), []string{"lower.go", "higher.go"}; !slices.Equal(got, want) {
+		t.Fatalf("collector sorted before Done: got %v, want %v", got, want)
+	}
+
+	result, ok := collector.Done()
+	if !ok {
+		t.Fatal("Done returned no result")
+	}
+	if got, want := collectTestFileNames(result.Files), []string{"higher.go", "lower.go"}; !slices.Equal(got, want) {
+		t.Fatalf("wrong final order: got %v, want %v", got, want)
+	}
+	if _, ok := collector.Done(); ok {
+		t.Fatal("second Done returned a result")
+	}
+}
+
+func TestCollectSenderDocumentLimitKeepsNovelExtension(t *testing.T) {
+	collector := newCollectSender(&zoekt.SearchOptions{MaxDocDisplayCount: 3})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("first.go", 100, 1),
+		collectTestFile("second.go", 99, 1),
+		collectTestFile("third.go", 98, 1),
+	}})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("novel.rs", 97, 1),
+	}})
+
+	if got := len(collector.aggregate.Files); got != 3 {
+		t.Fatalf("got %d buffered files, want 3", got)
+	}
+	result, ok := collector.Done()
+	if !ok {
+		t.Fatal("Done returned no result")
+	}
+	if got, want := collectTestFileNames(result.Files), []string{"first.go", "second.go", "novel.rs"}; !slices.Equal(got, want) {
+		t.Fatalf("wrong document-limited files: got %v, want %v", got, want)
+	}
+}
+
+func TestCollectSenderMatchLimit(t *testing.T) {
+	collector := newCollectSender(&zoekt.SearchOptions{MaxMatchDisplayCount: 3})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("first.go", 100, 2),
+		collectTestFile("second.go", 99, 2),
+	}})
+	collector.Send(&zoekt.SearchResult{Files: []zoekt.FileMatch{
+		collectTestFile("later.go", 101, 1),
+	}})
+
+	if got := collectTestLineFragmentCount(collector.aggregate.Files); got != 3 {
+		t.Fatalf("got %d buffered line fragments, want 3", got)
+	}
+	result, ok := collector.Done()
+	if !ok {
+		t.Fatal("Done returned no result")
+	}
+	if got, want := collectTestFileNames(result.Files), []string{"later.go", "first.go"}; !slices.Equal(got, want) {
+		t.Fatalf("wrong match-limited files: got %v, want %v", got, want)
+	}
+	if got := collectTestLineFragmentCount(result.Files); got != 3 {
+		t.Fatalf("got %d final line fragments, want 3", got)
+	}
+}
+
+func TestCollectSenderMatchLimitBoundsAggregate(t *testing.T) {
+	collector := newCollectSender(&zoekt.SearchOptions{MaxMatchDisplayCount: 4})
+	for chunk := range 32 {
+		files := make([]zoekt.FileMatch, 8)
+		for file := range files {
+			files[file] = collectTestFile("match.go", float64(chunk*len(files)+file), 1)
+		}
+		collector.Send(&zoekt.SearchResult{Files: files})
+
+		if got := len(collector.aggregate.Files); got != 4 {
+			t.Fatalf("chunk %d: got %d buffered files, want 4", chunk, got)
+		}
+		if got := collectTestLineFragmentCount(collector.aggregate.Files); got != 4 {
+			t.Fatalf("chunk %d: got %d buffered line fragments, want 4", chunk, got)
+		}
+	}
+
+	result, ok := collector.Done()
+	if !ok {
+		t.Fatal("Done returned no result")
+	}
+	if got := len(result.Files); got != 4 {
+		t.Fatalf("got %d final files, want 4", got)
+	}
+	if got := collectTestLineFragmentCount(result.Files); got != 4 {
+		t.Fatalf("got %d final line fragments, want 4", got)
+	}
+}
+
+func collectTestFile(name string, score float64, lineFragments int) zoekt.FileMatch {
+	return zoekt.FileMatch{
+		FileName: name,
+		Score:    score,
+		LineMatches: []zoekt.LineMatch{{
+			LineFragments: make([]zoekt.LineFragmentMatch, lineFragments),
+		}},
+	}
+}
+
+func collectTestFileNames(files []zoekt.FileMatch) []string {
+	names := make([]string, len(files))
+	for i := range files {
+		names[i] = files[i].FileName
+	}
+	return names
+}
+
+func collectTestLineFragmentCount(files []zoekt.FileMatch) int {
+	var count int
+	for i := range files {
+		for j := range files[i].LineMatches {
+			count += len(files[i].LineMatches[j].LineFragments)
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary

Accumulate matched files across result chunks for searches without a display limit, then sort and truncate the aggregate once collection finishes. Display-limited searches intentionally retain the existing per-chunk sort-and-truncate behavior so their intermediate result size remains bounded.

## Performance

On workload `end-to-end sharded search: 128 repositories × 64 interleaved file matches, no display limit`, median metric `ns/op` changed from 223830837 to 8627535.5; paired median delta 215135473 (at least 19/20 confidence interval 208254612–223253064 from 10 pairs).

On workload `end-to-end sharded search: 128 repositories × 64 interleaved file matches, no display limit`, median metric `allocs/op` changed from 562 to 366; paired median delta 195 (at least 19/20 confidence interval 194–198 from 10 pairs).

## Testing

Ran the search package tests and built all command packages.

All 2 declared correctness checks passed.

---

Authored and verified by [Perfloop](https://app.perfloop.ai): every claim above was co-measured on both trees and independently re-verified before submission — the full record is public: [case_3tyhw53hc7](https://app.perfloop.ai/t/oss/case_3tyhw53hc7). Replies from this account are human-approved, and a human operator is accountable for this contribution.