### PR TITLE
query: validate symbol expressions as text atoms

### DIFF
--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -1160,6 +1160,10 @@ func (d *indexData) newMatchTree(q query.Q, opt matchTreeOpt) (matchTree, error)
 		}, nil
 
 	case *query.Symbol:
+		if err := s.Validate(); err != nil {
+			return nil, err
+		}
+
 		// Disable WordMatchTree since we don't support it in symbols yet.
 		optCopy := opt
 		optCopy.DisableWordMatchOptimization = true

--- a/index/matchtree_test.go
+++ b/index/matchtree_test.go
@@ -287,6 +287,17 @@ func TestSymbolMatchTree(t *testing.T) {
 	}
 }
 
+func TestSymbolMatchTreeRejectsNonTextAtom(t *testing.T) {
+	q := &query.Symbol{Expr: &query.Language{Language: "go"}}
+	_, err := (&indexData{}).newMatchTree(q, matchTreeOpt{})
+	if err == nil {
+		t.Fatal("newMatchTree succeeded for a non-text symbol expression")
+	}
+	if got, want := err.Error(), "symbol expression must be a substring or regexp, got *query.Language"; got != want {
+		t.Fatalf("unexpected error: got %q, want %q", got, want)
+	}
+}
+
 func TestRepoSet(t *testing.T) {
 	d := &indexData{
 		repoMetaData:    []zoekt.Repository{{Name: "r0"}, {Name: "r1"}, {Name: "r2"}, {Name: "r3"}},

--- a/query/query.go
+++ b/query/query.go
@@ -125,9 +125,20 @@ func (q *Regexp) GobDecode(data []byte) error {
 	return nil
 }
 
-// Symbol finds a string that is a symbol.
+// Symbol finds a text atom within an indexed symbol section.
 type Symbol struct {
+	// Expr must be a *Substring or *Regexp.
 	Expr Q
+}
+
+// Validate reports whether the symbol expression is a supported text atom.
+func (s *Symbol) Validate() error {
+	switch s.Expr.(type) {
+	case *Substring, *Regexp:
+		return nil
+	default:
+		return fmt.Errorf("symbol expression must be a substring or regexp, got %T", s.Expr)
+	}
 }
 
 func (s *Symbol) String() string {

--- a/query/query_proto.go
+++ b/query/query_proto.go
@@ -132,9 +132,13 @@ func SymbolFromProto(p *webserverv1.Symbol) (*Symbol, error) {
 		return nil, err
 	}
 
-	return &Symbol{
+	symbol := &Symbol{
 		Expr: expr,
-	}, nil
+	}
+	if err := symbol.Validate(); err != nil {
+		return nil, err
+	}
+	return symbol, nil
 }
 
 func (s *Symbol) ToProto() *webserverv1.Symbol {

--- a/query/query_proto_test.go
+++ b/query/query_proto_test.go
@@ -18,9 +18,7 @@ func TestQueryRoundtrip(t *testing.T) {
 			CaseSensitive: true,
 		},
 		&Symbol{
-			Expr: &Language{
-				Language: "go",
-			},
+			Expr: &Substring{Pattern: "symbol"},
 		},
 		&Language{
 			Language: "typescript",
@@ -100,6 +98,13 @@ func TestQueryRoundtrip(t *testing.T) {
 				t.Fatalf("unexpected diff: %s", diff)
 			}
 		})
+	}
+}
+
+func TestSymbolFromProtoRejectsNonTextAtom(t *testing.T) {
+	p := (&Symbol{Expr: &Language{Language: "go"}}).ToProto()
+	if _, err := SymbolFromProto(p); err == nil {
+		t.Fatal("SymbolFromProto succeeded for a non-text expression")
 	}
 }
 


### PR DESCRIPTION
Parsed symbol queries always contain either a substring or a regexp, but the public Go structure and protobuf decoder currently accept any query node. Unsupported nodes then fail later in match-tree construction with errors determined by the physical planner shape.

This documents the existing text-atom contract, validates it while decoding protobuf queries, and applies the same validation when direct Go callers construct a match tree. The prior non-text protobuf roundtrip fixture is replaced with a valid symbol expression, with rejection coverage at both boundaries.