### PR TITLE
Multi-platform Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,9 @@ jobs:
         id: version
         run: .github/workflows/docker-version.sh
 
+      - name: setup-qemu
+        uses: docker/setup-qemu-action@v4
+
       - name: setup-buildx
         uses: docker/setup-buildx-action@v4
 
@@ -50,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I noticed the built image is only for platform amd64, not the somewhat widely used arm64. The sad reality here is that there look to be CGO bits, so the cross platform build is kinda slow (20 minutes as opposed to 3 minutes currently).

Not sure if we can adjust caching to speed this up, I just tried a hot run (~30 seconds) and then changed some code and was back to 20 minutes.

If this performance (albeit only on pushes to main) is unreasonably slow for you, I fully understand if you close this. Just wanted to throw it out there for your consideration.