### PR TITLE
indexserver: restrict tenant cleanup to shard files

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/merge.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge.go
@@ -251,7 +251,7 @@ func (s *Server) explodeTenantCompoundShards(ctx context.Context, explodeFunc fu
 		return err
 	}
 
-	paths, err := filepath.Glob(filepath.Join(s.IndexDir, "compound-*"))
+	paths, err := filepath.Glob(filepath.Join(s.IndexDir, "compound-*.zoekt"))
 	if err != nil {
 		return err
 	}

--- a/cmd/zoekt-sourcegraph-indexserver/merge_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/merge_test.go
@@ -224,6 +224,8 @@ func TestExplodeTenantCompoundShards(t *testing.T) {
 			in.TenantID = 3
 		}
 	})
+	orphanMeta := filepath.Join(dir, "compound-0000000000000000000000000000000000000000_v17.00000.zoekt.meta")
+	require.NoError(t, os.WriteFile(orphanMeta, []byte("[]"), 0o600))
 
 	// Create context with tenant 1
 	ctx := tenanttest.NewTestContext()
@@ -240,6 +242,7 @@ func TestExplodeTenantCompoundShards(t *testing.T) {
 	// 1) and cs2 remains untouched
 	require.NoFileExists(t, cs1)
 	require.FileExists(t, cs2)
+	require.FileExists(t, orphanMeta)
 
 	// Check that we have 2 simple shards (from cs1) and 1 compound shard (cs2)
 	simpleShards, err := filepath.Glob(filepath.Join(dir, "*_v16.00000.zoekt"))
@@ -255,7 +258,7 @@ func TestExplodeTenantCompoundShards(t *testing.T) {
 		}
 	}
 
-	compoundShards, err := filepath.Glob(filepath.Join(dir, "compound-*"))
+	compoundShards, err := filepath.Glob(filepath.Join(dir, "compound-*.zoekt"))
 	require.NoError(t, err)
 	require.Len(t, compoundShards, 1, "expected 1 compound shard")
 }


### PR DESCRIPTION
Tenant-wide deletion currently scans every path beginning with `compound-`, including metadata sidecars and temporary artifacts. Passing those files to the shard reader can abort cleanup before all tenant data is removed.

This narrows discovery to actual `compound-*.zoekt` shards. The existing tenant explosion test now includes an orphaned metadata sidecar and verifies that cleanup ignores it while processing the real compound shards.