### PR TITLE
index: surface failed tombstone updates

### DIFF
--- a/index/tombstones.go
+++ b/index/tombstones.go
@@ -50,7 +50,7 @@ func setTombstone(shardPath string, repoID uint32, tombstone bool) error {
 		os.Remove(tempPath)
 	}
 
-	return nil
+	return err
 }
 
 // JsonMarshalRepoMetaTemp writes the json encoding of the given repository metadata to a temporary file


### PR DESCRIPTION
Tombstone metadata is written through a temporary file and atomically renamed into place, but a failed rename was mistakenly reported as success. That suppresses caller recovery paths and can leave stale repository metadata active.

Return the rename error after cleaning up the temporary file so existing callers can handle the failure. The change is intentionally limited to the existing error path.