### PR TITLE
feat/indexserver: report clone-cache usage and monorepo latency

### DIFF
--- a/cmd/zoekt-sourcegraph-indexserver/git_cache.go
+++ b/cmd/zoekt-sourcegraph-indexserver/git_cache.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -18,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	sglog "github.com/sourcegraph/log"
 
 	"github.com/sourcegraph/zoekt"
@@ -38,6 +41,11 @@ import (
 // and write it only after success. An interrupted job cannot leave a reusable
 // clone with stale locks or partially updated refs. Metadata lives outside Git's
 // config because this acquisition policy must not affect shard/index identity.
+//
+// Cache gauges are sampled during cleanup, outside Prometheus's scrape path.
+// They sum file sizes, not filesystem allocation or network bytes transferred.
+// Lifecycle logs distinguish cold/reused fetches and explain resets; aggregate
+// gauges show growth without introducing another per-repository metric family.
 type gitRepoCache struct{}
 
 var gitCache gitRepoCache
@@ -46,9 +54,22 @@ var gitRepoCacheMaxAge = getEnvWithDefaultDuration("SRC_GIT_REPO_CACHE_MAX_AGE",
 
 const gitRepoCacheMetadata = "zoekt-cache.json"
 
+var (
+	metricGitRepoCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_git_repo_cache_size_bytes",
+		Help: "Sum of regular file sizes in retained Git clones, sampled during cache cleanup.",
+	})
+	metricGitRepoCacheRepositories = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "index_git_repo_cache_repositories",
+		Help: "Number of retained Git clones, sampled during cache cleanup.",
+	})
+)
+
 type gitRepoCacheEntry struct {
 	Created  time.Time
 	RepoID   uint32
+	Name     string
+	TenantID int
 	CloneURL string
 	Filtered bool
 	Branches []zoekt.RepositoryBranch
@@ -58,12 +79,14 @@ type gitRepoCacheEntry struct {
 // cached clones are marked reusable and temporary clones are deleted. Any
 // failure (including a panic) discards the clone; cleanup errors are logged
 // without hiding the job error. The callback must not retain the directory.
-func (cache gitRepoCache) withFetchedRepo(ctx context.Context, c gitIndexConfig, o *indexArgs, logger sglog.Logger, use func(string) error) error {
+func (cache gitRepoCache) withFetchedRepo(ctx context.Context, c gitIndexConfig, o *indexArgs, logger sglog.Logger, use func(string) error) (err error) {
 	var gitDir string
 	var cached gitRepoCacheEntry
-	var err error
+	var cacheState string
+	cacheLogger := logger
 	if o.CacheGitRepo {
-		gitDir, cached, err = cache.prepare(o, time.Now())
+		cacheLogger = logger.With(sglog.String("repo", o.Name), sglog.Uint32("id", o.RepoID), sglog.Int("tenant", o.TenantID))
+		gitDir, cached, cacheState, err = cache.prepare(o, time.Now(), cacheLogger)
 	} else {
 		gitDir, err = tmpGitDir(o.Name)
 	}
@@ -71,10 +94,15 @@ func (cache gitRepoCache) withFetchedRepo(ctx context.Context, c gitIndexConfig,
 		return err
 	}
 	keep := false
+	failureReason := "prepare_error"
 	defer func() {
 		if !keep {
-			if err := os.RemoveAll(gitDir); err != nil {
-				logger.Warn("failed to remove git clone", sglog.String("path", gitDir), sglog.Error(err))
+			if o.CacheGitRepo {
+				if _, removeErr := cache.removeDir(gitDir, failureReason, cacheLogger); removeErr != nil {
+					cacheLogger.Warn("failed to remove git clone cache", sglog.Error(removeErr))
+				}
+			} else if removeErr := os.RemoveAll(gitDir); removeErr != nil {
+				logger.Warn("failed to remove git clone", sglog.String("path", gitDir), sglog.Error(removeErr))
 			}
 		}
 	}()
@@ -86,13 +114,30 @@ func (cache gitRepoCache) withFetchedRepo(ctx context.Context, c gitIndexConfig,
 			return err
 		}
 	}
-	if err := cache.fetch(ctx, gitDir, o, c, logger); err != nil {
+	failureReason = "fetch_error"
+	fetchStart := time.Now()
+	err = cache.fetch(ctx, gitDir, o, c, logger)
+	if o.CacheGitRepo {
+		fetchDuration := time.Since(fetchStart)
+		size, sizeErr := gitRepoCacheSize(gitDir)
+		outcome := "success"
+		if err != nil {
+			outcome = "failure"
+		}
+		cacheLogger.Info("git clone cache fetch", sglog.String("cache_state", cacheState),
+			sglog.Duration("cache_age", fetchStart.Sub(cached.Created)), sglog.Duration("fetch_duration", fetchDuration),
+			sglog.String("outcome", outcome), sglog.Int64("cache_size_bytes", size), sglog.Error(sizeErr))
+	}
+	if err != nil {
 		return err
 	}
-	if err := use(gitDir); err != nil {
+
+	failureReason = "index_error"
+	if err = use(gitDir); err != nil {
 		return err
 	}
 	if o.CacheGitRepo {
+		failureReason = "metadata_error"
 		cached.Branches = o.Branches
 		b, err := json.Marshal(cached)
 		if err != nil {
@@ -151,7 +196,7 @@ func (gitRepoCache) fetch(ctx context.Context, gitDir string, o *indexArgs, c gi
 
 	defer func() {
 		success := strconv.FormatBool(allFetchesSucceeded)
-		name := repoNameForMetric(o.Name)
+		name := repoNameForMetric(o.Name, o.CacheGitRepo)
 		metricFetchDuration.WithLabelValues(success, name).Observe(fetchDuration.Seconds())
 	}()
 
@@ -229,7 +274,8 @@ func (gitRepoCache) fetch(ctx context.Context, gitDir string, o *indexArgs, c gi
 			if o.CacheGitRepo {
 				// Do not let a failed fetch poison a retained clone, including the
 				// existing fallback when a delta base is no longer available.
-				if err := os.RemoveAll(gitDir); err != nil {
+				cacheLogger := logger.With(sglog.String("repo", o.Name), sglog.Uint32("id", o.RepoID), sglog.Int("tenant", o.TenantID))
+				if _, err := gitCache.removeDir(gitDir, "delta_fetch_error", cacheLogger); err != nil {
 					return err
 				}
 				if err := initGitRepo(ctx, gitDir, o, c); err != nil {
@@ -307,21 +353,37 @@ func (gitRepoCache) readEntry(dir string) (gitRepoCacheEntry, error) {
 	return entry, err
 }
 
-func (cache gitRepoCache) prepare(o *indexArgs, now time.Time) (string, gitRepoCacheEntry, error) {
+func (cache gitRepoCache) prepare(o *indexArgs, now time.Time, logger sglog.Logger) (string, gitRepoCacheEntry, string, error) {
 	dir := cache.cachedDir(o)
 	entry, err := cache.readEntry(dir)
-	if err != nil || !now.Before(entry.Created.Add(gitRepoCacheMaxAge)) ||
-		entry.CloneURL != o.CloneURL || entry.Filtered != (len(o.LargeFiles) == 0) {
+	reason := ""
+	switch {
+	case err != nil:
+		reason = "incomplete"
+	case !now.Before(entry.Created.Add(gitRepoCacheMaxAge)):
+		reason = "age"
+	case entry.CloneURL != o.CloneURL:
+		reason = "source_change"
+	case entry.Filtered != (len(o.LargeFiles) == 0):
 		// Changing from filtered to full fetching can otherwise leave previously
 		// omitted blobs missing even when fetching a commit we already have.
-		if err := os.RemoveAll(dir); err != nil {
-			return "", entry, err
-		}
-		entry = gitRepoCacheEntry{Created: now, RepoID: o.RepoID, CloneURL: o.CloneURL, Filtered: len(o.LargeFiles) == 0}
-	} else if err := os.Remove(filepath.Join(dir, gitRepoCacheMetadata)); err != nil {
-		return "", entry, err
+		reason = "filter_change"
 	}
-	return dir, entry, nil
+	state := "reused"
+	if reason != "" {
+		removed, err := cache.removeDir(dir, reason, logger)
+		if err != nil {
+			return "", entry, "", err
+		}
+		state = "cold"
+		if removed {
+			state = "reset"
+		}
+		entry = gitRepoCacheEntry{Created: now, RepoID: o.RepoID, Name: o.Name, TenantID: o.TenantID, CloneURL: o.CloneURL, Filtered: len(o.LargeFiles) == 0}
+	} else if err := os.Remove(filepath.Join(dir, gitRepoCacheMetadata)); err != nil {
+		return "", entry, "", err
+	}
+	return dir, entry, state, nil
 }
 
 func removeStaleGitRefs(ctx context.Context, dir string, previous, current []zoekt.RepositoryBranch, c gitIndexConfig) error {
@@ -340,32 +402,92 @@ func removeStaleGitRefs(ctx context.Context, dir string, previous, current []zoe
 	return nil
 }
 
-func (cache gitRepoCache) remove(o *indexArgs) error {
-	return os.RemoveAll(cache.cachedDir(o))
+func (cache gitRepoCache) remove(o *indexArgs, reason string, logger sglog.Logger) (bool, error) {
+	return cache.removeDir(cache.cachedDir(o), reason, logger)
 }
 
-func (cache gitRepoCache) removeTenant(tenantID int) error {
-	return os.RemoveAll(filepath.Join(cache.rootDir(), strconv.Itoa(tenantID)))
+func (cache gitRepoCache) removeTenant(tenantID int, reason string, logger sglog.Logger) (bool, error) {
+	return cache.removeDir(filepath.Join(cache.rootDir(), strconv.Itoa(tenantID)), reason, logger)
 }
 
 // cleanup runs under indexMutex.Global, just like shard cleanup.
 // Sweeping also reclaims expired clones of repositories that never index again.
-func (cache gitRepoCache) cleanup(repos []uint32, now time.Time) error {
+func (cache gitRepoCache) cleanup(repos []uint32, now time.Time, logger sglog.Logger) error {
 	dirs, err := filepath.Glob(filepath.Join(cache.rootDir(), "*", "*.git"))
 	if err != nil {
 		return err
 	}
 	var errs error
+	var sizeErr error
+	var total int64
+	var repositories int
 	for _, dir := range dirs {
 		entry, err := cache.readEntry(dir)
 		// Only a handful of repos are cached; avoid allocating a second map of
 		// the potentially much larger complete assignment list for their lookup.
-		if err == nil && slices.Contains(repos, entry.RepoID) && now.Before(entry.Created.Add(gitRepoCacheMaxAge)) {
-			continue
+		reason := ""
+		switch {
+		case err != nil:
+			reason = "incomplete"
+		case !slices.Contains(repos, entry.RepoID):
+			reason = "unassigned"
+		case !now.Before(entry.Created.Add(gitRepoCacheMaxAge)):
+			reason = "age"
 		}
-		if err := os.RemoveAll(dir); err != nil {
-			errs = errors.Join(errs, err)
+		if reason != "" {
+			if _, err := cache.removeDir(dir, reason, logger); err == nil {
+				continue
+			} else {
+				errs = errors.Join(errs, err)
+			}
 		}
+		// Include clones whose deletion failed so the gauges don't hide them.
+		size, err := gitRepoCacheSize(dir)
+		sizeErr = errors.Join(sizeErr, err)
+		total += size
+		repositories++
 	}
-	return errs
+	if sizeErr == nil {
+		metricGitRepoCacheSize.Set(float64(total))
+		metricGitRepoCacheRepositories.Set(float64(repositories))
+	}
+	return errors.Join(errs, sizeErr)
+}
+
+func gitRepoCacheSize(dir string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
+// removeDir reports actual removals only, not every uncached repo's
+// no-op cleanup. Size-accounting failures must not prevent data deletion.
+func (cache gitRepoCache) removeDir(dir, reason string, logger sglog.Logger) (bool, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	if entry, err := cache.readEntry(dir); err == nil {
+		logger = logger.With(sglog.String("repo", entry.Name), sglog.Uint32("id", entry.RepoID), sglog.Int("tenant", entry.TenantID))
+	}
+	size, sizeErr := gitRepoCacheSize(dir)
+	if err := os.RemoveAll(dir); err != nil {
+		return false, err
+	}
+	logger.Info("removed git clone cache", sglog.String("path", dir), sglog.String("reason", reason),
+		sglog.Int64("cache_size_bytes", size), sglog.Error(sizeErr))
+	return true, nil
 }

--- a/cmd/zoekt-sourcegraph-indexserver/git_cache_test.go
+++ b/cmd/zoekt-sourcegraph-indexserver/git_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sourcegraph/log/logtest"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -135,14 +136,16 @@ func TestPrepareCachedGitDir(t *testing.T) {
 			require.NoError(t, os.WriteFile(sentinel, nil, 0o600))
 			// Access/mtime must not extend a busy repository's maximum lifetime.
 			require.NoError(t, os.Chtimes(dir, now, now))
-			gotDir, got, err := gitCache.prepare(&args, now)
+			gotDir, got, state, err := gitCache.prepare(&args, now, logtest.Scoped(t))
 			require.NoError(t, err)
 			require.Equal(t, dir, gotDir)
 			require.NoFileExists(t, filepath.Join(dir, gitRepoCacheMetadata))
 			if tc.reuse {
+				require.Equal(t, "reused", state)
 				require.FileExists(t, sentinel)
 				require.Equal(t, entry.Created, got.Created)
 			} else {
+				require.Equal(t, "reset", state)
 				require.NoDirExists(t, dir)
 				require.Equal(t, now, got.Created)
 			}
@@ -155,8 +158,9 @@ func TestPrepareCachedGitDir(t *testing.T) {
 		if contents != "" {
 			require.NoError(t, os.WriteFile(filepath.Join(dir, gitRepoCacheMetadata), []byte(contents), 0o600))
 		}
-		_, _, err := gitCache.prepare(&args, now)
+		_, _, state, err := gitCache.prepare(&args, now, logtest.Scoped(t))
 		require.NoError(t, err)
+		require.Equal(t, "reset", state)
 		require.NoDirExists(t, dir)
 	}
 	other := args
@@ -190,7 +194,7 @@ func TestCleanupGitRepoCache(t *testing.T) {
 			if tc.assigned {
 				assigned = []uint32{args.RepoID}
 			}
-			require.NoError(t, gitCache.cleanup(assigned, now))
+			require.NoError(t, gitCache.cleanup(assigned, now, logtest.Scoped(t)))
 			if tc.keep {
 				require.DirExists(t, dir)
 			} else {
@@ -201,7 +205,7 @@ func TestCleanupGitRepoCache(t *testing.T) {
 	args := indexArgs{IndexOptions: IndexOptions{RepoID: 42, TenantID: 1, Name: "interrupted"}}
 	dir := gitCache.cachedDir(&args)
 	require.NoError(t, os.MkdirAll(dir, 0o755))
-	require.NoError(t, gitCache.cleanup([]uint32{42}, now))
+	require.NoError(t, gitCache.cleanup([]uint32{42}, now, logtest.Scoped(t)))
 	require.NoDirExists(t, dir)
 }
 
@@ -216,7 +220,7 @@ func TestCachedGitIndexIntegration(t *testing.T) {
 			Branches: []zoekt.RepositoryBranch{{Name: "HEAD", Version: fixture.mainCommit}, {Name: "old", Version: fixture.mainCommit}},
 		},
 	}
-	logger := logtest.Scoped(t)
+	logger, captured := logtest.Captured(t)
 	c := gitIndexConfig{
 		timeout: time.Minute,
 		findRepositoryMetadata: func(args *indexArgs) (*zoekt.Repository, *zoekt.IndexMetadata, bool, error) {
@@ -326,6 +330,23 @@ func TestCachedGitIndexIntegration(t *testing.T) {
 	require.NoDirExists(t, dir)
 	require.NoError(t, gitIndex(context.Background(), c, &args, sourcegraphNop{}, logger))
 	require.NoDirExists(t, filepath.Join(os.TempDir(), "test%2Frepo.git"))
+
+	logs := captured()
+	fetchLogs := logs.Filter(func(l logtest.CapturedLog) bool { return l.Message == "git clone cache fetch" })
+	require.GreaterOrEqual(t, len(fetchLogs), 3)
+	for i, state := range []string{"cold", "reused", "reset"} {
+		require.Equal(t, state, fetchLogs[i].Fields["cache_state"])
+		require.Equal(t, "success", fetchLogs[i].Fields["outcome"])
+		require.Equal(t, args.Name, fetchLogs[i].Fields["repo"])
+		require.Contains(t, fetchLogs[i].Fields, "fetch_duration")
+		require.Contains(t, fetchLogs[i].Fields, "cache_size_bytes")
+	}
+	require.True(t, fetchLogs.Contains(func(l logtest.CapturedLog) bool { return l.Fields["outcome"] == "failure" }))
+	for _, reason := range []string{"filter_change", "delta_fetch_error", "fetch_error", "index_error", "disabled"} {
+		require.True(t, logs.Contains(func(l logtest.CapturedLog) bool {
+			return l.Message == "removed git clone cache" && l.Fields["reason"] == reason
+		}), "missing eviction reason %s", reason)
+	}
 }
 
 func TestGitCacheTenantDeletionAndRestart(t *testing.T) {
@@ -362,4 +383,50 @@ func TestCacheGitRepoProtoAndIndexIdentity(t *testing.T) {
 	before := args.BuildOptions()
 	args.CacheGitRepo = true
 	require.Equal(t, before, args.BuildOptions())
+}
+
+func TestGitRepoCacheMetrics(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	logger := logtest.Scoped(t)
+	now := time.Now()
+	var sizes []int64
+	for _, id := range []uint32{1, 2} {
+		args := indexArgs{IndexOptions: IndexOptions{RepoID: id, TenantID: 1, Name: "repo"}}
+		dir := writeCacheEntry(t, &args, gitRepoCacheEntry{Created: now, RepoID: id})
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "objects"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "objects", "pack"), []byte("contents"), 0o600))
+		metadata, err := os.Stat(filepath.Join(dir, gitRepoCacheMetadata))
+		require.NoError(t, err)
+		sizes = append(sizes, metadata.Size()+8)
+		// Directory accounting must neither follow symlinks nor include their targets.
+		require.NoError(t, os.Symlink(os.TempDir(), filepath.Join(dir, "external")))
+	}
+	require.NoError(t, gitCache.cleanup([]uint32{1, 2}, now, logger))
+	require.Equal(t, float64(sizes[0]+sizes[1]), testutil.ToFloat64(metricGitRepoCacheSize))
+	require.Equal(t, float64(2), testutil.ToFloat64(metricGitRepoCacheRepositories))
+	require.NoError(t, gitCache.cleanup([]uint32{1}, now, logger))
+	require.Equal(t, float64(sizes[0]), testutil.ToFloat64(metricGitRepoCacheSize))
+	require.Equal(t, float64(1), testutil.ToFloat64(metricGitRepoCacheRepositories))
+	require.NoError(t, gitCache.cleanup(nil, now, logger))
+	require.Zero(t, testutil.ToFloat64(metricGitRepoCacheSize))
+	require.Zero(t, testutil.ToFloat64(metricGitRepoCacheRepositories))
+}
+
+func TestRepoNameForMetric(t *testing.T) {
+	old := reposWithSeparateIndexingMetrics
+	reposWithSeparateIndexingMetrics = map[string]struct{}{"manual": {}}
+	t.Cleanup(func() { reposWithSeparateIndexingMetrics = old })
+	for _, tc := range []struct {
+		repo   string
+		cached bool
+		want   string
+	}{
+		{"ordinary", false, ""},
+		{"monorepo", true, "monorepo"},
+		{"manual", false, "manual"},
+		{"manual", true, "manual"},
+		{"Manual", false, ""}, // Preserve exact matching for the manual allowlist.
+	} {
+		require.Equal(t, tc.want, repoNameForMetric(tc.repo, tc.cached))
+	}
 }

--- a/cmd/zoekt-sourcegraph-indexserver/main.go
+++ b/cmd/zoekt-sourcegraph-indexserver/main.go
@@ -414,7 +414,7 @@ func (s *Server) Run() {
 				defer close(cleanupDone)
 				s.muIndexDir.Global(func() {
 					cleanup(s.IndexDir, repos.IDs, time.Now(), s.shardMerging)
-					if err := gitCache.cleanup(repos.IDs, time.Now()); err != nil {
+					if err := gitCache.cleanup(repos.IDs, time.Now(), s.logger); err != nil {
 						s.logger.Error("failed to clean git clone cache", sglog.Error(err))
 					}
 				})
@@ -503,10 +503,10 @@ func (s *Server) processQueue() {
 			state, err := s.index(context.Background(), args)
 
 			elapsed := time.Since(start)
-			metricIndexDuration.WithLabelValues(string(state), repoNameForMetric(opts.Name)).Observe(elapsed.Seconds())
+			metricIndexDuration.WithLabelValues(string(state), repoNameForMetric(opts.Name, opts.CacheGitRepo)).Observe(elapsed.Seconds())
 
 			indexDelay := time.Since(item.DateAddedToQueue)
-			metricIndexingDelay.WithLabelValues(string(state), repoNameForMetric(opts.Name)).Observe(indexDelay.Seconds())
+			metricIndexingDelay.WithLabelValues(string(state), repoNameForMetric(opts.Name, opts.CacheGitRepo)).Observe(indexDelay.Seconds())
 
 			if err != nil {
 				errorLog.Printf("error indexing %s: %s", args.String(), err)
@@ -542,11 +542,14 @@ func (s *Server) processQueue() {
 	}
 }
 
-// repoNameForMetric returns a normalized version of the given repository name that is
-// suitable for use with Prometheus metrics.
-func repoNameForMetric(repo string) string {
-	// Check to see if we want to be able to capture separate indexing metrics for this repository.
-	// If we don't, set to a default string to keep the cardinality for the Prometheus metric manageable.
+// repoNameForMetric keeps cardinality bounded to explicitly selected repositories.
+// Sourcegraph enables caching only for its small monorepo list; naming those repos
+// lets existing fetch/index latency panels show the impact without a second
+// allowlist or a new label dimension. The manual allowlist remains additive.
+func repoNameForMetric(repo string, cacheGitRepo bool) string {
+	if cacheGitRepo {
+		return repo
+	}
 	if _, ok := reposWithSeparateIndexingMetrics[repo]; ok {
 		return repo
 	}
@@ -625,7 +628,7 @@ func (s *Server) index(ctx context.Context, args *indexArgs) (state indexState, 
 	// Reclaim opt-outs even when the shard is already current and indexing
 	// below would be a no-op. Cached Git data is not part of index identity.
 	if !args.CacheGitRepo || len(args.Branches) == 0 {
-		if err := gitCache.remove(args); err != nil {
+		if _, err := gitCache.remove(args, "disabled", s.logger); err != nil {
 			return indexStateFail, err
 		}
 	}
@@ -1205,7 +1208,7 @@ func (s *Server) DeleteAllData(ctx context.Context, _ *indexserverv1.DeleteAllDa
 		if err := purgeTenantShards(ctx, filepath.Join(s.IndexDir, ".trash")); err != nil {
 			merr = multierr.Append(merr, err)
 		}
-		if err := gitCache.removeTenant(tnt.ID()); err != nil {
+		if _, err := gitCache.removeTenant(tnt.ID(), "tenant_delete", s.logger.With(sglog.Int("tenant", tnt.ID()))); err != nil {
 			merr = multierr.Append(merr, err)
 		}
 	})
@@ -1240,6 +1243,9 @@ func setupTmpDir(logger sglog.Logger, main bool, index string) error {
 	tmpRoot := filepath.Join(index, dir)
 
 	if main {
+		if _, err := gitCache.removeDir(filepath.Join(tmpRoot, "git-cache"), "startup", logger); err != nil {
+			logger.Error("failed to remove git clone cache", sglog.Error(err))
+		}
 		logger.Info("removing tmp dir", sglog.String("tmpRoot", tmpRoot))
 		err := os.RemoveAll(tmpRoot)
 		if err != nil {


### PR DESCRIPTION
Stacked on #1162. Report aggregate clone-cache bytes/count and structured fetch/eviction events so storage growth and cold-versus-warm wall time are visible. Cached monorepos automatically get their names in the existing latency histograms; the manual allowlist still works.

The Sourcegraph companion adds dashboard panels and temporarily pins this commit. Land the Zoekt stack first, then repin Sourcegraph to the landed revisions.