### PR TITLE
all: simplify promoted field references

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/index_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/index_test.go
@@ -440,7 +440,7 @@ func TestGetIndexOptions(t *testing.T) {
 			continue
 		}
 
-		tc.IndexOptions.CloneURL = sg.getCloneURL(got.Name)
+		tc.CloneURL = sg.getCloneURL(got.Name)
 
 		if d := cmp.Diff(*tc.IndexOptions, got); d != "" {
 			t.Errorf("mismatch (-want +got):\n%s", d)

--- a/cmd/zoekt-sourcegraph-indexserver/sg.go
+++ b/cmd/zoekt-sourcegraph-indexserver/sg.go
@@ -335,7 +335,7 @@ func (s *sourcegraphClient) getIndexOptions(ctx context.Context, fingerprint *co
 	for _, x := range protoItems {
 		var item indexOptionsItem
 		item.FromProto(x)
-		item.IndexOptions.CloneURL = s.getCloneURL(item.Name)
+		item.CloneURL = s.getCloneURL(item.Name)
 
 		items = append(items, item)
 	}

--- a/cmd/zoekt-webserver/grpc/server/sampling.go
+++ b/cmd/zoekt-webserver/grpc/server/sampling.go
@@ -25,10 +25,10 @@ func (s *samplingSender) Send(event *zoekt.SearchResult) {
 	if len(event.Files) == 0 {
 		s.aggCount++
 
-		s.agg.Stats.Add(event.Stats)
+		s.agg.Add(event.Stats)
 		s.agg.Progress = event.Progress
 
-		if s.aggCount%100 == 0 && !s.agg.Stats.Zero() {
+		if s.aggCount%100 == 0 && !s.agg.Zero() {
 			s.next.Send(&s.agg)
 			s.agg = zoekt.SearchResult{}
 		}
@@ -39,8 +39,8 @@ func (s *samplingSender) Send(event *zoekt.SearchResult) {
 	// If we have aggregate stats, we merge them with the new event before sending
 	// it. We drop agg.Progress, because we assume that event.Progress reflects the
 	// latest status.
-	if !s.agg.Stats.Zero() {
-		event.Stats.Add(s.agg.Stats)
+	if !s.agg.Zero() {
+		event.Add(s.agg.Stats)
 		s.agg = zoekt.SearchResult{}
 	}
 
@@ -49,7 +49,7 @@ func (s *samplingSender) Send(event *zoekt.SearchResult) {
 
 // Flush sends any aggregated stats that we haven't sent yet
 func (s *samplingSender) Flush() {
-	if !s.agg.Stats.Zero() {
+	if !s.agg.Zero() {
 		s.next.Send(&zoekt.SearchResult{
 			Stats: s.agg.Stats,
 			Progress: zoekt.Progress{

--- a/cmd/zoekt-webserver/grpc/server/server_test.go
+++ b/cmd/zoekt-webserver/grpc/server/server_test.go
@@ -282,7 +282,7 @@ type adapter struct {
 }
 
 func (a adapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) (err error) {
-	sr, err := a.Searcher.Search(ctx, q, opts)
+	sr, err := a.Search(ctx, q, opts)
 	if err != nil {
 		return err
 	}

--- a/index/eval.go
+++ b/index/eval.go
@@ -149,7 +149,7 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOpt
 
 	select {
 	case <-ctx.Done():
-		res.Stats.ShardsSkipped++
+		res.ShardsSkipped++
 		return &res, nil
 	default:
 	}
@@ -160,7 +160,7 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOpt
 	}
 
 	if opts.EstimateDocCount {
-		res.Stats.ShardFilesConsidered = len(d.fileBranchMasks)
+		res.ShardFilesConsidered = len(d.fileBranchMasks)
 		return &res, nil
 	}
 
@@ -178,13 +178,13 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOpt
 	if err != nil {
 		return nil, err
 	}
-	res.Stats.MatchTreeConstruction = timer.Elapsed()
+	res.MatchTreeConstruction = timer.Elapsed()
 	if mt == nil {
-		res.Stats.ShardsSkippedFilter++
+		res.ShardsSkippedFilter++
 		return &res, nil
 	}
 
-	res.Stats.ShardsScanned++
+	res.ShardsScanned++
 
 	cp := &contentProvider{
 		id:    d,
@@ -240,7 +240,7 @@ nextFileMatch:
 			// Skip documents over ShardRepoMaxMatchCount if specified.
 			if opts.ShardRepoMaxMatchCount > 0 {
 				if repoMatchCount >= opts.ShardRepoMaxMatchCount && repoID == lastRepoID {
-					res.Stats.FilesSkipped++
+					res.FilesSkipped++
 					continue
 				}
 			}
@@ -260,17 +260,17 @@ nextFileMatch:
 			repoMatchCount = 0
 		}
 
-		shardMaxMatchCountReached := opts.ShardMaxMatchCount > 0 && res.Stats.MatchCount >= opts.ShardMaxMatchCount
+		shardMaxMatchCountReached := opts.ShardMaxMatchCount > 0 && res.MatchCount >= opts.ShardMaxMatchCount
 		if canceled || shardMaxMatchCountReached {
 			filesSkipped := int(docCount - nextDoc)
-			res.Stats.FilesSkipped += filesSkipped
+			res.FilesSkipped += filesSkipped
 			if canceled && !shardMaxMatchCountReached {
-				res.Stats.FilesSkippedDueToCancellation += filesSkipped
+				res.FilesSkippedDueToCancellation += filesSkipped
 			}
 			break
 		}
 
-		res.Stats.FilesConsidered++
+		res.FilesConsidered++
 		mt.prepare(nextDoc)
 
 		cp.setDocument(nextDoc)
@@ -355,9 +355,9 @@ nextFileMatch:
 
 		res.Files = append(res.Files, fileMatch)
 
-		res.Stats.MatchCount += len(fileMatch.LineMatches)
-		res.Stats.MatchCount += matchedChunkRanges
-		res.Stats.FileCount++
+		res.MatchCount += len(fileMatch.LineMatches)
+		res.MatchCount += matchedChunkRanges
+		res.FileCount++
 	}
 
 	for _, md := range d.repoMetaData {
@@ -371,7 +371,7 @@ nextFileMatch:
 	// Update stats based on work done during document search.
 	updateMatchTreeStats(mt, &res.Stats)
 
-	res.Stats.MatchTreeSearch = timer.Elapsed()
+	res.MatchTreeSearch = timer.Elapsed()
 
 	return &res, nil
 }

--- a/index/eval_test.go
+++ b/index/eval_test.go
@@ -198,10 +198,10 @@ func TestSearch_ShardMaxMatchCountStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := sr.Stats.FilesSkipped, 1; got != want {
+	if got, want := sr.FilesSkipped, 1; got != want {
 		t.Errorf("FilesSkipped: got %d, want %d", got, want)
 	}
-	if got := sr.Stats.FilesSkippedDueToCancellation; got != 0 {
+	if got := sr.FilesSkippedDueToCancellation; got != 0 {
 		t.Errorf("FilesSkippedDueToCancellation: got %d, want 0", got)
 	}
 }

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -780,7 +780,7 @@ func TestNegativeMatchesOnlyShortcut(t *testing.T) {
 				Pattern: "appel",
 			}}))
 
-		if sres.Stats.FilesConsidered != 1 {
+		if sres.FilesConsidered != 1 {
 			t.Errorf("got %#v, want FilesConsidered: 1", sres.Stats)
 		}
 	})
@@ -794,7 +794,7 @@ func TestNegativeMatchesOnlyShortcut(t *testing.T) {
 				Pattern: "appel",
 			}}), chunkOpts)
 
-		if sres.Stats.FilesConsidered != 1 {
+		if sres.FilesConsidered != 1 {
 			t.Errorf("got %#v, want FilesConsidered: 1", sres.Stats)
 		}
 	})
@@ -1081,7 +1081,7 @@ func TestSearchMatchAllRegexp(t *testing.T) {
 		sres := searchForTest(t, b, &query.Regexp{Regexp: mustParseRE(".")})
 
 		matches := sres.Files
-		if len(matches) != 2 || sres.Stats.MatchCount != 2 {
+		if len(matches) != 2 || sres.MatchCount != 2 {
 			t.Fatalf("got %v, want 2 matches", matches)
 		}
 		if len(matches[0].LineMatches[0].Line) != 4 || len(matches[1].LineMatches[0].Line) != 4 {
@@ -1093,7 +1093,7 @@ func TestSearchMatchAllRegexp(t *testing.T) {
 		sres := searchForTest(t, b, &query.Regexp{Regexp: mustParseRE(".")}, chunkOpts)
 
 		matches := sres.Files
-		if len(matches) != 2 || sres.Stats.MatchCount != 8 {
+		if len(matches) != 2 || sres.MatchCount != 8 {
 			t.Fatalf("got %v, want 2 matches", matches)
 		}
 		if len(matches[0].ChunkMatches[0].Content) != 4 || len(matches[1].ChunkMatches[0].Content) != 4 {
@@ -1620,8 +1620,8 @@ func TestRepoName(t *testing.T) {
 			t.Fatalf("got %v, want 0 matches", sres.Files)
 		}
 
-		if sres.Stats.FilesConsidered > 0 {
-			t.Fatalf("got FilesConsidered %d, should have short circuited", sres.Stats.FilesConsidered)
+		if sres.FilesConsidered > 0 {
+			t.Fatalf("got FilesConsidered %d, should have short circuited", sres.FilesConsidered)
 		}
 
 		sres = searchForTest(t, b,
@@ -1647,8 +1647,8 @@ func TestRepoName(t *testing.T) {
 			t.Fatalf("got %v, want 0 matches", sres.Files)
 		}
 
-		if sres.Stats.FilesConsidered > 0 {
-			t.Fatalf("got FilesConsidered %d, should have short circuited", sres.Stats.FilesConsidered)
+		if sres.FilesConsidered > 0 {
+			t.Fatalf("got FilesConsidered %d, should have short circuited", sres.FilesConsidered)
 		}
 
 		sres = searchForTest(t, b,
@@ -2628,8 +2628,8 @@ func TestEstimateDocCount(t *testing.T) {
 				&query.Repo{Regexp: regexp.MustCompile("reponame")},
 			), zoekt.SearchOptions{
 				EstimateDocCount: true,
-			}); sres.Stats.ShardFilesConsidered != 2 {
-			t.Errorf("got FilesConsidered = %d, want 2", sres.Stats.FilesConsidered)
+			}); sres.ShardFilesConsidered != 2 {
+			t.Errorf("got FilesConsidered = %d, want 2", sres.FilesConsidered)
 		}
 		if sres := searchForTest(t, b,
 			query.NewAnd(
@@ -2637,8 +2637,8 @@ func TestEstimateDocCount(t *testing.T) {
 				&query.Repo{Regexp: regexp.MustCompile("nomatch")},
 			), zoekt.SearchOptions{
 				EstimateDocCount: true,
-			}); sres.Stats.ShardFilesConsidered != 0 {
-			t.Errorf("got FilesConsidered = %d, want 0", sres.Stats.FilesConsidered)
+			}); sres.ShardFilesConsidered != 0 {
+			t.Errorf("got FilesConsidered = %d, want 0", sres.FilesConsidered)
 		}
 	})
 
@@ -2650,8 +2650,8 @@ func TestEstimateDocCount(t *testing.T) {
 			), zoekt.SearchOptions{
 				EstimateDocCount: true,
 				ChunkMatches:     true,
-			}); sres.Stats.ShardFilesConsidered != 2 {
-			t.Errorf("got FilesConsidered = %d, want 2", sres.Stats.FilesConsidered)
+			}); sres.ShardFilesConsidered != 2 {
+			t.Errorf("got FilesConsidered = %d, want 2", sres.FilesConsidered)
 		}
 		if sres := searchForTest(t, b,
 			query.NewAnd(
@@ -2660,8 +2660,8 @@ func TestEstimateDocCount(t *testing.T) {
 			), zoekt.SearchOptions{
 				EstimateDocCount: true,
 				ChunkMatches:     true,
-			}); sres.Stats.ShardFilesConsidered != 0 {
-			t.Errorf("got FilesConsidered = %d, want 0", sres.Stats.FilesConsidered)
+			}); sres.ShardFilesConsidered != 0 {
+			t.Errorf("got FilesConsidered = %d, want 0", sres.FilesConsidered)
 		}
 	})
 }
@@ -2726,13 +2726,13 @@ func TestIOStats(t *testing.T) {
 		res := searchForTest(t, b, q)
 
 		// 4096 (content) + 2 (overhead: newlines or doc sections)
-		if got, want := res.Stats.ContentBytesLoaded, int64(4098); got != want {
+		if got, want := res.ContentBytesLoaded, int64(4098); got != want {
 			t.Errorf("got content I/O %d, want %d", got, want)
 		}
 
 		// 1024 entries, each 4 bytes apart. 4 fits into single byte
 		// delta encoded.
-		if got, want := res.Stats.IndexBytesLoaded, int64(1024); got != want {
+		if got, want := res.IndexBytesLoaded, int64(1024); got != want {
 			t.Errorf("got index I/O %d, want %d", got, want)
 		}
 	})
@@ -2742,13 +2742,13 @@ func TestIOStats(t *testing.T) {
 		res := searchForTest(t, b, q, chunkOpts)
 
 		// 4096 (content) + 2 (overhead: newlines or doc sections)
-		if got, want := res.Stats.ContentBytesLoaded, int64(4098); got != want {
+		if got, want := res.ContentBytesLoaded, int64(4098); got != want {
 			t.Errorf("got content I/O %d, want %d", got, want)
 		}
 
 		// 1024 entries, each 4 bytes apart. 4 fits into single byte
 		// delta encoded.
-		if got, want := res.Stats.IndexBytesLoaded, int64(1024); got != want {
+		if got, want := res.IndexBytesLoaded, int64(1024); got != want {
 			t.Errorf("got index I/O %d, want %d", got, want)
 		}
 	})
@@ -2758,13 +2758,13 @@ func TestIOStats(t *testing.T) {
 		res := searchForTest(t, b, q, zoekt.SearchOptions{UseBM25Scoring: true})
 
 		// 4096 (content) + 2 (overhead: newlines or doc sections)
-		if got, want := res.Stats.ContentBytesLoaded, int64(4098); got != want {
+		if got, want := res.ContentBytesLoaded, int64(4098); got != want {
 			t.Errorf("got content I/O %d, want %d", got, want)
 		}
 
 		// 1024 entries, each 4 bytes apart. 4 fits into single byte
 		// delta encoded.
-		if got, want := res.Stats.IndexBytesLoaded, int64(1024); got != want {
+		if got, want := res.IndexBytesLoaded, int64(1024); got != want {
 			t.Errorf("got index I/O %d, want %d", got, want)
 		}
 	})
@@ -2774,13 +2774,13 @@ func TestIOStats(t *testing.T) {
 		res := searchForTest(t, b, q, zoekt.SearchOptions{UseBM25Scoring: true, ChunkMatches: true})
 
 		// 4096 (content) + 2 (overhead: newlines or doc sections)
-		if got, want := res.Stats.ContentBytesLoaded, int64(4098); got != want {
+		if got, want := res.ContentBytesLoaded, int64(4098); got != want {
 			t.Errorf("got content I/O %d, want %d", got, want)
 		}
 
 		// 1024 entries, each 4 bytes apart. 4 fits into single byte
 		// delta encoded.
-		if got, want := res.Stats.IndexBytesLoaded, int64(1024); got != want {
+		if got, want := res.IndexBytesLoaded, int64(1024); got != want {
 			t.Errorf("got index I/O %d, want %d", got, want)
 		}
 	})
@@ -2988,8 +2988,8 @@ func TestLangShortcut(t *testing.T) {
 		if len(res.Files) != 0 {
 			t.Fatalf("got %v, want 0 results", res.Files)
 		}
-		if res.Stats.IndexBytesLoaded > 0 {
-			t.Errorf("got matchBytesLoaded %d, want 0", res.Stats.IndexBytesLoaded)
+		if res.IndexBytesLoaded > 0 {
+			t.Errorf("got matchBytesLoaded %d, want 0", res.IndexBytesLoaded)
 		}
 	})
 
@@ -2998,8 +2998,8 @@ func TestLangShortcut(t *testing.T) {
 		if len(res.Files) != 0 {
 			t.Fatalf("got %v, want 0 results", res.Files)
 		}
-		if res.Stats.IndexBytesLoaded > 0 {
-			t.Errorf("got matchBytesLoaded %d, want 0", res.Stats.IndexBytesLoaded)
+		if res.IndexBytesLoaded > 0 {
+			t.Errorf("got matchBytesLoaded %d, want 0", res.IndexBytesLoaded)
 		}
 	})
 }
@@ -4033,7 +4033,7 @@ func TestWordSearch(t *testing.T) {
 			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
 		}
 
-		if sres.Stats.RegexpsConsidered != 0 {
+		if sres.RegexpsConsidered != 0 {
 			t.Fatal("expected regexp to be skipped")
 		}
 
@@ -4067,7 +4067,7 @@ func TestWordSearch(t *testing.T) {
 			t.Fatalf("got %v, want 1 match in 1 file", sres.Files)
 		}
 
-		if sres.Stats.RegexpsConsidered != 0 {
+		if sres.RegexpsConsidered != 0 {
 			t.Fatal("expected regexp to be skipped")
 		}
 

--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -439,7 +439,7 @@ func (t *boostMatchTree) prepare(doc uint32) {
 
 func (t *substrMatchTree) prepare(nextDoc uint32) {
 	t.matchIterator.prepare(nextDoc)
-	t.current = t.matchIterator.candidates()
+	t.current = t.candidates()
 	t.contEvaluated = false
 }
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -116,7 +116,7 @@ func (fs fieldsStringer) String() string {
 	for _, f := range fs {
 		f.Marshal(&e)
 	}
-	return e.Builder.String()
+	return e.String()
 }
 
 // encoder is a log.Encoder used by fieldsStringer.
@@ -128,16 +128,16 @@ type encoder struct {
 func (e *encoder) EmitString(key, value string) {
 	if e.prefixNewline {
 		// most times encoder is used is for one field
-		e.Builder.WriteString("\n")
+		e.WriteString("\n")
 	}
 	if !e.prefixNewline {
 		e.prefixNewline = true
 	}
 
-	e.Builder.Grow(len(key) + 1 + len(value))
-	e.Builder.WriteString(key)
-	e.Builder.WriteString(":")
-	e.Builder.WriteString(value)
+	e.Grow(len(key) + 1 + len(value))
+	e.WriteString(key)
+	e.WriteString(":")
+	e.WriteString(value)
 }
 
 func (e *encoder) EmitBool(key string, value bool) {

--- a/search/aggregate.go
+++ b/search/aggregate.go
@@ -44,7 +44,7 @@ func (c *collectSender) Send(r *zoekt.SearchResult) {
 		}
 	}
 
-	c.aggregate.Stats.Add(r.Stats)
+	c.aggregate.Add(r.Stats)
 
 	if len(r.Files) > 0 {
 		c.aggregate.Files = append(c.aggregate.Files, r.Files...)

--- a/search/shards.go
+++ b/search/shards.go
@@ -606,11 +606,11 @@ func (ss *shardedSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.Se
 
 	if !loaded.ready {
 		// We may have missed results due to not being fully loaded.
-		aggregate.Stats.Crashes++
+		aggregate.Crashes++
 	}
 
-	aggregate.Stats.Wait = wait
-	aggregate.Stats.Duration = time.Since(start)
+	aggregate.Wait = wait
+	aggregate.Duration = time.Since(start)
 
 	return aggregate, nil
 }
@@ -828,7 +828,7 @@ search:
 
 			// Update the match count statistics and stop searching new shards if we've
 			// reached the limit set in the options.
-			totalMatchCount += r.SearchResult.Stats.MatchCount
+			totalMatchCount += r.MatchCount
 			if opts.TotalMaxMatchCount > 0 && totalMatchCount > opts.TotalMaxMatchCount {
 				stop()
 			}
@@ -916,20 +916,20 @@ func sendByRepository(result *zoekt.SearchResult, opts *zoekt.SearchOptions, sen
 }
 
 func observeMetrics(sr *zoekt.SearchResult) {
-	metricSearchContentBytesLoadedTotal.Add(float64(sr.Stats.ContentBytesLoaded))
-	metricSearchIndexBytesLoadedTotal.Add(float64(sr.Stats.IndexBytesLoaded))
-	metricSearchCrashesTotal.Add(float64(sr.Stats.Crashes))
-	metricSearchFileCountTotal.Add(float64(sr.Stats.FileCount))
-	metricSearchShardFilesConsideredTotal.Add(float64(sr.Stats.ShardFilesConsidered))
-	metricSearchFilesConsideredTotal.Add(float64(sr.Stats.FilesConsidered))
-	metricSearchFilesLoadedTotal.Add(float64(sr.Stats.FilesLoaded))
-	metricSearchFilesSkippedTotal.Add(float64(sr.Stats.FilesSkipped))
-	metricSearchFilesSkippedDueToCancellationTotal.Add(float64(sr.Stats.FilesSkippedDueToCancellation))
-	metricSearchShardsSkippedTotal.Add(float64(sr.Stats.ShardsSkipped))
-	metricSearchMatchCountTotal.Add(float64(sr.Stats.MatchCount))
-	metricSearchNgramMatchesTotal.Add(float64(sr.Stats.NgramMatches))
-	metricSearchNgramLookupsTotal.Add(float64(sr.Stats.NgramLookups))
-	metricSearchRegexpsConsideredTotal.Add(float64(sr.Stats.RegexpsConsidered))
+	metricSearchContentBytesLoadedTotal.Add(float64(sr.ContentBytesLoaded))
+	metricSearchIndexBytesLoadedTotal.Add(float64(sr.IndexBytesLoaded))
+	metricSearchCrashesTotal.Add(float64(sr.Crashes))
+	metricSearchFileCountTotal.Add(float64(sr.FileCount))
+	metricSearchShardFilesConsideredTotal.Add(float64(sr.ShardFilesConsidered))
+	metricSearchFilesConsideredTotal.Add(float64(sr.FilesConsidered))
+	metricSearchFilesLoadedTotal.Add(float64(sr.FilesLoaded))
+	metricSearchFilesSkippedTotal.Add(float64(sr.FilesSkipped))
+	metricSearchFilesSkippedDueToCancellationTotal.Add(float64(sr.FilesSkippedDueToCancellation))
+	metricSearchShardsSkippedTotal.Add(float64(sr.ShardsSkipped))
+	metricSearchMatchCountTotal.Add(float64(sr.MatchCount))
+	metricSearchNgramMatchesTotal.Add(float64(sr.NgramMatches))
+	metricSearchNgramLookupsTotal.Add(float64(sr.NgramLookups))
+	metricSearchRegexpsConsideredTotal.Add(float64(sr.RegexpsConsidered))
 }
 
 func copySlice(src *[]byte) {
@@ -983,7 +983,7 @@ func searchOneShard(ctx context.Context, s zoekt.Searcher, q query.Q, opts *zoek
 			if sr == nil {
 				sr = &zoekt.SearchResult{}
 			}
-			sr.Stats.Crashes = 1
+			sr.Crashes = 1
 		}
 	}()
 

--- a/search/shards_test.go
+++ b/search/shards_test.go
@@ -92,7 +92,7 @@ func TestCrashResilience(t *testing.T) {
 		opts := &zoekt.SearchOptions{}
 		if res, err := ss.Search(context.Background(), q, opts); err != nil {
 			t.Fatalf("Search: %v", err)
-		} else if res.Stats.Crashes != wantCrashes {
+		} else if res.Crashes != wantCrashes {
 			t.Errorf("got stats %#v, want crashes = %d", res.Stats, wantCrashes)
 		}
 
@@ -1406,7 +1406,7 @@ func TestNewDirectorySearcher_empty(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			return res.Stats.Crashes == 0
+			return res.Crashes == 0
 		})
 
 		test(t, ss)

--- a/web/e2e_test.go
+++ b/web/e2e_test.go
@@ -75,7 +75,7 @@ type adapter struct {
 }
 
 func (a adapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) (err error) {
-	sr, err := a.Searcher.Search(ctx, q, opts)
+	sr, err := a.Search(ctx, q, opts)
 	if err != nil {
 		return err
 	}
@@ -711,7 +711,7 @@ type crashSearcher struct {
 
 func (s *crashSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
 	res := zoekt.SearchResult{}
-	res.Stats.Crashes = 1
+	res.Crashes = 1
 	return &res, nil
 }
 


### PR DESCRIPTION
Running modernize over the zoekt codebase this is the most common change it does so shipping as its own PR.