### PR TITLE
zoekt-index: attach configured branches to documents

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -135,6 +135,11 @@ func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error 
 	// we returning the first call to builder.Finish.
 	defer builder.Finish() // nolint:errcheck
 
+	branches := make([]string, 0, len(opts.RepositoryDescription.Branches))
+	for _, branch := range opts.RepositoryDescription.Branches {
+		branches = append(branches, branch.Name)
+	}
+
 	comm := make(chan fileInfo, 100)
 	agg := fileAggregator{
 		ignoreDirs: ignore,
@@ -154,6 +159,7 @@ func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error 
 		if f.size > int64(opts.SizeMax) && !opts.IgnoreSizeMax(displayName) {
 			if err := builder.Add(index.Document{
 				Name:       displayName,
+				Branches:   branches,
 				SkipReason: index.SkipReasonTooLarge,
 			}); err != nil {
 				return err
@@ -165,7 +171,11 @@ func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error 
 			return err
 		}
 
-		if err := builder.AddFile(displayName, content); err != nil {
+		if err := builder.Add(index.Document{
+			Name:     displayName,
+			Content:  content,
+			Branches: branches,
+		}); err != nil {
 			return err
 		}
 	}

--- a/cmd/zoekt-index/main_test.go
+++ b/cmd/zoekt-index/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/zoekt"
+	"github.com/sourcegraph/zoekt/index"
+	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/search"
+)
+
+func TestIndexArgAttachesConfiguredBranches(t *testing.T) {
+	sourceDir := t.TempDir()
+	indexDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "file.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := index.Options{
+		IndexDir:     indexDir,
+		DisableCTags: true,
+		RepositoryDescription: zoekt.Repository{
+			Name: "repo",
+			Branches: []zoekt.RepositoryBranch{{
+				Name:    "main",
+				Version: "0123456789abcdef0123456789abcdef01234567",
+			}},
+		},
+	}
+	opts.SetDefaults()
+	if err := indexArg(sourceDir, opts, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher, err := search.NewDirectorySearcher(indexDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer searcher.Close()
+
+	result, err := searcher.Search(
+		context.Background(),
+		query.NewAnd(
+			&query.Substring{Pattern: "needle", Content: true},
+			&query.Branch{Pattern: "main"},
+		),
+		&zoekt.SearchOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("main branch returned %d files, want 1", len(result.Files))
+	}
+	if got := result.Files[0].Branches; !reflect.DeepEqual(got, []string{"main"}) {
+		t.Fatalf("branches = %v, want [main]", got)
+	}
+
+	result, err = searcher.Search(
+		context.Background(),
+		&query.Branch{Pattern: "release"},
+		&zoekt.SearchOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("unconfigured branch returned %d files, want 0", len(result.Files))
+	}
+}


### PR DESCRIPTION
## Summary

`zoekt-index` accepts repository branch metadata through its `-meta` file, but
files added through `Builder.AddFile` did not receive those branches. The shard
therefore described the repository branches while branch-qualified queries
could not match any document.

Attach every configured branch name to normal and size-skipped documents.

## Test plan

- `go test ./cmd/zoekt-index/...`
- Added an end-to-end package test that indexes a temporary directory, verifies
  the document reports branch `main`, verifies a `main` branch query matches,
  and verifies an unconfigured branch does not.
- `go test ./...` reaches the pre-existing macOS-only
  `cmd/zoekt-local-sync` failure where `/var/...` is compared with its canonical
  `/private/var/...` path. The same focused failure reproduces on untouched
  `upstream/main`.
