### PR TITLE
index: report the queried branch version in file matches

### DIFF
--- a/api.go
+++ b/api.go
@@ -51,7 +51,8 @@ type FileMatch struct {
 	// was mounted.
 	SubRepositoryPath string `json:",omitempty"`
 
-	// Commit SHA1 (hex) of the (sub)repo holding the file.
+	// Commit SHA1 (hex) of the (sub)repo holding the file. If Branches is not
+	// empty, Version is the commit for Branches[0].
 	Version string `json:",omitempty"`
 
 	// Detected language of the result.

--- a/index/eval.go
+++ b/index/eval.go
@@ -301,6 +301,7 @@ nextFileMatch:
 			Checksum:           d.getChecksum(nextDoc),
 			Language:           d.languageMap[d.getLanguage(nextDoc)],
 		}
+		branchMask := d.matchingBranchMask(nextDoc, mt, known)
 
 		if s := d.subRepos[nextDoc]; s > 0 {
 			if s >= uint32(len(d.subRepoPaths[d.repos[nextDoc]])) {
@@ -310,11 +311,11 @@ nextFileMatch:
 			fileMatch.SubRepositoryPath = path
 			sr := md.SubRepoMap[path]
 			fileMatch.SubRepositoryName = sr.Name
-			if idx := d.branchIndex(nextDoc); idx >= 0 {
+			if idx := branchIndex(branchMask); idx >= 0 {
 				fileMatch.Version = sr.Branches[idx].Version
 			}
 		} else {
-			idx := d.branchIndex(nextDoc)
+			idx := branchIndex(branchMask)
 			if idx >= 0 {
 				fileMatch.Version = md.Branches[idx].Version
 			}
@@ -338,7 +339,7 @@ nextFileMatch:
 			d.scoreFile(&fileMatch, nextDoc, mt, known, opts)
 		}
 
-		fileMatch.Branches = d.gatherBranches(nextDoc, mt, known)
+		fileMatch.Branches = d.gatherBranches(nextDoc, branchMask)
 		sortMatchesByScore(fileMatch.LineMatches)
 		sortChunkMatchesByScore(fileMatch.ChunkMatches)
 		if opts.Whole {
@@ -481,8 +482,7 @@ func setScoreWeight(scoreWeight float64, cm []*candidateMatch) []*candidateMatch
 	return cm
 }
 
-func (d *indexData) branchIndex(docID uint32) int {
-	mask := d.fileBranchMasks[docID]
+func branchIndex(mask uint64) int {
 	idx := 0
 	for mask != 0 {
 		if mask&0x1 != 0 {
@@ -494,11 +494,10 @@ func (d *indexData) branchIndex(docID uint32) int {
 	return -1
 }
 
-// gatherBranches returns a list of branch names taking into account any branch
-// filters in the query. If the query contains a branch filter, it returns all
-// branches containing the docID and matching the branch filter. Otherwise, it
-// returns all branches containing docID.
-func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTree]bool) []string {
+// matchingBranchMask returns the branches containing docID which matched a
+// branch filter in the query. If no branch filter matched, it returns all
+// branches containing docID.
+func (d *indexData) matchingBranchMask(docID uint32, mt matchTree, known map[matchTree]bool) uint64 {
 	var mask uint64
 	visitMatchAtoms(mt, known, func(mt matchTree) {
 		bq, ok := mt.(*branchQueryMatchTree)
@@ -512,7 +511,10 @@ func (d *indexData) gatherBranches(docID uint32, mt matchTree, known map[matchTr
 	if mask == 0 {
 		mask = d.fileBranchMasks[docID]
 	}
+	return mask
+}
 
+func (d *indexData) gatherBranches(docID uint32, mask uint64) []string {
 	var branches []string
 	id := uint64(1)
 	branchNames := d.branchNames[d.repos[docID]]

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -1457,6 +1457,70 @@ func TestBranchVersions(t *testing.T) {
 	})
 }
 
+func TestBranchVersionMatchesQuery(t *testing.T) {
+	const repoID = 42
+	b := testShardBuilder(t, &zoekt.Repository{
+		ID: repoID,
+		Branches: []zoekt.RepositoryBranch{
+			{Name: "master", Version: "v-master"},
+			{Name: "stable", Version: "v-stable"},
+		},
+	}, Document{
+		Name:     "shared",
+		Content:  []byte("needle"),
+		Branches: []string{"master", "stable"},
+	})
+
+	tests := []struct {
+		name         string
+		query        query.Q
+		wantVersion  string
+		wantBranches []string
+	}{
+		{
+			name:         "no branch query",
+			query:        &query.Substring{Pattern: "needle"},
+			wantVersion:  "v-master",
+			wantBranches: []string{"master", "stable"},
+		},
+		{
+			name: "branch query",
+			query: query.NewAnd(
+				&query.Substring{Pattern: "needle"},
+				&query.Branch{Pattern: "stable", Exact: true},
+			),
+			wantVersion:  "v-stable",
+			wantBranches: []string{"stable"},
+		},
+		{
+			name: "branches repos query",
+			query: query.NewAnd(
+				&query.Substring{Pattern: "needle"},
+				query.NewSingleBranchesRepos("stable", repoID),
+			),
+			wantVersion:  "v-stable",
+			wantBranches: []string{"stable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sres := searchForTest(t, b, tt.query)
+			if len(sres.Files) != 1 {
+				t.Fatalf("got %v, want 1 result", sres.Files)
+			}
+
+			f := sres.Files[0]
+			if f.Version != tt.wantVersion {
+				t.Errorf("got version %q, want %q", f.Version, tt.wantVersion)
+			}
+			if diff := cmp.Diff(tt.wantBranches, f.Branches); diff != "" {
+				t.Errorf("branches mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func mustParseRE(s string) *syntax.Regexp {
 	r, err := syntax.Parse(s, syntax.Perl)
 	if err != nil {

--- a/index/matchtree.go
+++ b/index/matchtree.go
@@ -1220,12 +1220,10 @@ func (d *indexData) newMatchTree(q query.Q) (matchTree, error) {
 			}
 			reposBranchesWant[repoIdx] = mask
 		}
-		return &docMatchTree{
-			reason:  "BranchesRepos",
-			numDocs: d.numDocs(),
-			predicate: func(docID uint32) bool {
-				return d.fileBranchMasks[docID]&reposBranchesWant[d.repos[docID]] != 0
-			},
+		return &branchQueryMatchTree{
+			masks:     reposBranchesWant,
+			fileMasks: d.fileBranchMasks,
+			repos:     d.repos,
 		}, nil
 
 	case *query.RepoSet:


### PR DESCRIPTION
Files shared by multiple branches previously reported the first indexed branch version even when the query selected another branch.

This reuses the matched branch mask for both `Branches` and `Version`, including `BranchesRepos` queries. Unfiltered and multi-branch results remain deterministic by using the first reported branch.