### PR TITLE
Centralize regexp pattern construction

### DIFF
--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -207,13 +207,17 @@ type regexpMatchTree struct {
 	bruteForceMatchTree
 }
 
-func newRegexpMatchTree(s *query.Regexp) *regexpMatchTree {
+func regexpPattern(s *query.Regexp) string {
 	prefix := ""
 	if !s.CaseSensitive {
 		prefix = "(?i)"
 	}
 
-	pattern := prefix + syntaxutil.RegexpString(s.Regexp)
+	return prefix + syntaxutil.RegexpString(s.Regexp)
+}
+
+func newRegexpMatchTree(s *query.Regexp) *regexpMatchTree {
+	pattern := regexpPattern(s)
 
 	// hybridRegexp is only used for file content matching; skip the RE2
 	// compilation overhead for filename-only regexps.


### PR DESCRIPTION
This is the behavior-preserving first change in a two-PR stack for #1147. It extracts the existing case-prefix and regexp serialization logic so ordinary regexp matching and the symbol-scoped verifier added by the next PR can share exactly the same pattern construction.

No matching or planning behavior changes. The existing index tests pass with `go test ./index -count=1`.