### PR TITLE
zoekt-git-index: add -meta flag for repository metadata

### DIFF
--- a/cmd/zoekt-git-index/main.go
+++ b/cmd/zoekt-git-index/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"log"
 	"os"
@@ -46,6 +47,7 @@ func run() int {
 	isDelta := flag.Bool("delta", false, "whether we should use delta build")
 	deltaShardNumberFallbackThreshold := flag.Uint64("delta_threshold", 0, "upper limit on the number of preexisting shards that can exist before attempting a delta build (0 to disable fallback behavior)")
 	languageMap := flag.String("language_map", "", "a mapping between a language and its ctags processor (a:0,b:3).")
+	metaFile := flag.String("meta", "", "path to .meta JSON file with repository description")
 
 	cpuProfile := flag.String("cpu_profile", "", "write cpu profile to `file`")
 
@@ -76,6 +78,16 @@ func run() int {
 
 	opts := cmd.OptionsFromFlags()
 	opts.IsDelta = *isDelta
+
+	if *metaFile != "" {
+		data, err := os.ReadFile(*metaFile)
+		if err != nil {
+			log.Fatalf("failed to read .meta file %s: %v", *metaFile, err)
+		}
+		if err := json.Unmarshal(data, &opts.RepositoryDescription); err != nil {
+			log.Fatalf("failed to decode .meta file %s: %v", *metaFile, err)
+		}
+	}
 
 	var branches []string
 	if *branchesStr != "" {
@@ -121,7 +133,9 @@ func run() int {
 	profiler.Init("zoekt-git-index")
 	exitStatus := 0
 	for dir, name := range gitRepos {
-		opts.RepositoryDescription.Name = name
+		if opts.RepositoryDescription.Name == "" {
+			opts.RepositoryDescription.Name = name
+		}
 		gitOpts := gitindex.Options{
 			BranchPrefix:                      *branchPrefix,
 			Incremental:                       *incremental,

--- a/web/api.go
+++ b/web/api.go
@@ -118,6 +118,7 @@ type Repository struct {
 	IndexTime time.Time
 	Branches  []Branch
 	Files     int64
+	Metadata  map[string]string
 
 	// Total amount of content bytes.
 	Size int64

--- a/web/server.go
+++ b/web/server.go
@@ -598,6 +598,7 @@ func (s *Server) serveListReposErr(q query.Q, qStr string, r *http.Request) (*Re
 			Size:       r.Stats.ContentBytes,
 			MemorySize: r.Stats.IndexBytes,
 			Files:      int64(r.Stats.Documents),
+			Metadata:   r.Repository.Metadata,
 		}
 		for _, b := range r.Repository.Branches {
 			var buf bytes.Buffer


### PR DESCRIPTION
Add a -meta flag that points to a JSON file with a repository description, decoded into the shard's RepositoryDescription. This allows setting arbitrary metadata (and an explicit repo name) at index time without deriving everything from the folder name.

- If the .meta file sets a Name, it takes precedence over the folder-derived name.
- Expose Repository.Metadata in the web API's repo list so indexed metadata is visible via /api and the web UI.