### PR TITLE
gitindex: isolate fixtures from host Git configuration

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -702,6 +702,7 @@ git init -b main
 `
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 

--- a/gitindex/clone_test.go
+++ b/gitindex/clone_test.go
@@ -35,6 +35,7 @@ git clone orig/.git clone.git
 
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("execution error: %v, output %s", err, out)

--- a/gitindex/ignore_test.go
+++ b/gitindex/ignore_test.go
@@ -41,6 +41,7 @@ git update-ref refs/meta/config HEAD
 `
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("execution error: %v, output %s", err, out)
 	}

--- a/gitindex/index_test.go
+++ b/gitindex/index_test.go
@@ -46,6 +46,7 @@ func TestIndexEmptyRepo(t *testing.T) {
 
 	cmd := exec.Command("git", "init", "-b", "master", "repo")
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("cmd.Run: %v", err)
@@ -1082,7 +1083,15 @@ func runGit(t *testing.T, cwd string, args ...string) {
 
 	cmd := exec.Command("git", args...)
 	cmd.Dir = cwd
-	cmd.Env = append(os.Environ(),
+	cmd.Env = gitTestEnv()
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("execution error: %v, output %s", err, out)
+	}
+}
+
+func gitTestEnv() []string {
+	return append(os.Environ(),
 		"GIT_CONFIG_GLOBAL=",
 		"GIT_CONFIG_SYSTEM=",
 		"GIT_COMMITTER_NAME=Kierkegaard",
@@ -1090,10 +1099,6 @@ func runGit(t *testing.T, cwd string, args ...string) {
 		"GIT_AUTHOR_NAME=Kierkegaard",
 		"GIT_AUTHOR_EMAIL=soren@apache.com",
 	)
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("execution error: %v, output %s", err, out)
-	}
 }
 
 func TestSetTemplates_e2e(t *testing.T) {

--- a/gitindex/tree_test.go
+++ b/gitindex/tree_test.go
@@ -99,6 +99,7 @@ EOF
 `
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("execution error: %v, output %s", err, out)
 	}
@@ -364,6 +365,7 @@ EOF
 `
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("execution error: %v, output %s", err, out)
 	}
@@ -491,6 +493,7 @@ git update-ref refs/meta/config HEAD
 `
 	cmd := exec.Command("/bin/sh", "-euxc", script)
 	cmd.Dir = dir
+	cmd.Env = gitTestEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("execution error: %v, output %s", err, out)
 	}


### PR DESCRIPTION
Ignore system and global Git configuration when creating test repositories so host settings such as mandatory commit signing cannot break fixtures.