### PR TITLE
zoekt-index: index symbolic links as target strings

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -32,8 +32,9 @@ import (
 )
 
 type fileInfo struct {
-	name string
-	size int64
+	name      string
+	size      int64
+	isSymlink bool
 }
 
 type fileAggregator struct {
@@ -54,8 +55,13 @@ func (a *fileAggregator) add(path string, info os.FileInfo, err error) error {
 		}
 	}
 
-	if info.Mode().IsRegular() {
-		a.sink <- fileInfo{path, info.Size()}
+	mode := info.Mode()
+	if mode.IsRegular() || mode&os.ModeSymlink != 0 {
+		a.sink <- fileInfo{
+			name:      path,
+			size:      info.Size(),
+			isSymlink: mode&os.ModeSymlink != 0,
+		}
 	}
 	return nil
 }
@@ -166,9 +172,19 @@ func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error 
 			}
 			continue
 		}
-		content, err := os.ReadFile(f.name)
-		if err != nil {
-			return err
+		var content []byte
+		if f.isSymlink {
+			target, err := os.Readlink(f.name)
+			if err != nil {
+				return err
+			}
+			content = []byte(target)
+		} else {
+			var err error
+			content, err = os.ReadFile(f.name)
+			if err != nil {
+				return err
+			}
 		}
 
 		if err := builder.Add(index.Document{

--- a/cmd/zoekt-index/main_test.go
+++ b/cmd/zoekt-index/main_test.go
@@ -72,3 +72,47 @@ func TestIndexArgAttachesConfiguredBranches(t *testing.T) {
 		t.Fatalf("unconfigured branch returned %d files, want 0", len(result.Files))
 	}
 }
+
+func TestIndexArgIndexesSymlinkTarget(t *testing.T) {
+	sourceDir := t.TempDir()
+	indexDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(sourceDir, "target.txt"), []byte("file content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target.txt", filepath.Join(sourceDir, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := index.Options{
+		IndexDir:     indexDir,
+		DisableCTags: true,
+		RepositoryDescription: zoekt.Repository{
+			Name: "repo",
+		},
+	}
+	opts.SetDefaults()
+	if err := indexArg(sourceDir, opts, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher, err := search.NewDirectorySearcher(indexDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer searcher.Close()
+
+	result, err := searcher.Search(
+		context.Background(),
+		&query.Substring{Pattern: "target.txt", Content: true},
+		&zoekt.SearchOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("search returned %d files, want 1", len(result.Files))
+	}
+	if got := result.Files[0].FileName; got != "link" {
+		t.Fatalf("file name = %q, want %q", got, "link")
+	}
+}


### PR DESCRIPTION
`zoekt-index` currently drops symlinks unlike `zoekt-git-index`. This change matches the behaviour of our git indexer which indexes a symlink as the target string.

Closes #1114.