### PR TITLE
indexserver: cleanup orphaned meta files

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/cleanup.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup.go
@@ -26,13 +26,16 @@ var metricCleanupDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 // cleanup trashes shards in indexDir that do not exist in repos. For repos
 // that do not exist in indexDir, but do in indexDir/.trash it will move them
 // back into indexDir. Additionally it uses now to remove shards that have
-// been in the trash for 24 hours. It also deletes .tmp files older than 4 hours.
+// been in the trash for 24 hours. It also deletes files left behind by
+// interrupted index operations.
 func cleanup(indexDir string, repos []uint32, now time.Time, shardMerging bool) {
 	start := time.Now()
 	trashDir := filepath.Join(indexDir, ".trash")
 	if err := os.MkdirAll(trashDir, 0o755); err != nil {
 		errorLog.Printf("failed to create trash dir: %v", err)
 	}
+	removeStaleShardFiles(indexDir)
+	removeStaleShardFiles(trashDir)
 
 	trash := getShards(trashDir)
 	tombtones := getTombstonedRepos(indexDir)
@@ -257,25 +260,46 @@ func getTombstonedRepos(dir string) map[uint32]shard {
 
 var incompleteRE = regexp.MustCompile(`\.zoekt[0-9]+(\.\w+)?$`)
 
-func removeIncompleteShards(dir string) {
+func removeStaleShardFiles(dir string) {
 	d, err := os.Open(dir)
 	if err != nil {
-		debugLog.Printf("failed to removeIncompleteShards: %s", dir)
+		debugLog.Printf("failed to remove stale shard files in %s: %v", dir, err)
 		return
 	}
 	defer d.Close()
 
 	names, _ := d.Readdirnames(-1)
+	sort.Strings(names)
+
 	for _, n := range names {
+		path := filepath.Join(dir, n)
+		kind := ""
+
 		if incompleteRE.MatchString(n) {
-			path := filepath.Join(dir, n)
-			if err := os.Remove(path); err != nil {
-				debugLog.Printf("failed to remove incomplete shard %s: %v", path, err)
-			} else {
-				debugLog.Printf("cleaned up incomplete shard %s", path)
-			}
+			// Incomplete shard writes have a numeric suffix after .zoekt and
+			// may also have a metadata suffix.
+			kind = "incomplete shard"
+		} else if strings.HasSuffix(n, ".zoekt.meta") &&
+			!sortContainsString(names, strings.TrimSuffix(n, ".meta")) {
+			// Metadata sidecars are orphaned when their corresponding shard
+			// is not present in the directory.
+			kind = "orphan metadata"
+		} else {
+			continue
+		}
+
+		if err := os.Remove(path); err != nil {
+			debugLog.Printf("failed to remove %s %s: %v", kind, path, err)
+		} else {
+			debugLog.Printf("cleaned up %s %s", kind, path)
 		}
 	}
+}
+
+// sortContainsString reports whether a sorted list contains needle.
+func sortContainsString(list []string, needle string) bool {
+	i := sort.SearchStrings(list, needle)
+	return i < len(list) && list[i] == needle
 }
 
 func removeAll(shards ...shard) {

--- a/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/cleanup_test.go
@@ -196,8 +196,8 @@ func globBase(pattern string) []string {
 	return paths
 }
 
-func TestRemoveIncompleteShards(t *testing.T) {
-	shards, incomplete := []string{
+func TestRemoveStaleShardFiles(t *testing.T) {
+	shards, stale := []string{
 		"test.zoekt",
 		"foo.zoekt",
 		"bar.zoekt",
@@ -206,18 +206,19 @@ func TestRemoveIncompleteShards(t *testing.T) {
 		"incomplete.zoekt123",
 		"crash.zoekt567",
 		"metacrash.zoekt789.meta",
+		"orphan.zoekt.meta",
 	}
 	sort.Strings(shards)
 
 	dir := t.TempDir()
 
-	for _, shard := range append(shards, incomplete...) {
+	for _, shard := range append(shards, stale...) {
 		_, err := os.Create(filepath.Join(dir, shard))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	removeIncompleteShards(dir)
+	removeStaleShardFiles(dir)
 
 	left, _ := filepath.Glob(filepath.Join(dir, "*"))
 	sort.Strings(left)
@@ -227,6 +228,31 @@ func TestRemoveIncompleteShards(t *testing.T) {
 
 	if !reflect.DeepEqual(shards, left) {
 		t.Errorf("\ngot shards: %v\nwant: %v\n", left, shards)
+	}
+}
+
+func TestCleanupRemovesOrphanMetadata(t *testing.T) {
+	dir := t.TempDir()
+	trashDir := filepath.Join(dir, ".trash")
+	if err := os.Mkdir(trashDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	paths := []string{
+		filepath.Join(dir, "orphan.zoekt.meta"),
+		filepath.Join(trashDir, "trashed-orphan.zoekt.meta"),
+	}
+	for _, path := range paths {
+		if err := os.WriteFile(path, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cleanup(dir, nil, time.Now(), false)
+
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("orphan metadata still exists at %s", path)
+		}
 	}
 }
 

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -381,7 +381,7 @@ func isIndexingPaused(indexDir string) (bool, string) {
 
 // Run the sync loop. This blocks forever.
 func (s *Server) Run() {
-	removeIncompleteShards(s.IndexDir)
+	removeStaleShardFiles(s.IndexDir)
 
 	// Start a goroutine which updates the queue with commits to index.
 	go func() {


### PR DESCRIPTION
Interrupted shard deletion can leave `.zoekt.meta` sidecars whose corresponding shard no longer exists. The indexserver now removes these stale artifacts during its existing globally locked cleanup cycle, covering both the active index directory and trash while preserving paired sidecars. Startup cleanup remains in place, and recurring cleanup provides eventual reconciliation without adding recovery logic to every deletion path.

The directory snapshot is sorted once and searched in memory, avoiding a `stat` call for every metadata sidecar.