### PR TITLE
zoekt-index: reject colliding positional paths

### DIFF
--- a/cmd/zoekt-index/main.go
+++ b/cmd/zoekt-index/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sourcegraph/zoekt/cmd"
 	"github.com/sourcegraph/zoekt/ignore"
 	"github.com/sourcegraph/zoekt/index"
+	"github.com/sourcegraph/zoekt/internal/tenant"
 )
 
 type fileInfo struct {
@@ -131,12 +132,49 @@ func main() {
 		}
 	}
 
+	if err := checkDuplicateShardPrefixes(flag.Args(), *opts); err != nil {
+		log.Fatal(err)
+	}
+
 	for _, arg := range flag.Args() {
 		opts.RepositoryDescription.Source = arg
 		if err := indexArg(arg, *opts, ignoreDirMap); err != nil {
 			log.Fatal(err)
 		}
 	}
+}
+
+func checkDuplicateShardPrefixes(args []string, opts index.Options) error {
+	seen := make(map[string]string, len(args))
+	for _, arg := range args {
+		prefix, err := shardPrefix(arg, opts)
+		if err != nil {
+			return err
+		}
+		if previous, ok := seen[prefix]; ok {
+			return fmt.Errorf("cannot index %q and %q in one invocation: both use shard prefix %q, so the latter would overwrite the former", previous, arg, prefix)
+		}
+		seen[prefix] = arg
+	}
+	return nil
+}
+
+func shardPrefix(arg string, opts index.Options) (string, error) {
+	if opts.ShardPrefixOverride != "" {
+		return opts.ShardPrefixOverride, nil
+	}
+	if tenant.UseIDBasedShardNames() {
+		return fmt.Sprintf("%09d_%09d", opts.RepositoryDescription.TenantID, opts.RepositoryDescription.ID), nil
+	}
+	if opts.RepositoryDescription.Name != "" {
+		return opts.RepositoryDescription.Name, nil
+	}
+
+	dir, err := filepath.Abs(filepath.Clean(arg))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Base(dir), nil
 }
 
 func indexArg(arg string, opts index.Options, ignore map[string]struct{}) error {

--- a/cmd/zoekt-index/main_test.go
+++ b/cmd/zoekt-index/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sourcegraph/zoekt"
@@ -12,6 +13,58 @@ import (
 	"github.com/sourcegraph/zoekt/query"
 	"github.com/sourcegraph/zoekt/search"
 )
+
+func TestCheckDuplicateShardPrefixes(t *testing.T) {
+	t.Setenv("WORKSPACES_API_URL", "")
+
+	tests := []struct {
+		name    string
+		args    []string
+		opts    index.Options
+		wantErr string
+	}{
+		{
+			name: "shared repository name",
+			args: []string{"alpha", "beta"},
+			opts: index.Options{RepositoryDescription: zoekt.Repository{
+				Name: "repo",
+			}},
+			wantErr: `both use shard prefix "repo"`,
+		},
+		{
+			name:    "shared directory basename",
+			args:    []string{"alpha/src", "beta/src"},
+			wantErr: `both use shard prefix "src"`,
+		},
+		{
+			name: "shared prefix override",
+			args: []string{"alpha", "beta"},
+			opts: index.Options{
+				ShardPrefixOverride: "shared",
+			},
+			wantErr: `both use shard prefix "shared"`,
+		},
+		{
+			name: "distinct directory basenames",
+			args: []string{"alpha", "beta"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkDuplicateShardPrefixes(test.args, test.opts)
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("checkDuplicateShardPrefixes() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("checkDuplicateShardPrefixes() error = %v, want containing %q", err, test.wantErr)
+			}
+		})
+	}
+}
 
 func TestIndexArgAttachesConfiguredBranches(t *testing.T) {
 	sourceDir := t.TempDir()


### PR DESCRIPTION
Multiple positional paths can resolve to the same shard prefix, causing a later build to silently delete the shards created for an earlier path. This change detects those collisions and fails before writing any indexes.

Unlike the proposed fix in the issue, this does not implicitly combine directories into one repository. Multiple roots have ambiguous filename, source, and branch semantics, so a shared shard prefix is treated as invalid configuration instead.

Fixes #1133