### PR TITLE
CI: predictable Go version, better caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,28 @@
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
   workflow_dispatch:
 name: CI
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: alpine:edge # latest go pls
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
-      - name: add dependencies
-        run: apk add go git tar
+      - name: setup go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Cache ctags
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: /usr/local/bin/universal-ctags
           key: ${{ runner.os }}-ctags-${{ hashFiles('install-ctags-alpine.sh') }}
-
-      - name: Cache Go modules
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: install ctags
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - name: add dependencies
         # zstd for faster actions/cache
+        # tar needed for actions/cache (busybox tar is incompatible)
         # git for a native checkout (also needed in tests)
-        # tar needed for setup-go
         run: apk add zstd git tar
 
       - name: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
         # zstd for faster actions/cache
         # tar needed for actions/cache (busybox tar is incompatible)
         # git for a native checkout (also needed in tests)
-        run: apk add zstd git tar
+        # jansson is here until we move to prebuilt ctags binaries (TODO: remove)
+        run: apk add zstd git tar jansson
 
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ name: CI
 jobs:
   test:
     runs-on: ubuntu-latest
+    container: alpine:3
     steps:
       - name: checkout
         uses: actions/checkout@v7
+
+      # - name: add dependencies
+      #   run: apk add zstd
 
       - name: setup go
         uses: actions/setup-go@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
     container: alpine:3
     steps:
       - name: add dependencies
-        # zstd for faster actions/cache, git for a native checkout (also needed in tests)
-        run: apk add zstd git
+        # zstd for faster actions/cache
+        # git for a native checkout (also needed in tests)
+        # tar needed for setup-go
+        run: apk add zstd git tar
 
       - name: checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:3
     steps:
+      - name: add dependencies
+        # zstd for faster actions/cache, git for a native checkout (also needed in tests)
+        run: apk add zstd git
+
       - name: checkout
         uses: actions/checkout@v7
-
-      # - name: add dependencies
-      #   run: apk add zstd
 
       - name: setup go
         uses: actions/setup-go@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 RUN apk add --no-cache ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -148,3 +148,5 @@ require (
 )
 
 go 1.25.9
+
+toolchain go1.26.5


### PR DESCRIPTION
Saw a few things in the CI run I'd usually change and since it's invoked so often, decided to take a stab at fixing them:

- do not install Go from `alpine:edge`, use a more predictable `actions/setup-go`
  - this includes caching (we can remove the explicit `actions/cache`)
  - the version installed can match whatever we have in the `go.mod` toolchain directive (added that in)
- explicitly installed `zstd` into the container - found some years ago that if `zstd` is on the PATH, `actions/cache` uses it transparently and makes things much faster than the default `gzip` - the cache restoration went down from ~30 to ~10 seconds (it's also a smaller cache file)
- bumped Go from 1.26.2 to 1.26.5 while I was at it
- bumped a few Actions