### PR TITLE
index: fix symbol regexp alternation planning

### DIFF
--- a/index/eval.go
+++ b/index/eval.go
@@ -166,7 +166,7 @@ func (d *indexData) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOpt
 
 	q = query.Map(q, query.ExpandFileContent)
 
-	mt, err := d.newMatchTree(q, matchTreeOpt{})
+	mt, err := d.newMatchTree(q)
 	if err != nil {
 		return nil, err
 	}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -3160,6 +3160,20 @@ func TestSymbolSubstring(t *testing.T) {
 			t.Fatalf("got offset %d, end %d want 7, 10", m.Start.ByteOffset, m.End.ByteOffset)
 		}
 	})
+
+	t.Run("ShortSubstring", func(t *testing.T) {
+		q := &query.Symbol{
+			Expr: &query.Substring{Pattern: "la"},
+		}
+		res := searchForTest(t, b, q)
+		if len(res.Files) != 1 || len(res.Files[0].LineMatches) != 1 {
+			t.Fatalf("got %v, want 1 line in 1 file", res.Files)
+		}
+		m := res.Files[0].LineMatches[0].LineFragments[0]
+		if m.Offset != 8 || m.MatchLength != 2 {
+			t.Fatalf("got offset %d, size %d want 8 size 2", m.Offset, m.MatchLength)
+		}
+	})
 }
 
 func TestSymbolSubstringExact(t *testing.T) {
@@ -3277,6 +3291,83 @@ func TestSymbolRegexpPartial(t *testing.T) {
 			t.Fatalf("got match end %d, want 4", m.End.ByteOffset)
 		}
 	})
+}
+
+func TestSymbolRegexpAlternation(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		content string
+		symbols []DocumentSection
+		offsets []uint32
+	}{
+		{
+			name:    "ASCII",
+			query:   "sym:(abc|def)",
+			content: "abc def abc def",
+			symbols: []DocumentSection{{8, 11}, {12, 15}},
+			offsets: []uint32{8, 12},
+		},
+		{
+			name:    "Unicode",
+			query:   "sym:(éa|êb)",
+			content: "éa êb éa êb",
+			symbols: []DocumentSection{{8, 11}, {12, 15}},
+			offsets: []uint32{8, 12},
+		},
+		{
+			name:    "matches outside symbols only",
+			query:   "sym:(abc|def)",
+			content: "abc def ghi jkl",
+			symbols: []DocumentSection{{8, 11}, {12, 15}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := query.Parse(tt.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b := testShardBuilder(t, &zoekt.Repository{Name: "reponame"},
+				Document{
+					Name:    "f1",
+					Content: []byte(tt.content),
+					Symbols: tt.symbols,
+				},
+			)
+
+			t.Run("LineMatches", func(t *testing.T) {
+				res := searchForTest(t, b, q)
+				var got []uint32
+				for _, file := range res.Files {
+					for _, line := range file.LineMatches {
+						for _, fragment := range line.LineFragments {
+							got = append(got, fragment.Offset)
+						}
+					}
+				}
+				if diff := cmp.Diff(tt.offsets, got); diff != "" {
+					t.Fatalf("offsets mismatch (-want +got):\n%s", diff)
+				}
+			})
+
+			t.Run("ChunkMatches", func(t *testing.T) {
+				res := searchForTest(t, b, q, chunkOpts)
+				var got []uint32
+				for _, file := range res.Files {
+					for _, chunk := range file.ChunkMatches {
+						for _, r := range chunk.Ranges {
+							got = append(got, r.Start.ByteOffset)
+						}
+					}
+				}
+				if diff := cmp.Diff(tt.offsets, got); diff != "" {
+					t.Fatalf("offsets mismatch (-want +got):\n%s", diff)
+				}
+			})
+		})
+	}
 }
 
 func TestSymbolRegexpAll(t *testing.T) {

--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -193,10 +193,6 @@ type regexpMatchTree struct {
 	// For small inputs and filename matches, regexp is used directly.
 	hybridRegexp *hybridre2.Regexp
 
-	// origRegexp is the original parsed regexp from the query structure. It
-	// does not include mutations such as case sensitivity.
-	origRegexp *syntax.Regexp
-
 	fileName bool
 
 	// mutable
@@ -228,9 +224,21 @@ func newRegexpMatchTree(s *query.Regexp) *regexpMatchTree {
 	return &regexpMatchTree{
 		regexp:       regexp.MustCompile(pattern),
 		hybridRegexp: hr,
-		origRegexp:   s.Regexp,
 		fileName:     s.FileName,
 	}
+}
+
+func (d *indexData) newSymbolRegexpMatchTree(s *query.Regexp) (*symbolRegexpMatchTree, error) {
+	prefilter, _, _, err := d.regexpToMatchTreeRecursive(s.Regexp, ngramSize, s.FileName, s.CaseSensitive)
+	if err != nil {
+		return nil, err
+	}
+
+	return &symbolRegexpMatchTree{
+		regexp:    regexp.MustCompile(regexpPattern(s)),
+		all:       isRegexpAll(s.Regexp),
+		matchTree: prefilter,
+	}, nil
 }
 
 // \bLITERAL\b
@@ -996,13 +1004,7 @@ func (t *substrMatchTree) matches(cp *contentProvider, cost int, known map[match
 	return matchesStateForSlice(t.current)
 }
 
-type matchTreeOpt struct {
-	// DisableWordMatchOptimization is used to disable the use of wordMatchTree.
-	// This was added since we do not support wordMatchTree with symbol search.
-	DisableWordMatchOptimization bool
-}
-
-func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error) {
+func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 	if q == nil {
 		return nil, fmt.Errorf("got nil (sub)query")
 	}
@@ -1025,7 +1027,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 		}
 
 		var tr matchTree
-		if wmt, ok := regexpToWordMatchTree(s, opt); ok {
+		if wmt, ok := regexpToWordMatchTree(s); ok {
 			// A common search we get is "\bLITERAL\b". Avoid the regex engine and
 			// provide something faster.
 			tr = wmt
@@ -1041,7 +1043,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 	case *query.And:
 		var r []matchTree
 		for _, ch := range s.Children {
-			ct, err := d.newMatchTree(ch, opt)
+			ct, err := d.newMatchTree(ch)
 			if err != nil {
 				return nil, err
 			}
@@ -1051,7 +1053,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 	case *query.Or:
 		var r []matchTree
 		for _, ch := range s.Children {
-			ct, err := d.newMatchTree(ch, opt)
+			ct, err := d.newMatchTree(ch)
 			if err != nil {
 				return nil, err
 			}
@@ -1059,7 +1061,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 		}
 		return &orMatchTree{r}, nil
 	case *query.Not:
-		ct, err := d.newMatchTree(s.Child, opt)
+		ct, err := d.newMatchTree(s.Child)
 		return &notMatchTree{
 			child: ct,
 		}, err
@@ -1069,7 +1071,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 			break
 		}
 
-		ct, err := d.newMatchTree(s.Child, opt)
+		ct, err := d.newMatchTree(s.Child)
 		if err != nil {
 			return nil, err
 		}
@@ -1079,7 +1081,7 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 		}, nil
 
 	case *query.Boost:
-		ct, err := d.newMatchTree(s.Child, opt)
+		ct, err := d.newMatchTree(s.Child)
 		if err != nil {
 			return nil, err
 		}
@@ -1168,39 +1170,32 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 			return nil, err
 		}
 
-		// Disable WordMatchTree since we don't support it in symbols yet.
-		optCopy := opt
-		optCopy.DisableWordMatchOptimization = true
+		if regexpQuery, ok := s.Expr.(*query.Regexp); ok {
+			return d.newSymbolRegexpMatchTree(regexpQuery)
+		}
 
-		subMT, err := d.newMatchTree(s.Expr, optCopy)
+		substrQuery := s.Expr.(*query.Substring)
+		patternSize := utf8.RuneCountInString(substrQuery.Pattern)
+		if patternSize < ngramSize {
+			return d.newSymbolRegexpMatchTree(&query.Regexp{
+				Regexp:        &syntax.Regexp{Op: syntax.OpLiteral, Rune: []rune(substrQuery.Pattern)},
+				FileName:      substrQuery.FileName,
+				Content:       substrQuery.Content,
+				CaseSensitive: substrQuery.CaseSensitive,
+			})
+		}
+
+		subMT, err := d.newSubstringMatchTree(substrQuery)
 		if err != nil {
 			return nil, err
 		}
 
-		if substr, ok := subMT.(*substrMatchTree); ok {
-			return &symbolSubstrMatchTree{
-				substrMatchTree: substr,
-				patternSize:     uint32(utf8.RuneCountInString(substr.query.Pattern)),
-				fileEndRunes:    d.fileEndRunes,
-				fileEndSymbol:   d.fileEndSymbol,
-				sections:        d.runeDocSections,
-			}, nil
-		}
-
-		var regexpMT *regexpMatchTree
-		visitMatchTree(subMT, func(mt matchTree) {
-			if t, ok := mt.(*regexpMatchTree); ok {
-				regexpMT = t
-			}
-		})
-		if regexpMT == nil {
-			return nil, fmt.Errorf("found %T inside query.Symbol", subMT)
-		}
-
-		return &symbolRegexpMatchTree{
-			regexp:    regexpMT.regexp,
-			all:       isRegexpAll(regexpMT.origRegexp),
-			matchTree: subMT,
+		return &symbolSubstrMatchTree{
+			substrMatchTree: subMT.(*substrMatchTree),
+			patternSize:     uint32(patternSize),
+			fileEndRunes:    d.fileEndRunes,
+			fileEndSymbol:   d.fileEndSymbol,
+			sections:        d.runeDocSections,
 		}, nil
 
 	case *query.FileNameSet:
@@ -1330,10 +1325,7 @@ func (d *indexData) newSubstringMatchTree(s *query.Substring) (matchTree, error)
 	return st, nil
 }
 
-func regexpToWordMatchTree(q *query.Regexp, opt matchTreeOpt) (_ *wordMatchTree, ok bool) {
-	if opt.DisableWordMatchOptimization {
-		return nil, false
-	}
+func regexpToWordMatchTree(q *query.Regexp) (_ *wordMatchTree, ok bool) {
 	// Needs to be case sensitive
 	if !q.CaseSensitive || q.Regexp.Flags&syntax.FoldCase != 0 {
 		return nil, false

--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -207,13 +207,17 @@ type regexpMatchTree struct {
 	bruteForceMatchTree
 }
 
-func newRegexpMatchTree(s *query.Regexp) *regexpMatchTree {
+func regexpPattern(s *query.Regexp) string {
 	prefix := ""
 	if !s.CaseSensitive {
 		prefix = "(?i)"
 	}
 
-	pattern := prefix + syntaxutil.RegexpString(s.Regexp)
+	return prefix + syntaxutil.RegexpString(s.Regexp)
+}
+
+func newRegexpMatchTree(s *query.Regexp) *regexpMatchTree {
+	pattern := regexpPattern(s)
 
 	// hybridRegexp is only used for file content matching; skip the RE2
 	// compilation overhead for filename-only regexps.

--- a/index/matchtree_test.go
+++ b/index/matchtree_test.go
@@ -184,7 +184,7 @@ func TestEquivalentQuerySkipRegexpTree(t *testing.T) {
 		}
 
 		d := &indexData{}
-		mt, err := d.newMatchTree(q, matchTreeOpt{})
+		mt, err := d.newMatchTree(q)
 		if err != nil {
 			t.Errorf("Error creating match tree from query: %s", q)
 			continue
@@ -209,7 +209,7 @@ func TestWordSearchSkipRegexpTree(t *testing.T) {
 	}
 
 	d := &indexData{}
-	mt, err := d.newMatchTree(q, matchTreeOpt{})
+	mt, err := d.newMatchTree(q)
 	if err != nil {
 		t.Fatalf("Error creating match tree from query: %s", q)
 	}
@@ -241,10 +241,13 @@ func TestSymbolMatchTree(t *testing.T) {
 		regexAll bool
 	}{
 		{query: "sym:.*", regex: "(?i)(?-s:.)*", regexAll: true},
+		{query: "sym:a", regex: "(?i)a"},
+		{query: "sym:ab", regex: "(?i)ab"},
 		{query: "sym:(ab|cd)", regex: "(?i)ab|cd"},
+		{query: "sym:(abc|def)", regex: "(?i)abc|def"},
 		{query: "sym:b.r", regex: "(?i)b(?-s:.)r"},
 		{query: "sym:horse", substr: "horse"},
-		{query: `sym:\bthread\b case:yes`, regex: `\bthread\b`}, // check we disable word search opt
+		{query: `sym:\bthread\b case:yes`, regex: `\bthread\b`},
 		{query: `sym:\bthread\b case:no`, regex: `(?i)\bthread\b`},
 	}
 
@@ -256,7 +259,7 @@ func TestSymbolMatchTree(t *testing.T) {
 		}
 
 		d := &indexData{}
-		mt, err := d.newMatchTree(q, matchTreeOpt{})
+		mt, err := d.newMatchTree(q)
 		if err != nil {
 			t.Errorf("Error creating match tree from query: %s", q)
 			continue
@@ -289,7 +292,7 @@ func TestSymbolMatchTree(t *testing.T) {
 
 func TestSymbolMatchTreeRejectsNonTextAtom(t *testing.T) {
 	q := &query.Symbol{Expr: &query.Language{Language: "go"}}
-	_, err := (&indexData{}).newMatchTree(q, matchTreeOpt{})
+	_, err := (&indexData{}).newMatchTree(q)
 	if err == nil {
 		t.Fatal("newMatchTree succeeded for a non-text symbol expression")
 	}
@@ -304,7 +307,7 @@ func TestRepoSet(t *testing.T) {
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 2, 3, 3},
 	}
-	mt, err := d.newMatchTree(&query.RepoSet{Set: map[string]bool{"r1": true, "r3": true, "r99": true}}, matchTreeOpt{})
+	mt, err := d.newMatchTree(&query.RepoSet{Set: map[string]bool{"r1": true, "r3": true, "r99": true}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +330,7 @@ func TestRepo(t *testing.T) {
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 0, 1},
 	}
-	mt, err := d.newMatchTree(&query.Repo{Regexp: regexp.MustCompile("ar")}, matchTreeOpt{})
+	mt, err := d.newMatchTree(&query.Repo{Regexp: regexp.MustCompile("ar")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -358,7 +361,7 @@ func TestBranchesRepos(t *testing.T) {
 	mt, err := d.newMatchTree(&query.BranchesRepos{List: []query.BranchRepos{
 		{Branch: "b1", Repos: roaring.BitmapOf(hash("bar"))},
 		{Branch: "b2", Repos: roaring.BitmapOf(hash("bar"))},
-	}}, matchTreeOpt{})
+	}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +386,7 @@ func TestRepoIDs(t *testing.T) {
 		fileBranchMasks: []uint64{1, 1, 1, 1, 1, 1},
 		repos:           []uint16{0, 0, 1, 2, 3, 3},
 	}
-	mt, err := d.newMatchTree(&query.RepoIDs{Repos: roaring.BitmapOf(1, 3, 99)}, matchTreeOpt{})
+	mt, err := d.newMatchTree(&query.RepoIDs{Repos: roaring.BitmapOf(1, 3, 99)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +458,7 @@ func TestMetaQueryMatchTree(t *testing.T) {
 		Value: regexp.MustCompile("M.T"),
 	}
 
-	mt, err := d.newMatchTree(q, matchTreeOpt{})
+	mt, err := d.newMatchTree(q)
 	if err != nil {
 		t.Fatalf("failed to build matchTree: %v", err)
 	}


### PR DESCRIPTION
Symbol regexp planning now compiles the complete original expression as the section-scoped verifier and uses `regexpToMatchTreeRecursive` only to construct the document prefilter. It no longer depends on whether optimization leaves zero, one, or several regexp match-tree leaves.

Now that #1152 constrains symbol expressions to text atoms, match-tree construction handles regexp and substring inputs directly instead of traversing arbitrary physical trees. Indexed substrings keep their existing fast path, while one- and two-rune substrings use the same section-scoped regexp verifier with a brute-force prefilter because they cannot provide a trigram. This also removes the obsolete symbol-only planner option and avoids constructing an unused ordinary or hybrid regexp matcher.

FYI most of this PR is unrelated noise due to the fact we can simplify newMatchTree.

Fixes #1147.
