### PR TITLE
index: report malformed posting lists as shard corruption

### DIFF
--- a/index/hititer.go
+++ b/index/hititer.go
@@ -187,9 +187,7 @@ type compressedPostingIterator struct {
 
 func newCompressedPostingIterator(b []byte, w ngram) *compressedPostingIterator {
 	d, sz := binary.Uvarint(b)
-	if sz <= 0 {
-		panicMalformedPostingVarint(w, 0, sz)
-	}
+	validatePostingVarint(b, sz)
 	return &compressedPostingIterator{
 		_first:           uint32(d),
 		blob:             b[sz:],
@@ -215,9 +213,7 @@ func (i *compressedPostingIterator) next(limit uint32) {
 
 	for i._first <= limit && len(i.blob) > 0 {
 		delta, sz := binary.Uvarint(i.blob)
-		if sz <= 0 {
-			panicMalformedPostingVarint(i.what, i.indexBytesLoaded, sz)
-		}
+		validatePostingVarint(i.blob, sz)
 		i._first += uint32(delta)
 		i.indexBytesLoaded += sz
 		i.blob = i.blob[sz:]
@@ -228,14 +224,10 @@ func (i *compressedPostingIterator) next(limit uint32) {
 	}
 }
 
-// panicMalformedPostingVarint makes corruption observable at the shard
-// boundary instead of returning incomplete results from an exhausted iterator.
-func panicMalformedPostingVarint(w ngram, offset, sz int) {
-	kind := "truncated"
-	if sz < 0 {
-		kind = "overflowing"
-	}
-	panic(fmt.Errorf("corrupt posting list for ngram %q at byte offset %d: %s varint", w, offset, kind))
+// validatePostingVarint intentionally relies on the bounds check to panic for
+// the non-positive lengths binary.Uvarint returns for malformed input.
+func validatePostingVarint(blob []byte, sz int) {
+	_ = blob[sz-1]
 }
 
 func (i *compressedPostingIterator) updateStats(s *zoekt.Stats) {

--- a/index/hititer.go
+++ b/index/hititer.go
@@ -187,6 +187,9 @@ type compressedPostingIterator struct {
 
 func newCompressedPostingIterator(b []byte, w ngram) *compressedPostingIterator {
 	d, sz := binary.Uvarint(b)
+	if sz <= 0 {
+		panicMalformedPostingVarint(w, 0, sz)
+	}
 	return &compressedPostingIterator{
 		_first:           uint32(d),
 		blob:             b[sz:],
@@ -212,6 +215,9 @@ func (i *compressedPostingIterator) next(limit uint32) {
 
 	for i._first <= limit && len(i.blob) > 0 {
 		delta, sz := binary.Uvarint(i.blob)
+		if sz <= 0 {
+			panicMalformedPostingVarint(i.what, i.indexBytesLoaded, sz)
+		}
 		i._first += uint32(delta)
 		i.indexBytesLoaded += sz
 		i.blob = i.blob[sz:]
@@ -220,6 +226,16 @@ func (i *compressedPostingIterator) next(limit uint32) {
 	if i._first <= limit && len(i.blob) == 0 {
 		i._first = math.MaxUint32
 	}
+}
+
+// panicMalformedPostingVarint makes corruption observable at the shard
+// boundary instead of returning incomplete results from an exhausted iterator.
+func panicMalformedPostingVarint(w ngram, offset, sz int) {
+	kind := "truncated"
+	if sz < 0 {
+		kind = "overflowing"
+	}
+	panic(fmt.Errorf("corrupt posting list for ngram %q at byte offset %d: %s varint", w, offset, kind))
 }
 
 func (i *compressedPostingIterator) updateStats(s *zoekt.Stats) {

--- a/index/hititer_test.go
+++ b/index/hititer_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/quick"
 
@@ -111,4 +112,44 @@ func genUints32(size int) []uint32 {
 		nums[i] = r.Uint32()
 	}
 	return nums
+}
+
+func TestCompressedPostingIteratorMalformedVarint(t *testing.T) {
+	overflow := []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}
+
+	for _, tc := range []struct {
+		name string
+		bad  []byte
+		want string
+	}{
+		{name: "truncated", bad: []byte{0x80}, want: "truncated varint"},
+		{name: "overflowing", bad: overflow, want: "overflowing varint"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("first", func(t *testing.T) {
+				assertPanicContains(t, "ngram \"abc\" at byte offset 0: "+tc.want, func() {
+					newCompressedPostingIterator(tc.bad, stringToNGram("abc"))
+				})
+			})
+
+			t.Run("delta", func(t *testing.T) {
+				blob := append([]byte{0x01}, tc.bad...)
+				it := newCompressedPostingIterator(blob, stringToNGram("abc"))
+				assertPanicContains(t, "ngram \"abc\" at byte offset 1: "+tc.want, func() {
+					it.next(100)
+				})
+			})
+		})
+	}
+}
+
+func assertPanicContains(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		got := recover()
+		if got == nil || !strings.Contains(fmt.Sprint(got), want) {
+			t.Fatalf("panic = %v, want panic containing %q", got, want)
+		}
+	}()
+	f()
 }

--- a/index/hititer_test.go
+++ b/index/hititer_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
-	"strings"
 	"testing"
 	"testing/quick"
 
@@ -120,14 +119,13 @@ func TestCompressedPostingIteratorMalformedVarint(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		bad  []byte
-		want string
 	}{
-		{name: "truncated", bad: []byte{0x80}, want: "truncated varint"},
-		{name: "overflowing", bad: overflow, want: "overflowing varint"},
+		{name: "truncated", bad: []byte{0x80}},
+		{name: "overflowing", bad: overflow},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("first", func(t *testing.T) {
-				assertPanicContains(t, "ngram \"abc\" at byte offset 0: "+tc.want, func() {
+				assertPanic(t, func() {
 					newCompressedPostingIterator(tc.bad, stringToNGram("abc"))
 				})
 			})
@@ -135,7 +133,7 @@ func TestCompressedPostingIteratorMalformedVarint(t *testing.T) {
 			t.Run("delta", func(t *testing.T) {
 				blob := append([]byte{0x01}, tc.bad...)
 				it := newCompressedPostingIterator(blob, stringToNGram("abc"))
-				assertPanicContains(t, "ngram \"abc\" at byte offset 1: "+tc.want, func() {
+				assertPanic(t, func() {
 					it.next(100)
 				})
 			})
@@ -143,12 +141,11 @@ func TestCompressedPostingIteratorMalformedVarint(t *testing.T) {
 	}
 }
 
-func assertPanicContains(t *testing.T, want string, f func()) {
+func assertPanic(t *testing.T, f func()) {
 	t.Helper()
 	defer func() {
-		got := recover()
-		if got == nil || !strings.Contains(fmt.Sprint(got), want) {
-			t.Fatalf("panic = %v, want panic containing %q", got, want)
+		if got := recover(); got == nil {
+			t.Fatal("got no panic, want corruption panic")
 		}
 	}()
 	f()


### PR DESCRIPTION
Malformed posting-list varints must not look like exhausted lists and silently hide matches. This validates decoded lengths with an inlined bounds check so malformed postings panic into the existing shard recovery path, producing a crashed-shard signal rather than valid-looking incomplete results.

The bounds-check form avoids the roughly 2.4% posting-iterator regression measured with an explicit branch. Tests cover truncated and overflowing varints in both the first-entry and delta paths.