### PR TITLE
index: measure regexp optimizer thresholds in runes

### DIFF
--- a/index/eval.go
+++ b/index/eval.go
@@ -625,7 +625,7 @@ func (d *indexData) regexpToMatchTreeRecursive(r *syntax.Regexp, minTextSize int
 	switch r.Op {
 	case syntax.OpLiteral:
 		s := string(r.Rune)
-		if len(s) >= minTextSize {
+		if len(r.Rune) >= minTextSize {
 			ignoreCase := syntax.FoldCase == (r.Flags & syntax.FoldCase)
 			mt, err := d.newSubstringMatchTree(&query.Substring{Pattern: s, FileName: fileName, CaseSensitive: !ignoreCase && caseSensitive})
 			return mt, true, !strings.Contains(s, "\n"), err

--- a/index/eval_test.go
+++ b/index/eval_test.go
@@ -90,6 +90,9 @@ func TestRegexpParse(t *testing.T) {
 	cases := []testcase{
 		{"(foo|)bar", substrMT("bar"), false, false},
 		{"(foo|)", &bruteForceMatchTree{}, false, false},
+		{"éa", &bruteForceMatchTree{}, false, false},
+		{"éab", substrMT("éab"), true, false},
+		{"(éa|êb)", &bruteForceMatchTree{}, false, false},
 		{"(foo|bar)baz.*bla", &andMatchTree{[]matchTree{
 			&orMatchTree{[]matchTree{
 				substrMT("foo"),


### PR DESCRIPTION
Zoekt indexes rune trigrams, but the regexp optimizer currently decides whether a literal is large enough by measuring its UTF-8 byte length. Non-ASCII literals can therefore cross the optimizer threshold despite containing fewer than three runes, only to fall back to a different matcher when the substring planner counts runes correctly.

This makes the optimizer use the parsed regexp rune count and adds coverage around two-rune and three-rune Unicode literals, including the alternation shape from #1147. This is intentionally independent hardening rather than the complete symbol-alternation fix: the equivalent ASCII alternation still requires the separate symbol-planning change.

Validated with `go test ./... -short -count=1` and `go build ./cmd/...`.