### PR TITLE
zoekt-webserver: expose initial shard readiness via /readyz

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -209,13 +209,14 @@ func main() {
 		log.Fatal(err)
 	}
 
-	searcher = &loggedSearcher{
+	loggedSearcher := &loggedSearcher{
 		Streamer: searcher,
 		Logger:   sglog.Scoped("searcher"),
 	}
 
 	s := &web.Server{
-		Searcher: searcher,
+		Searcher: loggedSearcher,
+		Ready:    searcher.Ready,
 		Top:      web.Top,
 		Version:  index.Version,
 	}

--- a/search/shards.go
+++ b/search/shards.go
@@ -231,17 +231,24 @@ func NewDirectorySearcher(dir string) (zoekt.Streamer, error) {
 	return newDirectorySearcher(dir, true)
 }
 
+// ReadySearcher is a Streamer that reports whether its initial load is
+// complete.
+type ReadySearcher interface {
+	zoekt.Streamer
+	Ready() bool
+}
+
 // NewDirectorySearcherFast is like NewDirectorySearcher, but does not block
 // on the initial loading of shards.
 //
 // This exists since in the case of zoekt-webserver we are happy with having
 // partial availability since that is better than no availability on large
 // instances.
-func NewDirectorySearcherFast(dir string) (zoekt.Streamer, error) {
+func NewDirectorySearcherFast(dir string) (ReadySearcher, error) {
 	return newDirectorySearcher(dir, false)
 }
 
-func newDirectorySearcher(dir string, waitUntilReady bool) (zoekt.Streamer, error) {
+func newDirectorySearcher(dir string, waitUntilReady bool) (ReadySearcher, error) {
 	ss := newShardedSearcher(int64(runtime.GOMAXPROCS(0)))
 	tl := &loader{
 		ss: ss,
@@ -262,7 +269,19 @@ func newDirectorySearcher(dir string, waitUntilReady bool) (zoekt.Streamer, erro
 		directoryWatcher: dw,
 	}
 
-	return &typeRepoSearcher{Streamer: ds}, nil
+	return &readySearcher{
+		Streamer: &typeRepoSearcher{Streamer: ds},
+		ready:    ss,
+	}, nil
+}
+
+type readySearcher struct {
+	zoekt.Streamer
+	ready *shardedSearcher
+}
+
+func (s *readySearcher) Ready() bool {
+	return s.ready.Ready()
 }
 
 type directorySearcher struct {
@@ -1137,6 +1156,11 @@ func (s *shardedSearcher) getLoaded() loaded {
 		shards: ranked,
 		ready:  ready,
 	}
+}
+
+// Ready reports whether all shards present at startup have finished loading.
+func (s *shardedSearcher) Ready() bool {
+	return s.ready.Load()
 }
 
 func mkRankedShard(s zoekt.Searcher) *rankedShard {

--- a/search/shards_test.go
+++ b/search/shards_test.go
@@ -82,6 +82,9 @@ func TestCrashResilience(t *testing.T) {
 
 	ss := newShardedSearcher(2)
 	ss.ranked.Store([]*rankedShard{{Searcher: &crashSearcher{}}})
+	if ss.Ready() {
+		t.Fatal("new sharded searcher is ready before its initial load")
+	}
 
 	var wantCrashes int
 	test := func(t *testing.T) {
@@ -107,6 +110,9 @@ func TestCrashResilience(t *testing.T) {
 	// After marking as ready we should only have the crashSearcher
 	// contributing.
 	ss.markReady()
+	if !ss.Ready() {
+		t.Fatal("sharded searcher is not ready after its initial load")
+	}
 	wantCrashes = 1
 	t.Run("ready", test)
 }

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -963,6 +963,34 @@ func TestHealthz(t *testing.T) {
 	}
 }
 
+func TestReadyz(t *testing.T) {
+	ready := false
+	srv := Server{
+		Searcher: nil,
+		Ready:    func() bool { return ready },
+		Top:      Top,
+	}
+
+	mux, err := NewMux(&srv)
+	if err != nil {
+		t.Fatalf("NewMux: %v", err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if got, want := response.Code, http.StatusServiceUnavailable; got != want {
+		t.Fatalf("before initial load: got status %d, want %d", got, want)
+	}
+
+	ready = true
+	response = httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if got, want := response.Code, http.StatusOK; got != want {
+		t.Fatalf("after initial load: got status %d, want %d", got, want)
+	}
+}
+
 func assertResults(t *testing.T, files []zoekt.FileMatch, want string) {
 	t.Helper()
 

--- a/web/server.go
+++ b/web/server.go
@@ -124,6 +124,9 @@ const defaultNumResults = 50
 
 type Server struct {
 	Searcher zoekt.Streamer
+	// Ready reports whether the initial shard load is complete. A nil Ready
+	// function means the Searcher does not load asynchronously and is ready.
+	Ready func() bool
 
 	// Serve HTML interface
 	HTML bool
@@ -241,8 +244,18 @@ func NewMux(s *Server) (*http.ServeMux, error) {
 	}
 
 	mux.HandleFunc("/healthz", s.serveHealthz)
+	mux.HandleFunc("/readyz", s.serveReadyz)
 
 	return mux, nil
+}
+
+func (s *Server) serveReadyz(w http.ResponseWriter, _ *http.Request) {
+	if s.Ready != nil && !s.Ready() {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) serveHealthz(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
zoekt-webserver begins serving requests while its fast directory searcher is still loading the initial shard set. That partial availability is useful, but it means the existing search-based health check cannot safely gate traffic that requires complete results.

This adds `/readyz`, backed directly by the sharded searcher’s existing atomic readiness state. It returns 503 until the initial loader calls `markReady`, then returns 200 without executing a search. `/healthz` remains unchanged, so liveness and readiness retain separate semantics. Tests cover both the underlying state transition and the HTTP statuses.

Closes #1112.