### PR TITLE
agents: setup uses same ctags script as CI

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -6,9 +6,6 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 buf_path="/usr/local/bin/buf"
 buf_url="https://github.com/bufbuild/buf/releases/download/v1.47.2/buf-Linux-x86_64"
 buf_sha256="3a0c4da8d46eea8136affa63db202c76a44f8112384160b73c3fffb1cf14b5d8"
-ctags_path="/usr/local/bin/universal-ctags"
-ctags_url="https://storage.googleapis.com/universal_ctags/x86_64-linux/dist/universal-ctags-6.0.0.2783f009"
-ctags_sha256="e99b942754ce9d55c9445513236c010753d26decbb38ed932780bec098ac0809"
 
 if ! command -v go >/dev/null 2>&1; then
   echo "Installing Go from Debian testing..."
@@ -43,13 +40,8 @@ if ! echo "$buf_sha256  $buf_path" | sha256sum --check --status 2>/dev/null; the
   trap - EXIT
 fi
 
-if ! echo "$ctags_sha256  $ctags_path" | sha256sum --check --status 2>/dev/null; then
-  echo "Installing Universal Ctags..."
-  ctags_download="$(mktemp)"
-  trap 'rm -f "$ctags_download"' EXIT
-  curl -fsSL --retry 5 -o "$ctags_download" "$ctags_url"
-  echo "$ctags_sha256  $ctags_download" | sha256sum --check --status
-  sudo install -m 0755 "$ctags_download" "$ctags_path"
+if ! command -v universal-ctags >/dev/null 2>&1; then
+  sudo CTAGS_INSTALL_DIR=/usr/local/bin "$repo_root/install-ctags-alpine.sh"
 fi
 
 echo "Downloading Go modules..."

--- a/install-ctags-alpine.sh
+++ b/install-ctags-alpine.sh
@@ -9,13 +9,16 @@
 
 CTAGS_VERSION=2024.01.07
 CTAGS_COMMIT=4053f69a35d8d3d307b274040f27c147eec79ee7
+CTAGS_INSTALL_DIR=${CTAGS_INSTALL_DIR:-/usr/bin}
 # GitHub release asset digests for uctags-${CTAGS_VERSION}-linux-*.tar.xz
 CTAGS_TAR_SHA256_X86_64=0c0bbc9f81d3f7151988b94e78c64914ab41ee4c5e10debfe79f73fee54a68a0
 CTAGS_TAR_SHA256_AARCH64=a50e25cb5b4ced8fea119984695e77464aaa73d5d4a53c10fec34dd82b1d9e5f
 
 set -eux
 
-apk add --no-cache xz
+if command -v apk >/dev/null 2>&1; then
+  apk add --no-cache xz
+fi
 
 case "${TARGETARCH:-$(uname -m)}" in
   amd64 | x86_64)
@@ -26,7 +29,10 @@ case "${TARGETARCH:-$(uname -m)}" in
     ctags_arch=aarch64
     tar_sha256=$CTAGS_TAR_SHA256_AARCH64
     ;;
-  *) echo "unsupported architecture: ${TARGETARCH:-$(uname -m)}" >&2; exit 1 ;;
+  *)
+    echo "unsupported architecture: ${TARGETARCH:-$(uname -m)}" >&2
+    exit 1
+    ;;
 esac
 
 archive_name="uctags-${CTAGS_VERSION}-linux-${ctags_arch}.tar.xz"
@@ -38,7 +44,7 @@ wget -qO "$archive_path" "${base_url}/${archive_name}"
 
 echo "$tar_sha256  $archive_path" | sha256sum -c -
 tar -xJf "$archive_path" -C /tmp
-install -m 0755 "/tmp/${extract_dir}/bin/ctags" /usr/bin/ctags
+install -m 0755 "/tmp/${extract_dir}/bin/ctags" "$CTAGS_INSTALL_DIR/ctags"
 rm -rf "$archive_path" "/tmp/${extract_dir}"
 
-ln -sf /usr/bin/ctags /usr/bin/universal-ctags
+ln -sf "$CTAGS_INSTALL_DIR/ctags" "$CTAGS_INSTALL_DIR/universal-ctags"


### PR DESCRIPTION
This follows #1130 and consolidates Orb setup on the prebuilt ctags installer introduced there, so development uses the same architecture selection, release pinning, and checksum verification as Docker and CI instead of maintaining a separate Google Storage artifact.